### PR TITLE
GCC warning fixes

### DIFF
--- a/Compressonator/Header/Codec/ASTC/Codec_ASTC.h
+++ b/Compressonator/Header/Codec/ASTC/Codec_ASTC.h
@@ -8,10 +8,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -44,22 +44,22 @@ public:
     virtual bool SetParameter(const CMP_CHAR* /*pszParamName*/, CODECFLOAT /*fValue*/);
 
     // Required interfaces
-    virtual CodecError Compress             (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Decompress           (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
+    virtual CodecError Compress             (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Decompress           (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
 
 private:
 
     // ASTC User configurable variables
-    CMP_WORD    m_NumThreads;    
+    CMP_WORD    m_NumThreads;
     char        m_BlockRate[64];
 
-    // ASTC Internal status 
+    // ASTC Internal status
     CMP_BOOL    m_LibraryInitialized;
     CMP_WORD    m_NumEncodingThreads;
     bool        m_AbortRequested;
 
     int m_xdim, m_ydim, m_zdim;        // Is now implamented and set by user ( defined in g_ASTCEncode )
-    float m_target_bitrate;            // defined in g_ASTCEncode 
+    float m_target_bitrate;            // defined in g_ASTCEncode
 
                                        // ASTC Encoders and decoders: for encoding use the interfaces below
     ASTCBlockDecoder*    m_decoder;
@@ -86,7 +86,7 @@ private:
     void find_closest_blockdim_3d(float target_bitrate, int *x, int *y, int *z, int consider_illegal);
     void find_closest_blockxy_2d(int *x, int *y, int consider_illegal);
 
-    // Internal status 
+    // Internal status
     CMP_BOOL    m_Use_MultiThreading;
     CMP_WORD    m_LiveThreads;
     CMP_WORD    m_LastThread;

--- a/Compressonator/Header/Codec/ATC/Codec_ATC_RGB.h
+++ b/Compressonator/Header/Codec/ATC/Codec_ATC_RGB.h
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -31,17 +31,17 @@
 
 #include "Codec_ATC.h"
 
-class CCodec_ATC_RGB : public CCodec_ATC  
+class CCodec_ATC_RGB : public CCodec_ATC
 {
 public:
     CCodec_ATC_RGB();
     virtual ~CCodec_ATC_RGB();
 
     virtual CCodecBuffer* CreateBuffer(
-        CMP_BYTE nBlockWidth, CMP_BYTE nBlockHeight, CMP_BYTE nBlockDepth, 
+        CMP_BYTE nBlockWidth, CMP_BYTE nBlockHeight, CMP_BYTE nBlockDepth,
         CMP_DWORD dwWidth, CMP_DWORD dwHeight, CMP_DWORD dwPitch = 0, CMP_BYTE* pData = 0) const;
 
-    virtual CodecError Compress(CCodecBuffer& bufferIn,     CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Decompress(CCodecBuffer& bufferIn,   CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
+    virtual CodecError Compress(CCodecBuffer& bufferIn,     CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Decompress(CCodecBuffer& bufferIn,   CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
 };
 #endif // !defined(_CODEC_ATC_RGB_H_INCLUDED_)

--- a/Compressonator/Header/Codec/ATC/Codec_ATC_RGBA_Explicit.h
+++ b/Compressonator/Header/Codec/ATC/Codec_ATC_RGBA_Explicit.h
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -31,13 +31,13 @@
 
 #include "Codec_ATC.h"
 
-class CCodec_ATC_RGBA_Explicit : public CCodec_ATC  
+class CCodec_ATC_RGBA_Explicit : public CCodec_ATC
 {
 public:
     CCodec_ATC_RGBA_Explicit();
     virtual ~CCodec_ATC_RGBA_Explicit();
 
-    virtual CodecError Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
+    virtual CodecError Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
 };
 #endif // !defined(_CODEC_ATC_RGBA_H_INCLUDED_)

--- a/Compressonator/Header/Codec/ATC/Codec_ATC_RGBA_Interpolated.h
+++ b/Compressonator/Header/Codec/ATC/Codec_ATC_RGBA_Interpolated.h
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -31,13 +31,13 @@
 
 #include "Codec_ATC.h"
 
-class CCodec_ATC_RGBA_Interpolated : public CCodec_ATC  
+class CCodec_ATC_RGBA_Interpolated : public CCodec_ATC
 {
 public:
     CCodec_ATC_RGBA_Interpolated();
     virtual ~CCodec_ATC_RGBA_Interpolated();
 
-    virtual CodecError Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
+    virtual CodecError Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
 };
 #endif // !defined(_CODEC_ATC_RGBA_INTERP_H_INCLUDED_)

--- a/Compressonator/Header/Codec/ATI/Codec_ATI1N.h
+++ b/Compressonator/Header/Codec/ATI/Codec_ATI1N.h
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -31,15 +31,15 @@
 
 #include "Codec_DXTC.h"
 
-class CCodec_ATI1N : public CCodec_DXTC  
+class CCodec_ATI1N : public CCodec_DXTC
 {
 public:
     CCodec_ATI1N(CodecType codecType = CT_ATI1N);
     virtual ~CCodec_ATI1N();
 
-    virtual CodecError Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Compress_Fast(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
+    virtual CodecError Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Compress_Fast(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
 
     virtual CCodecBuffer* CreateBuffer(
         CMP_BYTE nBlockWidth, CMP_BYTE nBlockHeight, CMP_BYTE nBlockDepth,

--- a/Compressonator/Header/Codec/ATI/Codec_ATI2N.h
+++ b/Compressonator/Header/Codec/ATI/Codec_ATI2N.h
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -31,15 +31,15 @@
 
 #include "Codec_DXTC.h"
 
-class CCodec_ATI2N : public CCodec_DXTC  
+class CCodec_ATI2N : public CCodec_DXTC
 {
 public:
     CCodec_ATI2N(CodecType codecType = CT_ATI2N);
     virtual ~CCodec_ATI2N();
 
-    virtual CodecError Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Compress_Fast(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
+    virtual CodecError Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Compress_Fast(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
 
 protected:
     CodecType m_codecType;

--- a/Compressonator/Header/Codec/ATI/Codec_ATI2N_DXT5.h
+++ b/Compressonator/Header/Codec/ATI/Codec_ATI2N_DXT5.h
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -31,14 +31,14 @@
 
 #include "Codec_ATI2N.h"
 
-class CCodec_ATI2N_DXT5 : public CCodec_ATI2N  
+class CCodec_ATI2N_DXT5 : public CCodec_ATI2N
 {
 public:
     CCodec_ATI2N_DXT5();
     virtual ~CCodec_ATI2N_DXT5();
 
-    virtual CodecError Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
+    virtual CodecError Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
 };
 
 #endif // !defined(_Codec_ATI2N_DXT5_H_INCLUDED_)

--- a/Compressonator/Header/Codec/BC6H/BC6H_Definitions.h
+++ b/Compressonator/Header/Codec/BC6H/BC6H_Definitions.h
@@ -31,7 +31,6 @@
 #include <cstdlib>
 #include <cstring>
 
-typedef std::uint8_t byte;
 typedef std::uint8_t BYTE;
 typedef std::uint32_t DWORD;
 typedef std::int32_t BOOL;
@@ -271,8 +270,8 @@ struct AMD_BC6H_Format
     
     union
     {
-        byte indices[4][4];            // Indices data after header block
-        byte indices16[16];
+        BYTE indices[4][4];            // Indices data after header block
+        BYTE indices16[16];
     };
 
     float         din[MAX_SUBSET_SIZE][MAX_DIMENSION_BIG];   // Original data input

--- a/Compressonator/Header/Codec/BC6H/BC6H_utils.h
+++ b/Compressonator/Header/Codec/BC6H/BC6H_utils.h
@@ -8,10 +8,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -22,7 +22,7 @@
 //
 // BC6H_utils.h Genenral functions and definitions for use in encoder and decoder
 // Revision
-// 0.1    First implementation 
+// 0.1    First implementation
 //////////////////////////////////////////////////////////////////////////////////
 
 #ifndef _BC6H_UTILS_H_
@@ -111,7 +111,9 @@ public:
    int     m_sizeinbytes;
 };
 
+#ifdef _MSC_VER
 #pragma warning(disable:4201)
+#endif //_MSC_VER
 // https://gist.github.com/rygorous/2156668
 union FP32
 {
@@ -124,7 +126,7 @@ union FP32
         uint Sign        : 1;
     };
 };
- 
+
 union FP16
 {
     unsigned short u;

--- a/Compressonator/Header/Codec/BC6H/Codec_BC6H.h
+++ b/Compressonator/Header/Codec/BC6H/Codec_BC6H.h
@@ -8,10 +8,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -45,7 +45,7 @@ struct BC6HEncodeThreadParam
     volatile CMP_BOOL    exit;
 };
 
-class CCodec_BC6H : public CCodec_DXTC  
+class CCodec_BC6H : public CCodec_DXTC
 {
 public:
     CCodec_BC6H(CodecType codecType);
@@ -56,10 +56,10 @@ public:
     virtual bool SetParameter(const CMP_CHAR* /*pszParamName*/, CODECFLOAT /*fValue*/);
 
     // Required interfaces
-    virtual CodecError Compress             (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL,  CMP_DWORD_PTR pUser1 = NULL,  CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Compress_Fast        (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL,  CMP_DWORD_PTR pUser1 = NULL,  CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Compress_SuperFast   (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL,  CMP_DWORD_PTR pUser1 = NULL,  CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Decompress           (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL,  CMP_DWORD_PTR pUser1 = NULL,  CMP_DWORD_PTR pUser2 = NULL);
+    virtual CodecError Compress             (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL,  CMP_DWORD_PTR pUser1 = CMP_NULL,  CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Compress_Fast        (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL,  CMP_DWORD_PTR pUser1 = CMP_NULL,  CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Compress_SuperFast   (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL,  CMP_DWORD_PTR pUser1 = CMP_NULL,  CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Decompress           (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL,  CMP_DWORD_PTR pUser1 = CMP_NULL,  CMP_DWORD_PTR pUser2 = CMP_NULL);
 
 
 private:
@@ -68,12 +68,12 @@ private:
     // BC6H User configurable variables
     CMP_WORD        m_ModeMask;
     double          m_Quality;
-    CMP_WORD        m_NumThreads;    
+    CMP_WORD        m_NumThreads;
     bool            m_bIsSigned;
     bool            m_UsePatternRec;
     double          m_Exposure;
 
-    // BC6H Internal status 
+    // BC6H Internal status
     CMP_BOOL        m_LibraryInitialized;
     CMP_BOOL        m_Use_MultiThreading;
     CMP_WORD        m_NumEncodingThreads;
@@ -90,7 +90,7 @@ private:
     CodecError    CEncodeBC6HBlock(float  in[BC6H_BLOCK_PIXELS][MAX_DIMENSION_BIG],CMP_BYTE *out);
     CodecError    CFinishBC6HEncoding(void);
 
-    
+
 };
 
 #endif // !defined(_CODEC_DXT5_H_INCLUDED_)

--- a/Compressonator/Header/Codec/BC7/Codec_BC7.h
+++ b/Compressonator/Header/Codec/BC7/Codec_BC7.h
@@ -8,10 +8,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -45,7 +45,7 @@ struct BC7EncodeThreadParam
     volatile CMP_BOOL    exit;
 };
 
-class CCodec_BC7 : public CCodec_DXTC  
+class CCodec_BC7 : public CCodec_DXTC
 {
 public:
     CCodec_BC7();
@@ -56,10 +56,10 @@ public:
     virtual bool SetParameter(const CMP_CHAR* /*pszParamName*/, CODECFLOAT /*fValue*/);
 
     // Required interfaces
-    virtual CodecError Compress             (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Compress_Fast        (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Compress_SuperFast   (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Decompress           (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
+    virtual CodecError Compress             (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Compress_Fast        (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Compress_SuperFast   (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Decompress           (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
 
 
 private:
@@ -71,11 +71,11 @@ private:
     double  m_Performance;
     CMP_BOOL    m_ColourRestrict;
     CMP_BOOL    m_AlphaRestrict;
-    CMP_WORD    m_NumThreads;    
+    CMP_WORD    m_NumThreads;
     CMP_BOOL    m_ImageNeedsAlpha;
 
 
-    // BC7 Internal status 
+    // BC7 Internal status
     CMP_BOOL     m_LibraryInitialized;
     CMP_BOOL     m_Use_MultiThreading;
     CMP_WORD     m_NumEncodingThreads;

--- a/Compressonator/Header/Codec/Buffer/CodecBuffer.h
+++ b/Compressonator/Header/Codec/Buffer/CodecBuffer.h
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -33,9 +33,13 @@
 
 #include "MathMacros.h"
 
+#ifdef _MSC_VER
 #pragma warning(disable:4244)
+#endif //_MSC_VER
 #include "half.h"
+#ifdef _MSC_VER
 #pragma warning(default:4244)
+#endif //_MSC_VER
 
 typedef enum _CodecBufferType
 {
@@ -205,13 +209,13 @@ template <typename T> void PadBlock(CMP_DWORD j, CMP_BYTE w, CMP_BYTE h, CMP_BYT
     memcpy(&block[j*w*c], &block[0], dwPadHeight * w * c * sizeof(T));
 }
 
-class CCodecBuffer  
+class CCodecBuffer
 {
 public:
 
     CCodecBuffer(
                  CMP_BYTE nBlockWidth, CMP_BYTE nBlockHeight, CMP_BYTE nBlockDepth,
-                 CMP_DWORD dwWidth, CMP_DWORD dwHeight, CMP_DWORD dwPitch = 0, 
+                 CMP_DWORD dwWidth, CMP_DWORD dwHeight, CMP_DWORD dwPitch = 0,
                  CMP_BYTE* pData = 0);
     virtual ~CCodecBuffer();
 
@@ -226,7 +230,7 @@ public:
     inline const CMP_DWORD GetHeight() const {return m_dwHeight;};
     inline const CMP_DWORD GetPitch()  const {return m_dwPitch;};
 
-    inline const void SetPitch(CMP_DWORD dwPitch)  { 
+    inline const void SetPitch(CMP_DWORD dwPitch)  {
         m_dwPitch = dwPitch;
         };
 
@@ -320,7 +324,7 @@ public:
     virtual bool ReadBlock(CMP_DWORD x, CMP_DWORD y, CMP_DWORD* pBlock, CMP_DWORD dwBlockSize);
     virtual bool WriteBlock(CMP_DWORD x, CMP_DWORD y, CMP_DWORD* pBlock, CMP_DWORD dwBlockSize);
 
-    inline CMP_BYTE* GetData() const {return m_pData;}; 
+    inline CMP_BYTE* GetData() const {return m_pData;};
 
 protected:
 
@@ -366,9 +370,9 @@ protected:
     void SwizzleBlock(CMP_DWORD dwBlock[], CMP_DWORD dwBlockSize);
     void SwizzleBlock(CMP_WORD wBlock[], CMP_DWORD dwBlockSize);
 
-    CMP_DWORD m_dwWidth;        // Final Image Width  
-    CMP_DWORD m_dwHeight;       // Final Image Height 
-    CMP_DWORD m_dwDepth;        // Final Image Depth  
+    CMP_DWORD m_dwWidth;        // Final Image Width
+    CMP_DWORD m_dwHeight;       // Final Image Height
+    CMP_DWORD m_dwDepth;        // Final Image Depth
     CMP_DWORD m_dwPitch;
 
     CMP_BYTE m_nBlockWidth;     // DeCompression Block Sizes (Default is 4x4x1)
@@ -381,7 +385,7 @@ protected:
     bool m_bPerformingConversion;
 };
 
-CCodecBuffer*   CreateCodecBuffer(CodecBufferType nCodecBufferType, 
+CCodecBuffer*   CreateCodecBuffer(CodecBufferType nCodecBufferType,
                                   CMP_BYTE nBlockWidth, CMP_BYTE nBlockHeight, CMP_BYTE nBlockDepth,
                                   CMP_DWORD dwWidth, CMP_DWORD dwHeight, CMP_DWORD dwPitch = 0, CMP_BYTE* pData = 0);
 CodecBufferType GetCodecBufferType(CMP_FORMAT format);

--- a/Compressonator/Header/Codec/Codec.h
+++ b/Compressonator/Header/Codec/Codec.h
@@ -8,10 +8,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -93,17 +93,17 @@ public:
     virtual bool GetParameter(const CMP_CHAR* pszParamName, CODECFLOAT& fValue);
 
     virtual bool SetParameter(const CMP_CHAR* pszParamName, CMP_CHAR*  dwValue);
-    
+
     virtual CodecType GetType() const {return m_CodecType;};
 
     virtual CMP_DWORD GetBlockHeight() {return 1;};
 
     virtual CCodecBuffer* CreateBuffer(
-                                        CMP_BYTE nBlockWidth, CMP_BYTE nBlockHeight, CMP_BYTE nBlockDepth, 
+                                        CMP_BYTE nBlockWidth, CMP_BYTE nBlockHeight, CMP_BYTE nBlockDepth,
                                         CMP_DWORD dwWidth, CMP_DWORD dwHeight, CMP_DWORD dwPitch = 0, CMP_BYTE* pData = 0) const = 0;
 
-    virtual CodecError Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL) = 0;
-    virtual CodecError Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL) = 0;
+    virtual CodecError Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL) = 0;
+    virtual CodecError Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL) = 0;
 
 protected:
     CodecType m_CodecType;

--- a/Compressonator/Header/Codec/DXT/Codec_DXT1.h
+++ b/Compressonator/Header/Codec/DXT/Codec_DXT1.h
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -31,7 +31,7 @@
 
 #include "Codec_DXTC.h"
 
-class CCodec_DXT1 : public CCodec_DXTC  
+class CCodec_DXT1 : public CCodec_DXTC
 {
 public:
     CCodec_DXT1();
@@ -41,10 +41,10 @@ public:
     virtual bool SetParameter(const CMP_CHAR* pszParamName, CMP_DWORD dwValue);
     virtual bool GetParameter(const CMP_CHAR* pszParamName, CMP_DWORD& dwValue);
 
-    virtual CodecError Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Compress_Fast(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Compress_SuperFast(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
+    virtual CodecError Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Compress_Fast(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Compress_SuperFast(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
 
     virtual CCodecBuffer* CreateBuffer(
         CMP_BYTE nBlockWidth, CMP_BYTE nBlockHeight, CMP_BYTE nBlockDepth,

--- a/Compressonator/Header/Codec/DXT/Codec_DXT3.h
+++ b/Compressonator/Header/Codec/DXT/Codec_DXT3.h
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -31,16 +31,16 @@
 
 #include "Codec_DXTC.h"
 
-class CCodec_DXT3 : public CCodec_DXTC  
+class CCodec_DXT3 : public CCodec_DXTC
 {
 public:
     CCodec_DXT3();
     virtual ~CCodec_DXT3();
 
-    virtual CodecError Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Compress_Fast(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Compress_SuperFast(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
+    virtual CodecError Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Compress_Fast(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Compress_SuperFast(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
 };
 
 #endif // !defined(_CODEC_DXT3_H_INCLUDED_)

--- a/Compressonator/Header/Codec/DXT/Codec_DXT5.h
+++ b/Compressonator/Header/Codec/DXT/Codec_DXT5.h
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -31,16 +31,16 @@
 
 #include "Codec_DXTC.h"
 
-class CCodec_DXT5 : public CCodec_DXTC  
+class CCodec_DXT5 : public CCodec_DXTC
 {
 public:
     CCodec_DXT5();
     virtual ~CCodec_DXT5();
 
-    virtual CodecError Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Compress_Fast(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Compress_SuperFast(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
+    virtual CodecError Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Compress_Fast(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Compress_SuperFast(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
 };
 
 #endif // !defined(_CODEC_DXT5_H_INCLUDED_)

--- a/Compressonator/Header/Codec/DXT/Codec_DXT5_Swizzled.h
+++ b/Compressonator/Header/Codec/DXT/Codec_DXT5_Swizzled.h
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -31,16 +31,16 @@
 
 #include "Codec_DXTC.h"
 
-class CCodec_DXT5_Swizzled : public CCodec_DXTC  
+class CCodec_DXT5_Swizzled : public CCodec_DXTC
 {
 public:
     CCodec_DXT5_Swizzled(CodecType codecType);
     virtual ~CCodec_DXT5_Swizzled();
 
-    virtual CodecError Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Compress_Fast(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Compress_SuperFast(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
+    virtual CodecError Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Compress_Fast(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Compress_SuperFast(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
 
 protected:
     virtual void ReadBlock(CCodecBuffer& buffer, CMP_DWORD x, CMP_DWORD y, CMP_BYTE block[BLOCK_SIZE_4X4X4]) = 0;

--- a/Compressonator/Header/Codec/ETC/Codec_ETC2_RGB.h
+++ b/Compressonator/Header/Codec/ETC/Codec_ETC2_RGB.h
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -41,7 +41,7 @@ public:
         CMP_BYTE nBlockWidth, CMP_BYTE nBlockHeight, CMP_BYTE nBlockDepth,
         CMP_DWORD dwWidth, CMP_DWORD dwHeight, CMP_DWORD dwPitch = 0, CMP_BYTE* pData = 0) const;
 
-    virtual CodecError Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
+    virtual CodecError Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
 };
 #endif // !defined(_Codec_ETC2_RGB_H_INCLUDED_)

--- a/Compressonator/Header/Codec/ETC/Codec_ETC_RGB.h
+++ b/Compressonator/Header/Codec/ETC/Codec_ETC_RGB.h
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -41,7 +41,7 @@ public:
                                         CMP_BYTE nBlockWidth, CMP_BYTE nBlockHeight, CMP_BYTE nBlockDepth,
                                         CMP_DWORD dwWidth, CMP_DWORD dwHeight, CMP_DWORD dwPitch = 0, CMP_BYTE* pData = 0) const;
 
-    virtual CodecError Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
+    virtual CodecError Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
 };
 #endif // !defined(_Codec_ETC_RGB_H_INCLUDED_)

--- a/Compressonator/Header/Codec/ETC/etcpack/etcimage.h
+++ b/Compressonator/Header/Codec/ETC/etcpack/etcimage.h
@@ -1,7 +1,7 @@
 //// etcpack v2.74
-//// 
-//// NO WARRANTY 
-//// 
+////
+//// NO WARRANTY
+////
 //// BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE THE PROGRAM IS PROVIDED
 //// "AS IS". ERICSSON MAKES NO REPRESENTATIONS OF ANY KIND, EXTENDS NO
 //// WARRANTIES OR CONDITIONS OF ANY KIND; EITHER EXPRESS, IMPLIED OR
@@ -18,7 +18,7 @@
 //// TO YOUR SOLE RESPONSIBILITY TO MAKE SUCH DETERMINATION AND ACQUIRE
 //// SUCH LICENSES AS MAY BE NECESSARY WITH RESPECT TO PATENTS, COPYRIGHT
 //// AND OTHER INTELLECTUAL PROPERTY OF THIRD PARTIES.
-//// 
+////
 //// FOR THE AVOIDANCE OF DOUBT THE PROGRAM (I) IS NOT LICENSED FOR; (II)
 //// IS NOT DESIGNED FOR OR INTENDED FOR; AND (III) MAY NOT BE USED FOR;
 //// ANY MISSION CRITICAL APPLICATIONS SUCH AS, BUT NOT LIMITED TO
@@ -30,7 +30,7 @@
 //// DAMAGE. YOUR RIGHTS UNDER THIS LICENSE WILL TERMINATE AUTOMATICALLY
 //// AND IMMEDIATELY WITHOUT NOTICE IF YOU FAIL TO COMPLY WITH THIS
 //// PARAGRAPH.
-//// 
+////
 //// IN NO EVENT WILL ERICSSON, BE LIABLE FOR ANY DAMAGES WHATSOEVER,
 //// INCLUDING BUT NOT LIMITED TO PERSONAL INJURY, ANY GENERAL, SPECIAL,
 //// INDIRECT, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF OR IN
@@ -41,23 +41,23 @@
 //// THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS) REGARDLESS OF THE
 //// THEORY OF LIABILITY (CONTRACT, TORT OR OTHERWISE), EVEN IF SUCH HOLDER
 //// OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-//// 
+////
 //// (C) Ericsson AB 2005-2013. All Rights Reserved.
-//// 
+////
 
 #ifndef IMAGE_H
 #define IMAGE_H
 
-bool fReadPPM(char *filename, int &width, int &height, unsigned char *&pixels, int targetbitrate);
-bool fWritePPM(char *filename, int width, int height, unsigned char *pixels, int bitrate, bool reverse_y);
+bool fReadPPM(const char *filename, int &width, int &height, unsigned char *&pixels, int targetbitrate);
+bool fWritePPM(const char *filename, int width, int height, unsigned char *pixels, int bitrate, bool reverse_y);
 
-bool fReadPFM(char *filename, int &width, int &height, float *&pixels);
-bool fWritePFM(char *filename, int width, int height, float *pixels,bool reverse_y);
+bool fReadPFM(const char *filename, int &width, int &height, float *&pixels);
+bool fWritePFM(const char *filename, int width, int height, float *pixels,bool reverse_y);
 // write a grey scale image
-bool fWritePGM(char *filename, int width, int height, unsigned char *pixels,bool reverse_y, int bitdepth);
-int fReadPGM(char *filename, int &width, int &height, unsigned char *&pixels, int wantedBitDepth);
+bool fWritePGM(const char *filename, int width, int height, unsigned char *pixels,bool reverse_y, int bitdepth);
+int fReadPGM(const char *filename, int &width, int &height, unsigned char *&pixels, int wantedBitDepth);
 // write a TGA image with both RGB and alpha
-bool fWriteTGAfromRGBandA(char *filename, int width, int height, unsigned char *pixelsRGB, unsigned char *pixelsA, bool reverse_y);
+bool fWriteTGAfromRGBandA(const char *filename, int width, int height, unsigned char *pixelsRGB, unsigned char *pixelsA, bool reverse_y);
 
 #endif
 

--- a/Compressonator/Header/Codec/GT/Codec_GT.h
+++ b/Compressonator/Header/Codec/GT/Codec_GT.h
@@ -8,10 +8,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -46,17 +46,17 @@ public:
     virtual bool SetParameter(const CMP_CHAR* /*pszParamName*/, CODECFLOAT /*fValue*/);
 
     // Required interfaces
-    virtual CodecError Compress             (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Compress_Fast        (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Compress_SuperFast   (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
-    virtual CodecError Decompress           (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = NULL, CMP_DWORD_PTR pUser2 = NULL);
+    virtual CodecError Compress             (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Compress_Fast        (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Compress_SuperFast   (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
+    virtual CodecError Decompress           (CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, Codec_Feedback_Proc pFeedbackProc = NULL, CMP_DWORD_PTR pUser1 = CMP_NULL, CMP_DWORD_PTR pUser2 = CMP_NULL);
 
 
 private:
     // GT User configurable variables
-    WORD    m_NumThreads;    
+    WORD    m_NumThreads;
 
-    // GT Internal status 
+    // GT Internal status
     BOOL     m_LibraryInitialized;
     BOOL     m_Use_MultiThreading;
     WORD     m_NumEncodingThreads;

--- a/Compressonator/Header/Common.h
+++ b/Compressonator/Header/Common.h
@@ -8,10 +8,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -50,9 +50,9 @@ typedef unsigned int UINT;
 
 using namespace std;
 
-#define UNREFERENCED_PARAMETER(P)          (P)
+#define UNREFERENCED_PARAMETER(P)          ((void)P)
 
-//#define USE_DBGTRACE                                //  Show messages via Win Debug 
+//#define USE_DBGTRACE                                //  Show messages via Win Debug
 //#define BC7_DEBUG_TO_RESULTS_TXT                    //  Send debug info to a results text file
 //#define DXT5_COMPDEBUGGER                           //  Remote connect data to Comp Debugger views
 //#define BC6H_COMPDEBUGGER                           //  Remote connect data to Comp Debugger views

--- a/Compressonator/Header/Compressonator.h
+++ b/Compressonator/Header/Compressonator.h
@@ -8,10 +8,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -19,7 +19,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-// 
+//
 /// \file Compressonator.h
 //
 //=====================================================================
@@ -39,12 +39,15 @@ typedef long                CMP_LONG;
 typedef CMP::BOOL           CMP_BOOL;          ///< A 32-bit integer boolean format.
 typedef CMP::DWORD_PTR      CMP_DWORD_PTR;
 
+// Invalid pointer value of CMP_DWORD_PTR (same as NULL, used to prevent compiler warning by GCC)
+#define CMP_NULL 0
+
 // CMP_HALF and CMP_FLOAT
 //bit-layout for a half number, h:
 //
 // CMP_HALF (HALF)
 //    15 (msb)
-//    | 
+//    |
 //    | 14  10
 //    | |   |
 //    | |   | 9        0 (lsb)
@@ -57,9 +60,9 @@ typedef CMP::DWORD_PTR      CMP_DWORD_PTR;
 //
 // CMP_FLOAT
 //    31 (msb)
-//    | 
+//    |
 //    | 30     23
-//    | |      | 
+//    | |      |
 //    | |      | 22                    0 (lsb)
 //    | |      | |                     |
 //    X XXXXXXXX XXXXXXXXXXXXXXXXXXXXXXX
@@ -91,7 +94,7 @@ typedef struct
 /// These enum are all used internally for each version of the SDK the order may change
 /// Typically reordered in alpha betical order per catagory for easy referance
 //  Use the enum by name and not by its value
-// 
+//
 typedef enum
 {
    CMP_FORMAT_Unknown,                    ///< Undefined texture format.
@@ -152,8 +155,8 @@ typedef enum
    CMP_FORMAT_DXT5_xRBG,                  ///<    swizzled DXT5 format with the green component swizzled into the alpha channel & the red component swizzled into the green channel. Eight bits per pixel.
    CMP_FORMAT_DXT5_RGxB,                  ///<    swizzled DXT5 format with the blue component swizzled into the alpha channel. Eight bits per pixel.
    CMP_FORMAT_DXT5_xGxR,                  ///<    two-component swizzled DXT5 format with the red component swizzled into the alpha channel & the green component in the green channel. Eight bits per pixel.
-   CMP_FORMAT_ETC_RGB,                    ///< ETC  (Ericsson Texture Compression) 
-   CMP_FORMAT_ETC2_RGB,                   ///< ETC2 (Ericsson Texture Compression) 
+   CMP_FORMAT_ETC_RGB,                    ///< ETC  (Ericsson Texture Compression)
+   CMP_FORMAT_ETC2_RGB,                   ///< ETC2 (Ericsson Texture Compression)
    CMP_FORMAT_GT,                         ///< GT   (Reserved for a future implementation)
                                           //--------------------------------------------------------------------------------------------------------
    CMP_FORMAT_MAX = CMP_FORMAT_GT
@@ -236,10 +239,10 @@ typedef struct
    CMP_DWORD         dwSize;                    ///< The size of this structure.
    CMP_BOOL         bUseChannelWeighting;      ///< Use channel weightings. With swizzled formats the weighting applies to the data within the specified channel not the channel itself.
                                                 ///< channel weigthing is not implemented for BC6H and BC7
-   double            fWeightingRed;             ///<    The weighting of the Red or X Channel. 
-   double            fWeightingGreen;           ///<    The weighting of the Green or Y Channel. 
-   double            fWeightingBlue;            ///<    The weighting of the Blue or Z Channel. 
-   CMP_BOOL          bUseAdaptiveWeighting;     ///<    Adapt weighting on a per-block basis. 
+   double            fWeightingRed;             ///<    The weighting of the Red or X Channel.
+   double            fWeightingGreen;           ///<    The weighting of the Green or Y Channel.
+   double            fWeightingBlue;            ///<    The weighting of the Blue or Z Channel.
+   CMP_BOOL          bUseAdaptiveWeighting;     ///<    Adapt weighting on a per-block basis.
    CMP_BOOL          bDXT1UseAlpha;             ///< Encode single-bit alpha data. Only valid when compressing to DXT1 & BC1.
    CMP_BOOL          bUseGPUDecompress;         ///< Use GPU to decompress. Decode API can be changed by specified in DecodeWith parameter. Default is OpenGL.
    CMP_BOOL          bUseGPUCompress;           ///< Use GPU to compress. Encode API can be changed by specified in EncodeWith parameter. Default is OpenCL.
@@ -248,13 +251,13 @@ typedef struct
    CMP_BOOL          bDisableMultiThreading;    ///< Disable multi-threading of the compression. This will slow the compression but can be useful if you're managing threads in your application.
                                                 ///< if set BC7 dwnumThreads will default to 1 during encoding and then return back to its original value when done.
    CMP_Speed         nCompressionSpeed;         ///< The trade-off between compression speed & quality.
-                                                ///< Notes: 
-                                                ///< 1. This value is ignored for BC6H and BC7 (for BC7 the compression speed depends on fquaility value)  
+                                                ///< Notes:
+                                                ///< 1. This value is ignored for BC6H and BC7 (for BC7 the compression speed depends on fquaility value)
                                                 ///< 2. For 64 bit DXT1 to DXT5 and BC1 to BC5 nCompressionSpeed is ignored and set to Noramal Speed
                                                 ///< 3. To force the use of nCompressionSpeed setting regarless of Note 2 use fQuality at 0.05
    CMP_GPUDecode     nGPUDecode;                ///< This value is set using DecodeWith argument (OpenGL, DirectX) default is OpenGL
    CMP_Compute_type  nComputeWith;              ///< This value is set using ComputeWith argument (OpenGL, DirectX)  default is OpenCL
-   CMP_DWORD         dwnumThreads;              ///< Number of threads to initialize for BC7 encoding (Max up to 128). Default set to 8, 
+   CMP_DWORD         dwnumThreads;              ///< Number of threads to initialize for BC7 encoding (Max up to 128). Default set to 8,
    double            fquality;                  ///< Quality of encoding. This value ranges between 0.0 and 1.0. Default set to 0.05
                                                 ///< setting fquality above 0.0 gives the fastest, lowest quality encoding, 1.0 is the slowest, highest quality encoding. Default set to a low value of 0.05
    CMP_BOOL          brestrictColour;           ///< This setting is a quality tuning setting for BC7 which may be necessary for convenience in some applications. Default set to false
@@ -265,14 +268,14 @@ typedef struct
    CMP_BOOL          brestrictAlpha;            ///< This setting is a quality tuning setting for BC7 which may be necessary for some textures. Default set to false,
                                                 ///< if set it will also apply restriction to blocks with alpha to avoid issues with punch-through or thresholded alpha encoding
    CMP_DWORD         dwmodeMask;                ///< Mode to set BC7 to encode blocks using any of 8 different block modes in order to obtain the highest quality. Default set to 0xCF, (Skips Color components with separate alpha component)
-                                                ///< You can combine the bits to test for which modes produce the best image quality. 
-                                                ///< The mode that produces the best image quality above a set quality level (fquality) is used and subsequent modes set in the mask 
-                                                ///< are not tested, this optimizes the performance of the compression versus the required quality. 
+                                                ///< You can combine the bits to test for which modes produce the best image quality.
+                                                ///< The mode that produces the best image quality above a set quality level (fquality) is used and subsequent modes set in the mask
+                                                ///< are not tested, this optimizes the performance of the compression versus the required quality.
                                                 ///< If you prefer to check all modes regardless of the quality then set the fquality to a value of 0
    int               NumCmds;                   ///< Count of the number of command value pairs in CmdSet[].  Max value that can be set is AMD_MAX_CMDS = 20 on this release
    AMD_CMD_SET       CmdSet[AMD_MAX_CMDS];      ///< Extended command options that can be set for the specified codec\n
                                                 ///< Example to set the number of threads and quality used for compression\n
-                                                ///<        CMP_CompressOptions Options;\n 
+                                                ///<        CMP_CompressOptions Options;\n
                                                 ///<        memset(Options,0,sizeof(CMP_CompressOptions));\n
                                                 ///<        Options.dwSize = sizeof(CMP_CompressOptions)\n
                                                 ///<        Options.CmdSet[0].strCommand   = "NumThreads"\n
@@ -351,7 +354,7 @@ extern "C" {
     // Must be called before any other library methods are valid
     //
     BC_ERROR CMP_API CMP_InitializeBCLibrary();
-    
+
     //
     // ShutdownBCLibrary - Shutdown the BC6H or BC7 library
     //
@@ -374,7 +377,7 @@ extern "C" {
     // Library must be initialized before calling this function.
     //
     // Arguments and Settings:
-    //        
+    //
     //      quality       - Quality of encoding. This value ranges between 0.0 and 1.0. (Valid only for BC7 in this release) default is 0.01
     //                      0.0 gives the fastest, lowest quality encoding, 1.0 is the slowest, highest quality encoding
     //                      In general even quality level 0.0 will give very good results on the vast majority of images
@@ -406,8 +409,8 @@ extern "C" {
     //                      being pulled away from zero or one by the global minimization of the error. If this flag is specified then the encoder
     //                      will restrict its behaviour so that for blocks which contain an alpha of zero or one then these values should be
     //                      precisely represented
-    //                      
-    //      modeMask      - This is an advanced option. (Valid only for BC7 in this release) 
+    //
+    //      modeMask      - This is an advanced option. (Valid only for BC7 in this release)
     //                      BC7 can encode blocks using any of 8 different block modes in order to obtain the highest quality (for reference of how each
     //                      of these block modes work consult the BC7 specification)
     //                      Under some circumstances it is possible that it might be desired to manipulate the encoder to only produce certain modes
@@ -423,23 +426,23 @@ extern "C" {
     //      isSigned      - For BC6H this flag sets the bit layout, false = UF16 (unsigned float) and true = SF16 (signed float)
     //
     // Note: For BC6H quality and modeMask are reserved for future release
-    // 
+    //
     BC_ERROR CMP_API CMP_CreateBC6HEncoder(CMP_BC6H_BLOCK_PARAMETERS user_settings, BC6HBlockEncoder** encoder);
     BC_ERROR CMP_API CMP_CreateBC7Encoder (double quality, CMP_BOOL restrictColour, CMP_BOOL restrictAlpha, CMP_DWORD modeMask, double performance, BC7BlockEncoder** encoder);
 
     // CMP_EncodeBC7Block()  - Enqueue a single BC7  block to the library for encoding
     // CMP_EncodeBC6HBlock() - Enqueue a single BC6H block to the library for encoding
     //
-    // For BC7: 
+    // For BC7:
     // Input is expected to be a single 16 element block containing 4 components in the range 0.->255.
     // Pixel data in the block should be arranged in row-major order
     // For three-component input images the 4th component (BC7_COMP_ALPHA) should be set to 255 for
     // all pixels to ensure optimal encoding
     //
-    // For BC6H: 
+    // For BC6H:
     // Input is expected to be a single 16 element block containing 4 components in Half-Float format (16bit).
     // Pixel data in the block should be arranged in row-major order.
-    // the 4th component should be set to 0, since Alpha is not supported in BC6H 
+    // the 4th component should be set to 0, since Alpha is not supported in BC6H
     //
     BC_ERROR CMP_API CMP_EncodeBC7Block(BC7BlockEncoder* encoder, double in[BC_BLOCK_PIXELS][BC_COMPONENT_COUNT], CMP_BYTE* out);
     BC_ERROR CMP_API CMP_EncodeBC6HBlock(BC6HBlockEncoder* encoder, CMP_FLOAT  in[BC_BLOCK_PIXELS][BC_COMPONENT_COUNT], CMP_BYTE* out);
@@ -486,7 +489,7 @@ extern "C" {
    /// \param[in] pUser1 User data to pass to the feedback function.
    /// \param[in] pUser2 User data to pass to the feedback function.
    /// \return    CMP_OK if successful, otherwise the error code.
-   CMP_ERROR CMP_API CMP_ConvertTexture(CMP_Texture* pSourceTexture, 
+   CMP_ERROR CMP_API CMP_ConvertTexture(CMP_Texture* pSourceTexture,
                                         CMP_Texture* pDestTexture,
                                         const CMP_CompressOptions* pOptions,
                                         CMP_Feedback_Proc pFeedbackProc, CMP_DWORD_PTR pUser1, CMP_DWORD_PTR pUser2);

--- a/Compressonator/Source/Codec/ASTC/ASTC_Encode.cpp
+++ b/Compressonator/Source/Codec/ASTC/ASTC_Encode.cpp
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -39,7 +39,9 @@
 #include "compclient.h"
 #endif
 
+#ifdef _MSC_VER
 #pragma warning(disable:4100)       // Dont show parameter warnings
+#endif //_MSC_VER
 
 void prepare_block_statistics(int xdim, int ydim, int zdim, const imageblock * blk, const error_weight_block * ewb, int *is_normal_map, float *lowest_correl);
 int realign_weights(astc_decode_mode decode_mode, int xdim, int ydim, int zdim, const imageblock * blk, const error_weight_block * ewb, symbolic_compressed_block * scb, uint8_t * weight_set8, uint8_t * plane2_weight_set8);
@@ -66,10 +68,10 @@ double ASTCBlockEncoder::CompressBlock_kernel(
         (const astc_codec_image_cpu *)input_image,
         (imageblock_cpu *) &m_pb,
         ASTCEncode->m_xdim,
-        ASTCEncode->m_ydim, 
-        ASTCEncode->m_zdim, 
-        x, 
-        y, 
+        ASTCEncode->m_ydim,
+        ASTCEncode->m_zdim,
+        x,
+        y,
         z
         );
 

--- a/Compressonator/Source/Codec/ASTC/ASTC_Host.cpp
+++ b/Compressonator/Source/Codec/ASTC/ASTC_Host.cpp
@@ -1814,7 +1814,7 @@ void InitializeASTCSettingsForSetBlockSize(__global ASTC_Encode *ASTCEncode)
         maxiters_autoset = 1;
     }
     else
-        if (ASTCEncode->m_Quality < 0.5) 
+        if (ASTCEncode->m_Quality < 0.5)
         {
             // Medium speed setting
             plimit_autoset = 2;
@@ -3662,7 +3662,7 @@ int compute_value_of_texel_int_cpu(int texel_to_get, const decimation_table_cpu 
 void decompress_symbolic_block_cpu(ASTC_Encoder::astc_decode_mode decode_mode,
 							   int xdim, int ydim, int zdim,   // dimensions of block
 							   int xpos, int ypos, int zpos,   // position of block
-							   symbolic_compressed_block_cpu * scb, 
+							   symbolic_compressed_block_cpu * scb,
                                imageblock_cpu * blk)
 {
 	blk->xpos = xpos;
@@ -3777,7 +3777,9 @@ void decompress_symbolic_block_cpu(ASTC_Encoder::astc_decode_mode decode_mode,
 	int partition_count = scb->partition_count;
 
     if ((partition_count > 5) || (scb->partition_index > 1024))
+    {
         return;
+    }
 
 
 	// get the appropriate block descriptor
@@ -3799,14 +3801,14 @@ void decompress_symbolic_block_cpu(ASTC_Encoder::astc_decode_mode decode_mode,
 
 	for (i = 0; i < partition_count; i++)
 		unpack_color_endpoints_cpu(
-            decode_mode,				   
-            scb->color_formats[i],		   
+            decode_mode,
+            scb->color_formats[i],
             scb->color_quantization_level,
             scb->color_values[i],
-            &(rgb_hdr_endpoint[i]), 
-            &(alpha_hdr_endpoint[i]), 
-            &(nan_endpoint[i]), 
-            &(color_endpoint0[i]), 
+            &(rgb_hdr_endpoint[i]),
+            &(alpha_hdr_endpoint[i]),
+            &(nan_endpoint[i]),
+            &(color_endpoint0[i]),
             &(color_endpoint1[i]));
 
 	// first unquantize the weights
@@ -3849,7 +3851,7 @@ void decompress_symbolic_block_cpu(ASTC_Encoder::astc_decode_mode decode_mode,
 	for (i = 0; i < texels_per_block; i++)
 	{
         ASTC_Encoder::uint8_t partition = g_ASTCEncode.partition_tables[partition_count][scb->partition_index].partition_of_texel[i];
- 
+
         ASTC_Encoder::ushort4 color = lerp_color_int(decode_mode,
 									   color_endpoint0[partition],
 									   color_endpoint1[partition],
@@ -3871,6 +3873,6 @@ void decompress_symbolic_block_cpu(ASTC_Encoder::astc_decode_mode decode_mode,
 	update_imageblock_flags_cpu(blk, xdim, ydim, zdim);
 }
 
-// End CPU Decoder Code 
+// End CPU Decoder Code
 //-----------------------------------------------
 

--- a/Compressonator/Source/Codec/ASTC/Codec_ASTC.cpp
+++ b/Compressonator/Source/Codec/ASTC/Codec_ASTC.cpp
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -27,9 +27,11 @@
 //
 //////////////////////////////////////////////////////////////////////////////
 
+#ifdef _MSC_VER
 #pragma warning(disable:4100)    // Ignore warnings of unreferenced formal parameters
 #pragma warning(disable:4101)    // Ignore warnings of unreferenced local variable
 #pragma warning(disable:4996)   // This function or variable may be unsafe
+#endif //_MSC_VER
 
 #include "Common.h"
 #include "ASTC/Codec_ASTC.h"
@@ -104,8 +106,10 @@ CCodec_ASTC::~CCodec_ASTC()
                 // If we don't wait then there is a race condition here where we have
                 // told the thread to run but it hasn't yet been scheduled - if we set
                 // the exit flag before it runs then its block will not be processed.
+#ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable:4127) //warning C4127: conditional expression is constant
+#endif //_MSC_VER
                 while (1)
                 {
                     if (g_EncodeParameterStorage[i].run != TRUE)
@@ -113,7 +117,9 @@ CCodec_ASTC::~CCodec_ASTC()
                         break;
                     }
                 }
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif //_MSC_VER
                 // Signal to the thread that it can exit
                 g_EncodeParameterStorage[i].exit = TRUE;
             }
@@ -536,8 +542,8 @@ CodecError CCodec_ASTC::EncodeASTCBlock(
         g_ASTCEncode.m_zdim = zdim;
 
         m_encoder[0]->CompressBlock_kernel(
-            (ASTC_Encoder::astc_codec_image *)input_image, 
-            bp, 
+            (ASTC_Encoder::astc_codec_image *)input_image,
+            bp,
             x,
             y,
             z,
@@ -629,7 +635,7 @@ CodecError CCodec_ASTC::Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut
 
     DbgTrace(("OUT: BufferType %d ChannelCount %d ChannelDepth %d", bufferOut.GetBufferType(), bufferOut.GetChannelCount(), bufferOut.GetChannelDepth()));
     DbgTrace(("   : Height %d Width %d Pitch %d isFloat %d", bufferOut.GetHeight(), bufferOut.GetWidth(), bufferOut.GetWidth(), bufferOut.IsFloat()));
-#endif;
+#endif
 
 
     int bitness = 0; //todo: replace astc_codec_image with bufferIn and rewrite fetch_imageblock()
@@ -673,7 +679,7 @@ CodecError CCodec_ASTC::Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut
     if (!input_image)
         assert("Unable to allocate image buffer");
 
-    // Loop through the original input image and setup compression threads for each 
+    // Loop through the original input image and setup compression threads for each
     // block to encode  we will load the buffer to pass to ASTC code as 8 bit 4x4 blocks
     // the fill in source image. ASTC code will then use the adaptive sizes for process on the input
     BYTE *pData = bufferIn.GetData();
@@ -702,7 +708,7 @@ CodecError CCodec_ASTC::Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut
     uint8_t *bufferOutput = bufferOut.GetData();
 
     // Common ARM and Compressonator Code
-    int x, y, z, i;
+    int x, y, z;
     int xblocks = (xsize + xdim - 1) / xdim;
     int yblocks = (ysize + ydim - 1) / ydim;
     int zblocks = (zsize + zdim - 1) / zdim;
@@ -763,7 +769,7 @@ CodecError CCodec_ASTC::Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferO
     // Our Compressed data Blocks are always 128 bit long (4x4 blocks)
     const CMP_DWORD imageWidth  = bufferIn.GetWidth();
     const CMP_DWORD imageHeight = bufferIn.GetHeight();
-    const CMP_DWORD imageDepth  = 1;
+    const CMP_DWORD imageDepth  = 1;        // unused
     const BYTE      bitness     = 8;
 
     const CMP_DWORD CompBlockX  = bufferIn.GetBlockWidth();
@@ -773,8 +779,8 @@ CodecError CCodec_ASTC::Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferO
 
     const CMP_DWORD dwBlocksX = ((bufferIn.GetWidth() + (CompBlockX - 1)) / CompBlockX);
     const CMP_DWORD dwBlocksY = ((bufferIn.GetHeight()+ (CompBlockY - 1)) / CompBlockY);
-    const CMP_DWORD dwBlocksZ = 1;
-    const CMP_DWORD dwBufferInDepth = 1;
+    const CMP_DWORD dwBlocksZ = 1;          // unused
+    const CMP_DWORD dwBufferInDepth = 1;    // unused
 
     // Override the current input buffer Pitch size  (Since it will be set according to the Compressed Block Sizes
     // and not to the Compressed Codec data which is for ASTC 16 Bytes per block x Number of blocks per row
@@ -797,7 +803,7 @@ CodecError CCodec_ASTC::Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferO
                 float decodedBlock[144][4];            // max 12x12 block size
                 float destBlock[576];                  // max 12x12x4
             } DecData;
-    
+
             union BBLOCKS
             {
                 CMP_DWORD       compressedBlock[4];
@@ -809,23 +815,23 @@ CodecError CCodec_ASTC::Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferO
 
             // Encode to the appropriate location in the compressed image
             m_decoder->DecompressBlock(Block_Width, Block_Height, bitness, DecData.decodedBlock,CompData.in);
-            
+
             // Now that we have a decoded block lets copy that data over to the target image buffer
             CMP_DWORD outCol = cmpColX*Block_Width;
             CMP_DWORD outRow = cmpRowY*Block_Height;
             CMP_DWORD outImgRow = outRow;
             CMP_DWORD outImgCol = outCol;
 
-            for (int row = 0; row < Block_Height; row++)
+            for (unsigned int row = 0; row < Block_Height; row++)
             {
                 CMP_DWORD  nextRowCol  = (outRow+row)*dwPitch + (outCol * 4);
                 CMP_BYTE*  pData       = (CMP_BYTE*)(pDataOut + nextRowCol);
                 if ((outImgRow + row) < imageHeight)
                 {
                     outImgCol = outCol;
-                    for (int col = 0; col < Block_Width; col++)
+                    for (unsigned int col = 0; col < Block_Width; col++)
                     {
-                        int w = outImgCol + col;
+                        unsigned int w = outImgCol + col;
                         if (w < imageWidth)
                         {
                             int index = row*Block_Width + col;

--- a/Compressonator/Source/Codec/ATC/Codec_ATC_RGB.cpp
+++ b/Compressonator/Source/Codec/ATC/Codec_ATC_RGB.cpp
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -22,11 +22,13 @@
 // THE SOFTWARE.
 //
 //
-//  File Name:   Codec_ATC.cpp  
+//  File Name:   Codec_ATC.cpp
 //  Description: implementation of the CCodec_ATC class
 //
 //////////////////////////////////////////////////////////////////////////////
+#ifdef _MSC_VER
 #pragma warning(disable:4100)
+#endif //_MSC_VER
 
 #include "Common.h"
 #include "Codec_ATC_RGB.h"
@@ -50,7 +52,7 @@ CCodec_ATC_RGB::~CCodec_ATC_RGB()
 }
 
 CCodecBuffer* CCodec_ATC_RGB::CreateBuffer(
-    CMP_BYTE nBlockWidth, CMP_BYTE nBlockHeight, CMP_BYTE nBlockDepth, 
+    CMP_BYTE nBlockWidth, CMP_BYTE nBlockHeight, CMP_BYTE nBlockDepth,
     CMP_DWORD dwWidth, CMP_DWORD dwHeight, CMP_DWORD dwPitch, CMP_BYTE* pData) const
 {
     return CreateCodecBuffer(CBT_4x4Block_4BPP, 4,4,1,dwWidth, dwHeight, dwPitch, pData);

--- a/Compressonator/Source/Codec/ATC/Codec_ATC_RGBA_Explicit.cpp
+++ b/Compressonator/Source/Codec/ATC/Codec_ATC_RGBA_Explicit.cpp
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -26,7 +26,9 @@
 //  Description: implementation of the CCodec_ATC class
 //
 //////////////////////////////////////////////////////////////////////////////
+#ifdef _MSC_VER
 #pragma warning(disable:4100)
+#endif //_MSC_VER
 
 #include "Common.h"
 #include "Codec_ATC_RGBA_Explicit.h"

--- a/Compressonator/Source/Codec/ATC/Codec_ATC_RGBA_Interpolated.cpp
+++ b/Compressonator/Source/Codec/ATC/Codec_ATC_RGBA_Interpolated.cpp
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -26,7 +26,9 @@
 //  Description: implementation of the CCodec_ATC class
 //
 //////////////////////////////////////////////////////////////////////////////
+#ifdef _MSC_VER
 #pragma warning(disable:4100)
+#endif //_MSC_VER
 
 #include "Common.h"
 #include "Codec_ATC_RGBA_Interpolated.h"

--- a/Compressonator/Source/Codec/ATI/Codec_ATI1N.cpp
+++ b/Compressonator/Source/Codec/ATI/Codec_ATI1N.cpp
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -22,11 +22,13 @@
 // THE SOFTWARE.
 //
 //
-//  File Name:   Codec_ATI1N.cpp  
+//  File Name:   Codec_ATI1N.cpp
 //  Description: implementation of the CCodec_ATI1N class
 //
 //////////////////////////////////////////////////////////////////////////////
+#ifdef _MSC_VER
 #pragma warning(disable:4100)
+#endif //_MSC_VER
 
 #include "Common.h"
 #include "Codec_ATI1N.h"
@@ -154,7 +156,7 @@ CodecError CCodec_ATI1N::Decompress(CCodecBuffer& bufferIn, CCodecBuffer& buffer
         {
             CMP_DWORD compressedBlock[2];
             bufferIn.ReadBlock(i*4, j*4, compressedBlock, 2);
-        
+
             if(bUseFixed)
             {
                 CMP_BYTE alphaBlock[BLOCK_SIZE_4X4];

--- a/Compressonator/Source/Codec/ATI/Codec_ATI2N.cpp
+++ b/Compressonator/Source/Codec/ATI/Codec_ATI2N.cpp
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -22,11 +22,13 @@
 // THE SOFTWARE.
 //
 //
-//  File Name:   Codec_ATI2N.cpp  
+//  File Name:   Codec_ATI2N.cpp
 //  Description: implementation of the CCodec_ATI2N class
 //
 //////////////////////////////////////////////////////////////////////////////
+#ifdef _MSC_VER
 #pragma warning(disable:4100)
+#endif //_MSC_VER
 
 #include "Common.h"
 #include "Codec_ATI2N.h"
@@ -172,7 +174,7 @@ CodecError CCodec_ATI2N::Decompress(CCodecBuffer& bufferIn, CCodecBuffer& buffer
 
 
     bool bUseFixed = (!bufferOut.IsFloat() && bufferOut.GetChannelDepth() == 8 && !m_bUseFloat);
-    
+
    CMP_BYTE alphaBlockA[BLOCK_SIZE_4X4];
    CMP_BYTE alphaBlockR[BLOCK_SIZE_4X4];
    CMP_BYTE alphaBlockG[BLOCK_SIZE_4X4];
@@ -186,15 +188,15 @@ CodecError CCodec_ATI2N::Decompress(CCodecBuffer& bufferIn, CCodecBuffer& buffer
    float falphaBlockA[BLOCK_SIZE_4X4];
    memset(falphaBlockA, 255, sizeof(falphaBlockA));
    memset(falphaBlockB, 0, sizeof(falphaBlockB));
-   
+
    CMP_DWORD compressedBlock[4];
-   
+
    for(CMP_DWORD j = 0; j < dwBlocksY; j++)
    {
        for(CMP_DWORD i = 0; i < dwBlocksX; i++)
        {
            bufferIn.ReadBlock(i*4, j*4, compressedBlock, 4);
-   
+
            if(bUseFixed)
            {
                DecompressAlphaBlock(alphaBlockR, &compressedBlock[dwXOffset]);

--- a/Compressonator/Source/Codec/ATI/Codec_ATI2N_DXT5.cpp
+++ b/Compressonator/Source/Codec/ATI/Codec_ATI2N_DXT5.cpp
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -26,7 +26,9 @@
 //  Description: implementation of the CCodec_ATI2N_DXT5 class
 //
 //////////////////////////////////////////////////////////////////////////////
+#ifdef _MSC_VER
 #pragma warning(disable:4100)
+#endif //_MSC_VER
 
 #include "Common.h"
 #include "Codec_ATI2N_DXT5.h"

--- a/Compressonator/Source/Codec/BC6H/BC6H_Decode.cpp
+++ b/Compressonator/Source/Codec/BC6H/BC6H_Decode.cpp
@@ -8,10 +8,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -24,7 +24,7 @@
 // BC6H_Decode.cpp : Decoder for BC6H
 //
 // Revision
-// 0.1    First implementation 
+// 0.1    First implementation
 //
 #include <assert.h>
 #include "debug.h"
@@ -38,9 +38,13 @@
 #include <bitset>
 #include <stddef.h>
 
+#ifdef _MSC_VER
 #pragma warning(disable:4244)
+#endif //_MSC_VER
 #include "half.h"
+#ifdef _MSC_VER
 #pragma warning(default:4244)
+#endif //_MSC_VER
 
 
 #ifdef BC6H_DECODE_DEBUG
@@ -76,11 +80,11 @@ void extract_compressed_endpoints2(AMD_BC6H_Format& bc6h_format)
                 t = SIGN_EXTEND(bc6h_format.EC[0].B[i], bc6h_format.tBits[i]); // C_RED
                 t = (t + bc6h_format.EC[0].A[i]) & MASK(bc6h_format.wBits);
                 bc6h_format.E[0].B[i] = SIGN_EXTEND(t,bc6h_format.wBits);
-                
+
                 t = SIGN_EXTEND(bc6h_format.EC[1].A[i], bc6h_format.tBits[i]); //C_GREEN
                 t = (t + bc6h_format.EC[0].A[i]) & MASK(bc6h_format.wBits);
                 bc6h_format.E[1].A[i] = SIGN_EXTEND(t,bc6h_format.wBits);
-                
+
                 t = SIGN_EXTEND(bc6h_format.EC[1].B[i], bc6h_format.tBits[i]); //C_BLUE
                 t = (t + bc6h_format.EC[0].A[i]) & MASK(bc6h_format.wBits);
                 bc6h_format.E[1].B[i] = SIGN_EXTEND(t,bc6h_format.wBits);
@@ -107,10 +111,10 @@ void extract_compressed_endpoints2(AMD_BC6H_Format& bc6h_format)
                 bc6h_format.E[0].A[i] = bc6h_format.EC[0].A[i];
                 t = SIGN_EXTEND(bc6h_format.EC[0].B[i], bc6h_format.tBits[i]); // C_RED
                 bc6h_format.E[0].B[i] = (t + bc6h_format.EC[0].A[i]) & MASK(bc6h_format.wBits);
-                
+
                 t = SIGN_EXTEND(bc6h_format.EC[1].A[i], bc6h_format.tBits[i]); // C_GREEN
                 bc6h_format.E[1].A[i] = (t + bc6h_format.EC[0].A[i]) & MASK(bc6h_format.wBits);
-                
+
                 t = SIGN_EXTEND(bc6h_format.EC[1].B[i], bc6h_format.tBits[i]); //C_BLUE
                 bc6h_format.E[1].B[i] = (t + bc6h_format.EC[0].A[i]) & MASK(bc6h_format.wBits);
             }
@@ -126,7 +130,7 @@ void extract_compressed_endpoints2(AMD_BC6H_Format& bc6h_format)
             }
         }
     }
-    
+
 }
 
 void extract_compressed_endpoints(AMD_BC6H_Format& bc6h_format)
@@ -177,7 +181,7 @@ void extract_compressed_endpoints(AMD_BC6H_Format& bc6h_format)
             }
         }
     }
-    
+
 }
 
 // NV code: Used with modifcations
@@ -193,11 +197,11 @@ int unquantize(AMD_BC6H_Format& bc6h_format, int q, int prec)
         // since we have 16 bits available, let's unquantize this to 16 bits unsigned
         // thus the scale factor is [0-7c00)/[0-10000) = 31/64
         case UNSIGNED_F16:
-            if (prec >= 15) 
+            if (prec >= 15)
                 unq = q;
-            else if (q == 0) 
+            else if (q == 0)
                 unq = 0;
-            else if (q == ((1<<prec)-1)) 
+            else if (q == ((1<<prec)-1))
                 unq = U16MAX;
             else
                 unq = (q * (U16MAX+1) + (U16MAX+1)/2) >> prec;
@@ -234,7 +238,7 @@ int lerp(int a, int b, int i, int denom)
 {
     assert (denom == 3 || denom == 7 || denom == 15);
     assert (i >= 0 && i <= denom);
-    
+
     int shift = 6, *weights = NULL;
 
     switch(denom)
@@ -245,7 +249,9 @@ int lerp(int a, int b, int i, int denom)
     default:    assert(0);
     }
 
-    #pragma warning(disable:4244)
+#ifdef _MSC_VER
+#pragma warning(disable:4244)
+#endif //_MSC_VER
     // no need to round these as this is an exact division
     return (int)(a*weights[denom-i] +b*weights[i]) / float(1 << shift);
 }
@@ -265,24 +271,24 @@ void generate_palette_quantized(int max, AMD_BC6H_Format& bc6h_format, int regio
     // scale endpoints
     int a, b, c;            // really need a IntVec3...
 
-    a = unquantize(bc6h_format, bc6h_format.E[region].A[0], bc6h_format.wBits); 
+    a = unquantize(bc6h_format, bc6h_format.E[region].A[0], bc6h_format.wBits);
     b = unquantize(bc6h_format, bc6h_format.E[region].B[0], bc6h_format.wBits);
 
-    // interpolate : This part of code is used for debuging data 
+    // interpolate : This part of code is used for debuging data
     for (int i = 0; i < max; i++)
     {
         c = finish_unquantize(bc6h_format, lerp(a, b, i, max-1));
         bc6h_format.Palete[region][i].x = c;
     }
 
-    a = unquantize(bc6h_format, bc6h_format.E[region].A[1], bc6h_format.wBits); 
+    a = unquantize(bc6h_format, bc6h_format.E[region].A[1], bc6h_format.wBits);
     b = unquantize(bc6h_format, bc6h_format.E[region].B[1], bc6h_format.wBits);
 
     // interpolate
     for (int i = 0; i < max; i++)
         bc6h_format.Palete[region][i].y = finish_unquantize(bc6h_format, lerp(a, b, i, max-1));
 
-    a = unquantize(bc6h_format,bc6h_format.E[region].A[2], bc6h_format.wBits); 
+    a = unquantize(bc6h_format,bc6h_format.E[region].A[2], bc6h_format.wBits);
     b = unquantize(bc6h_format,bc6h_format.E[region].B[2], bc6h_format.wBits);
 
     // interpolate
@@ -300,7 +306,7 @@ AMD_BC6H_Format extract_format(BYTE in[COMPRESSED_BLOCK_SIZE])
     memset(&bc6h_format,0,sizeof(AMD_BC6H_Format));
 
     // 2 bit mode has Mode bit:2 = 0 and mode bits:1 = 0 or 1
-    // 5 bit mode has Mode bit:2 = 1 
+    // 5 bit mode has Mode bit:2 = 1
     if ((in[0]&0x02) > 0)
     {
         decvalue = (in[0]&0x1F);    // first five bits
@@ -311,7 +317,7 @@ AMD_BC6H_Format extract_format(BYTE in[COMPRESSED_BLOCK_SIZE])
     }
 
     BitHeader header(in,16);
-    
+
     switch (decvalue)
     {
     case 0x00:
@@ -320,7 +326,7 @@ AMD_BC6H_Format extract_format(BYTE in[COMPRESSED_BLOCK_SIZE])
                 bc6h_format.tBits[C_RED]    = 5;
                 bc6h_format.tBits[C_GREEN]  = 5;
                 bc6h_format.tBits[C_BLUE]   = 5;
-                bc6h_format.rw = header.getvalue(5 ,10);            // 10:   rw[9:0] 
+                bc6h_format.rw = header.getvalue(5 ,10);            // 10:   rw[9:0]
                 bc6h_format.rx = header.getvalue(35,5);             // 5:    rx[4:0]
                 bc6h_format.ry = header.getvalue(65,5);             // 5:    ry[4:0]
                 bc6h_format.rz = header.getvalue(71,5);             // 5:    rz[4:0]
@@ -346,7 +352,7 @@ AMD_BC6H_Format extract_format(BYTE in[COMPRESSED_BLOCK_SIZE])
                 bc6h_format.tBits[C_RED]    = 6;
                 bc6h_format.tBits[C_GREEN]  = 6;
                 bc6h_format.tBits[C_BLUE]   = 6;
-                bc6h_format.rw = header.getvalue(5,7);               // 7:    rw[6:0] 
+                bc6h_format.rw = header.getvalue(5,7);               // 7:    rw[6:0]
                 bc6h_format.rx = header.getvalue(35,6);              // 6:    rx[5:0]
                 bc6h_format.ry = header.getvalue(65,6);              // 6:    ry[5:0]
                 bc6h_format.rz = header.getvalue(71,6);              // 6:    rz[5:0]
@@ -376,7 +382,7 @@ AMD_BC6H_Format extract_format(BYTE in[COMPRESSED_BLOCK_SIZE])
                 bc6h_format.tBits[C_RED]    = 5;
                 bc6h_format.tBits[C_GREEN]  = 4;
                 bc6h_format.tBits[C_BLUE]   = 4;
-                bc6h_format.rw = header.getvalue(5,10)  |            //11:    rw[9:0] 
+                bc6h_format.rw = header.getvalue(5,10)  |            //11:    rw[9:0]
                                 (header.getvalue(40,1) << 10);       //       rw[10]
                 bc6h_format.rx = header.getvalue(35,5);              // 5:    rx[4:0]
                 bc6h_format.ry = header.getvalue(65,5);              // 5:    ry[4:0]
@@ -401,7 +407,7 @@ AMD_BC6H_Format extract_format(BYTE in[COMPRESSED_BLOCK_SIZE])
                 bc6h_format.tBits[C_RED]    = 4;
                 bc6h_format.tBits[C_GREEN]  = 5;
                 bc6h_format.tBits[C_BLUE]   = 4;
-                bc6h_format.rw = header.getvalue(5,10)  |             //11:   rw[9:0] 
+                bc6h_format.rw = header.getvalue(5,10)  |             //11:   rw[9:0]
                                 (header.getvalue(39,1) << 10);        //      rw[10]
                 bc6h_format.rx = header.getvalue(35,4);               //4:    rx[3:0]
                 bc6h_format.ry = header.getvalue(65,4);               //4:    ry[3:0]
@@ -428,7 +434,7 @@ AMD_BC6H_Format extract_format(BYTE in[COMPRESSED_BLOCK_SIZE])
                 bc6h_format.tBits[C_RED]    = 4;
                 bc6h_format.tBits[C_GREEN]  = 4;
                 bc6h_format.tBits[C_BLUE]   = 5;
-                bc6h_format.rw = header.getvalue(5,10)  |             //11:   rw[9:0] 
+                bc6h_format.rw = header.getvalue(5,10)  |             //11:   rw[9:0]
                                 (header.getvalue(39,1) << 10);        //      rw[10]
                 bc6h_format.rx = header.getvalue(35,4);               //4:    rx[3:0]
                 bc6h_format.ry = header.getvalue(65,4);               //4:    ry[3:0]
@@ -455,7 +461,7 @@ AMD_BC6H_Format extract_format(BYTE in[COMPRESSED_BLOCK_SIZE])
                 bc6h_format.tBits[C_RED]    = 5;
                 bc6h_format.tBits[C_GREEN]  = 5;
                 bc6h_format.tBits[C_BLUE]   = 5;
-                bc6h_format.rw = header.getvalue(5,9);                 //9:   rw[8:0] 
+                bc6h_format.rw = header.getvalue(5,9);                 //9:   rw[8:0]
                 bc6h_format.gw = header.getvalue(15,9);                //9:   gw[8:0]
                 bc6h_format.bw = header.getvalue(25,9);                //9:   bw[8:0]
                 bc6h_format.rx = header.getvalue(35,5);                //5:   rx[4:0]
@@ -481,7 +487,7 @@ AMD_BC6H_Format extract_format(BYTE in[COMPRESSED_BLOCK_SIZE])
                 bc6h_format.tBits[C_RED]    = 6;
                 bc6h_format.tBits[C_GREEN]  = 5;
                 bc6h_format.tBits[C_BLUE]   = 5;
-                bc6h_format.rw = header.getvalue(5,8);                 //8:    rw[7:0] 
+                bc6h_format.rw = header.getvalue(5,8);                 //8:    rw[7:0]
                 bc6h_format.gw = header.getvalue(15,8);                //8:    gw[7:0]
                 bc6h_format.bw = header.getvalue(25,8);                //8:    bw[7:0]
                 bc6h_format.rx = header.getvalue(35,6);                //6:    rx[5:0]
@@ -507,7 +513,7 @@ AMD_BC6H_Format extract_format(BYTE in[COMPRESSED_BLOCK_SIZE])
                 bc6h_format.tBits[C_RED]    = 5;
                 bc6h_format.tBits[C_GREEN]  = 6;
                 bc6h_format.tBits[C_BLUE]   = 5;
-                bc6h_format.rw = header.getvalue(5,8);                 //8:    rw[7:0] 
+                bc6h_format.rw = header.getvalue(5,8);                 //8:    rw[7:0]
                 bc6h_format.gw = header.getvalue(15,8);                //8:    gw[7:0]
                 bc6h_format.bw = header.getvalue(25,8);                //8:    bw[7:0]
                 bc6h_format.rx = header.getvalue(35,5);                //5:    rx[4:0]
@@ -535,7 +541,7 @@ AMD_BC6H_Format extract_format(BYTE in[COMPRESSED_BLOCK_SIZE])
                 bc6h_format.tBits[C_RED]    = 5;
                 bc6h_format.tBits[C_GREEN]  = 5;
                 bc6h_format.tBits[C_BLUE]   = 6;
-                bc6h_format.rw = header.getvalue(5,8);                 //8:    rw[7:0] 
+                bc6h_format.rw = header.getvalue(5,8);                 //8:    rw[7:0]
                 bc6h_format.gw = header.getvalue(15,8);                //8:    gw[7:0]
                 bc6h_format.bw = header.getvalue(25,8);                //8:    bw[7:0]
                 bc6h_format.rx = header.getvalue(35,5);                //5:    rx[4:0]
@@ -564,7 +570,7 @@ AMD_BC6H_Format extract_format(BYTE in[COMPRESSED_BLOCK_SIZE])
                 bc6h_format.tBits[C_RED]    = 6;
                 bc6h_format.tBits[C_GREEN]  = 6;
                 bc6h_format.tBits[C_BLUE]   = 6;
-                bc6h_format.rw = header.getvalue(5,6);                 //6:    rw[5:0] 
+                bc6h_format.rw = header.getvalue(5,6);                 //6:    rw[5:0]
                 bc6h_format.gw = header.getvalue(15,6);                //6:    gw[5:0]
                 bc6h_format.bw = header.getvalue(25,6);                //6:    bw[5:0]
                 bc6h_format.rx = header.getvalue(35,6);                //6:    rx[5:0]
@@ -589,14 +595,14 @@ AMD_BC6H_Format extract_format(BYTE in[COMPRESSED_BLOCK_SIZE])
                                 (header.getvalue(33,1) << 5);          //      bz[5]
                 break;
 
-    // Single region modes    
+    // Single region modes
     case 0x03:
                 bc6h_format.m_mode            = 11;  // 10:10
                 bc6h_format.wBits             = 10;
                 bc6h_format.tBits[C_RED]      = 10;
                 bc6h_format.tBits[C_GREEN]    = 10;
                 bc6h_format.tBits[C_BLUE]     = 10;
-                bc6h_format.rw = header.getvalue(5,10);             // 10: rw[9:0] 
+                bc6h_format.rw = header.getvalue(5,10);             // 10: rw[9:0]
                 bc6h_format.gw = header.getvalue(15,10);            // 10: gw[9:0]
                 bc6h_format.bw = header.getvalue(25,10);            // 10: bw[9:0]
                 bc6h_format.rx = header.getvalue(35,10);            // 10: rx[9:0]
@@ -609,7 +615,7 @@ AMD_BC6H_Format extract_format(BYTE in[COMPRESSED_BLOCK_SIZE])
                 bc6h_format.tBits[C_RED]        = 9;
                 bc6h_format.tBits[C_GREEN]      = 9;
                 bc6h_format.tBits[C_BLUE]       = 9;
-                bc6h_format.rw = header.getvalue(5,10) |               // 10:   rw[9:0] 
+                bc6h_format.rw = header.getvalue(5,10) |               // 10:   rw[9:0]
                                 (header.getvalue(44,1) << 10);         //       rw[10]
                 bc6h_format.gw = header.getvalue(15,10) |              // 10:   gw[9:0]
                                 (header.getvalue(54,1) << 10);         //       gw[10]
@@ -625,7 +631,7 @@ AMD_BC6H_Format extract_format(BYTE in[COMPRESSED_BLOCK_SIZE])
                 bc6h_format.tBits[C_RED]        = 8;
                 bc6h_format.tBits[C_GREEN]      = 8;
                 bc6h_format.tBits[C_BLUE]       = 8;
-                bc6h_format.rw = header.getvalue(5, 10) |               // 12:   rw[9:0] 
+                bc6h_format.rw = header.getvalue(5, 10) |               // 12:   rw[9:0]
                                  (header.getvalue(43, 1) << 11) |       //       rw[11]
                                  (header.getvalue(44, 1) << 10);        //       rw[10]
                 bc6h_format.gw = header.getvalue(15, 10) |              // 12:   gw[9:0]
@@ -644,7 +650,7 @@ AMD_BC6H_Format extract_format(BYTE in[COMPRESSED_BLOCK_SIZE])
                 bc6h_format.tBits[C_RED]    = 4;
                 bc6h_format.tBits[C_GREEN]  = 4;
                 bc6h_format.tBits[C_BLUE]   = 4;
-                bc6h_format.rw = header.getvalue(5,10) |                // 16:   rw[9:0] 
+                bc6h_format.rw = header.getvalue(5,10) |                // 16:   rw[9:0]
                                  (header.getvalue(39,6) << 10);         //       rw[15:10]
                 bc6h_format.gw = header.getvalue(15,10) |               // 16:   gw[9:0]
                                  (header.getvalue(49,6) << 10);         //       gw[15:10]
@@ -659,24 +665,24 @@ AMD_BC6H_Format extract_format(BYTE in[COMPRESSED_BLOCK_SIZE])
                 return bc6h_format;
     }
 
-    // Each format in the mode table can be uniquely identified by the mode bits. 
-    // The first ten modes are used for two-region tiles, and the mode bit field 
-    // can be either two or five bits long. These blocks also have fields for 
-    // the compressed color endpoints (72 or 75 bits), the partition (5 bits), 
+    // Each format in the mode table can be uniquely identified by the mode bits.
+    // The first ten modes are used for two-region tiles, and the mode bit field
+    // can be either two or five bits long. These blocks also have fields for
+    // the compressed color endpoints (72 or 75 bits), the partition (5 bits),
     // and the partition indices (46 bits).
 
-    if (bc6h_format.m_mode <= 10) 
+    if (bc6h_format.m_mode <= 10)
     {
         bc6h_format.region = BC6_TWO;
         // Get the shape index bits 77 to 81
         bc6h_format.d_shape_index = (unsigned short) header.getvalue(77,5);
-        bc6h_format.istransformed = (bc6h_format.m_mode < 10) ? TRUE : FALSE; 
+        bc6h_format.istransformed = (bc6h_format.m_mode < 10) ? TRUE : FALSE;
     }
-    else 
+    else
     {
         bc6h_format.region           = BC6_ONE;
         bc6h_format.d_shape_index    = 0;
-        bc6h_format.istransformed    = (bc6h_format.m_mode > 11) ? TRUE : FALSE; 
+        bc6h_format.istransformed    = (bc6h_format.m_mode > 11) ? TRUE : FALSE;
     }
 
     // Save the points in a form easy to compute with
@@ -687,24 +693,24 @@ AMD_BC6H_Format extract_format(BYTE in[COMPRESSED_BLOCK_SIZE])
     if (bc6h_format.region    == BC6_ONE)
     {
         int startbits = ONE_REGION_INDEX_OFFSET;
-        bc6h_format.indices16[0] = (byte) header.getvalue(startbits,3);
+        bc6h_format.indices16[0] = (BYTE) header.getvalue(startbits,3);
         startbits+=3;
         for (int i=1; i<16; i++)
         {
-            bc6h_format.indices16[i] = (byte) header.getvalue(startbits,4);
+            bc6h_format.indices16[i] = (BYTE) header.getvalue(startbits,4);
             startbits+=4;
         }
     }
     else
     {
-        int startbit = TWO_REGION_INDEX_OFFSET, 
+        int startbit = TWO_REGION_INDEX_OFFSET,
             nbits = 2;
-        bc6h_format.indices16[0 ] = (byte) header.getvalue(startbit,2);
+        bc6h_format.indices16[0 ] = (BYTE) header.getvalue(startbit,2);
         for (int i= 1; i<16; i++)
         {
             startbit += nbits; // offset start bit for next index using prior nbits used
             nbits    = g_indexfixups[bc6h_format.d_shape_index] == i?2:3; // get new number of bit to save index with
-            bc6h_format.indices16[i] = (byte) header.getvalue(startbit,nbits);    
+            bc6h_format.indices16[i] = (BYTE) header.getvalue(startbit,nbits);
         }
 
     }
@@ -716,7 +722,7 @@ AMD_BC6H_Format extract_format(BYTE in[COMPRESSED_BLOCK_SIZE])
 
 void BC6HBlockDecoder::DecompressBlock( float out[MAX_SUBSET_SIZE][MAX_DIMENSION_BIG],BYTE in[COMPRESSED_BLOCK_SIZE])
 {
-    // now determine the mode type and extract the coded endpoints data 
+    // now determine the mode type and extract the coded endpoints data
     AMD_BC6H_Format bc6h_format = extract_format(in);
     if (!bc6signed)
         bc6h_format.format = UNSIGNED_F16;
@@ -737,13 +743,13 @@ void BC6HBlockDecoder::DecompressBlock( float out[MAX_SUBSET_SIZE][MAX_DIMENSION
         }
     }
 
-    
+
     BC6H_Vec3 data;
     int indexPos=0;
     half rgb[3];
 
     // Note first 32 BC6H_PARTIONS is shared with BC6H
-    // Partitioning is always arranged such that index 0 is always in subset 0 of BC6H_PARTIONS array 
+    // Partitioning is always arranged such that index 0 is always in subset 0 of BC6H_PARTIONS array
     // Partition order goes from top-left to bottom-right, moving left to right and then top to bottom.
     for (int block_row = 0; block_row < 4; block_row++)
     for (int block_col = 0; block_col < 4; block_col++)
@@ -758,10 +764,10 @@ void BC6HBlockDecoder::DecompressBlock( float out[MAX_SUBSET_SIZE][MAX_DIMENSION
 
         // Index is validated as ok
         int paleteIndex  = bc6h_format.indices[block_row][block_col];
-        
-        // this result is validated ok for region = BC6_ONE , BC6_TWO To be determined 
+
+        // this result is validated ok for region = BC6_ONE , BC6_TWO To be determined
         data = bc6h_format.Palete[region][paleteIndex];
-    
+
         // Int to Half
         rgb[0].setBits((unsigned short) data.x);
         rgb[1].setBits((unsigned short) data.y);

--- a/Compressonator/Source/Codec/BC6H/BC6H_Encode.cpp
+++ b/Compressonator/Source/Codec/BC6H/BC6H_Encode.cpp
@@ -8,10 +8,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -76,7 +76,7 @@ void SaveDataBlock(AMD_BC6H_Format bc6h_format, BYTE out[BC6H_COMPRESSED_BLOCK_S
             header.setvalue(2, 1, bc6h_format.gy, 4);        //        gy[4]
             header.setvalue(3, 1, bc6h_format.by, 4);        //        by[4]
             header.setvalue(4, 1, bc6h_format.bz, 4);        //        bz[4]
-            header.setvalue(5, 10, bc6h_format.rw);          // 10:    rw[9:0] 
+            header.setvalue(5, 10, bc6h_format.rw);          // 10:    rw[9:0]
             header.setvalue(15, 10, bc6h_format.gw);          // 10:    gw[9:0]
             header.setvalue(25, 10, bc6h_format.bw);          // 10:    bw[9:0]
             header.setvalue(35, 5, bc6h_format.rx);          // 5:     rx[4:0]
@@ -98,7 +98,7 @@ void SaveDataBlock(AMD_BC6H_Format bc6h_format, BYTE out[BC6H_COMPRESSED_BLOCK_S
             header.setvalue(2, 1, bc6h_format.gy, 5);        //        gy[5]
             header.setvalue(3, 1, bc6h_format.gz, 4);        //        gz[4]
             header.setvalue(4, 1, bc6h_format.gz, 5);        //        gz[5]
-            header.setvalue(5, 7, bc6h_format.rw);          //        rw[6:0] 
+            header.setvalue(5, 7, bc6h_format.rw);          //        rw[6:0]
             header.setvalue(12, 1, bc6h_format.bz);          //        bz[0]
             header.setvalue(13, 1, bc6h_format.bz, 1);        //        bz[1]
             header.setvalue(14, 1, bc6h_format.by, 4);        //        by[4]
@@ -121,7 +121,7 @@ void SaveDataBlock(AMD_BC6H_Format bc6h_format, BYTE out[BC6H_COMPRESSED_BLOCK_S
             break;
         case 3: // 0x02
             header.setvalue(0, 5, 0x02);
-            header.setvalue(5, 10, bc6h_format.rw);          // 11:    rw[9:0] 
+            header.setvalue(5, 10, bc6h_format.rw);          // 11:    rw[9:0]
             header.setvalue(15, 10, bc6h_format.gw);          // 11:    gw[9:0]
             header.setvalue(25, 10, bc6h_format.bw);          // 11:    bw[9:0]
             header.setvalue(35, 5, bc6h_format.rx);          // 5:     rx[4:0]
@@ -142,7 +142,7 @@ void SaveDataBlock(AMD_BC6H_Format bc6h_format, BYTE out[BC6H_COMPRESSED_BLOCK_S
             break;
         case 4: // 0x06
             header.setvalue(0, 5, 0x06);
-            header.setvalue(5, 10, bc6h_format.rw);          // 11:    rw[9:0] 
+            header.setvalue(5, 10, bc6h_format.rw);          // 11:    rw[9:0]
             header.setvalue(15, 10, bc6h_format.gw);          // 11:    gw[9:0]
             header.setvalue(25, 10, bc6h_format.bw);          // 11:    bw[9:0]
             header.setvalue(35, 4, bc6h_format.rx);          //        rx[3:0]
@@ -165,7 +165,7 @@ void SaveDataBlock(AMD_BC6H_Format bc6h_format, BYTE out[BC6H_COMPRESSED_BLOCK_S
             break;
         case 5: // 0x0A
             header.setvalue(0, 5, 0x0A);
-            header.setvalue(5, 10, bc6h_format.rw);           // 11:   rw[9:0] 
+            header.setvalue(5, 10, bc6h_format.rw);           // 11:   rw[9:0]
             header.setvalue(15, 10, bc6h_format.gw);           // 11:   gw[9:0]
             header.setvalue(25, 10, bc6h_format.bw);           // 11:   bw[9:0]
             header.setvalue(35, 4, bc6h_format.rx);           // 4:    rx[3:0]
@@ -188,7 +188,7 @@ void SaveDataBlock(AMD_BC6H_Format bc6h_format, BYTE out[BC6H_COMPRESSED_BLOCK_S
             break;
         case 6: // 0x0E
             header.setvalue(0, 5, 0x0E);
-            header.setvalue(5, 9, bc6h_format.rw);           // 9:    rw[8:0] 
+            header.setvalue(5, 9, bc6h_format.rw);           // 9:    rw[8:0]
             header.setvalue(14, 1, bc6h_format.by, 4);         //       by[4]
             header.setvalue(15, 9, bc6h_format.gw);           // 9:    gw[8:0]
             header.setvalue(24, 1, bc6h_format.gy, 4);         //       gy[4]
@@ -210,7 +210,7 @@ void SaveDataBlock(AMD_BC6H_Format bc6h_format, BYTE out[BC6H_COMPRESSED_BLOCK_S
             break;
         case 7: // 0x12
             header.setvalue(0, 5, 0x12);
-            header.setvalue(5, 8, bc6h_format.rw);           // 8:    rw[7:0] 
+            header.setvalue(5, 8, bc6h_format.rw);           // 8:    rw[7:0]
             header.setvalue(13, 1, bc6h_format.gz, 4);         //       gz[4]
             header.setvalue(14, 1, bc6h_format.by, 4);         //       by[4]
             header.setvalue(15, 8, bc6h_format.gw);           // 8:    gw[7:0]
@@ -232,7 +232,7 @@ void SaveDataBlock(AMD_BC6H_Format bc6h_format, BYTE out[BC6H_COMPRESSED_BLOCK_S
             break;
         case 8: // 0x16
             header.setvalue(0, 5, 0x16);
-            header.setvalue(5, 8, bc6h_format.rw);            // 8:   rw[7:0] 
+            header.setvalue(5, 8, bc6h_format.rw);            // 8:   rw[7:0]
             header.setvalue(13, 1, bc6h_format.bz);            // 5:   bz[0]
             header.setvalue(14, 1, bc6h_format.by, 4);          //      by[4]
             header.setvalue(15, 8, bc6h_format.gw);            // 8:   gw[7:0]
@@ -256,7 +256,7 @@ void SaveDataBlock(AMD_BC6H_Format bc6h_format, BYTE out[BC6H_COMPRESSED_BLOCK_S
             break;
         case 9: // 0x1A
             header.setvalue(0, 5, 0x1A);
-            header.setvalue(5, 8, bc6h_format.rw);            // 8:   rw[7:0] 
+            header.setvalue(5, 8, bc6h_format.rw);            // 8:   rw[7:0]
             header.setvalue(13, 1, bc6h_format.bz, 1);          //      bz[1]
             header.setvalue(14, 1, bc6h_format.by, 4);          //      by[4]
             header.setvalue(15, 8, bc6h_format.gw);            // 8:   gw[7:0]
@@ -280,7 +280,7 @@ void SaveDataBlock(AMD_BC6H_Format bc6h_format, BYTE out[BC6H_COMPRESSED_BLOCK_S
             break;
         case 10: // 0x1E
             header.setvalue(0, 5, 0x1E);
-            header.setvalue(5, 6, bc6h_format.rw);            // 6:   rw[5:0] 
+            header.setvalue(5, 6, bc6h_format.rw);            // 6:   rw[5:0]
             header.setvalue(11, 1, bc6h_format.gz, 4);          //      gz[4]
             header.setvalue(12, 1, bc6h_format.bz);            // 6:   bz[0]
             header.setvalue(13, 1, bc6h_format.bz, 1);          //      bz[1]
@@ -308,7 +308,7 @@ void SaveDataBlock(AMD_BC6H_Format bc6h_format, BYTE out[BC6H_COMPRESSED_BLOCK_S
             // Single regions Modes
         case 11: // 0x03
             header.setvalue(0, 5, 0x03);
-            header.setvalue(5, 10, bc6h_format.rw);            // 10:   rw[9:0] 
+            header.setvalue(5, 10, bc6h_format.rw);            // 10:   rw[9:0]
             header.setvalue(15, 10, bc6h_format.gw);            // 10:   gw[9:0]
             header.setvalue(25, 10, bc6h_format.bw);            // 10:   bw[9:0]
             header.setvalue(35, 10, bc6h_format.rx);            // 10:   rx[9:0]
@@ -317,7 +317,7 @@ void SaveDataBlock(AMD_BC6H_Format bc6h_format, BYTE out[BC6H_COMPRESSED_BLOCK_S
             break;
         case 12: // 0x07
             header.setvalue(0, 5, 0x07);
-            header.setvalue(5, 10, bc6h_format.rw);            // 11:   rw[9:0] 
+            header.setvalue(5, 10, bc6h_format.rw);            // 11:   rw[9:0]
             header.setvalue(15, 10, bc6h_format.gw);            // 11:   gw[9:0]
             header.setvalue(25, 10, bc6h_format.bw);            // 11:   bw[9:0]
             header.setvalue(35, 9, bc6h_format.rx);            // 9:    rx[8:0]
@@ -329,7 +329,7 @@ void SaveDataBlock(AMD_BC6H_Format bc6h_format, BYTE out[BC6H_COMPRESSED_BLOCK_S
             break;
         case 13: // 0x0B
             header.setvalue(0, 5, 0x0B);
-            header.setvalue(5, 10, bc6h_format.rw);            // 12:   rw[9:0] 
+            header.setvalue(5, 10, bc6h_format.rw);            // 12:   rw[9:0]
             header.setvalue(15, 10, bc6h_format.gw);            // 12:   gw[9:0]
             header.setvalue(25, 10, bc6h_format.bw);            // 12:   bw[9:0]
             header.setvalue(35, 8, bc6h_format.rx);            // 8:    rx[7:0]
@@ -344,7 +344,7 @@ void SaveDataBlock(AMD_BC6H_Format bc6h_format, BYTE out[BC6H_COMPRESSED_BLOCK_S
             break;
         case 14: // 0x0F
             header.setvalue(0, 5, 0x0F);
-            header.setvalue(5, 10, bc6h_format.rw);            // 16:   rw[9:0] 
+            header.setvalue(5, 10, bc6h_format.rw);            // 16:   rw[9:0]
             header.setvalue(15, 10, bc6h_format.gw);            // 16:   gw[9:0]
             header.setvalue(25, 10, bc6h_format.bw);            // 16:   bw[9:0]
             header.setvalue(35, 4, bc6h_format.rx);            //  4:   rx[3:0]
@@ -358,10 +358,10 @@ void SaveDataBlock(AMD_BC6H_Format bc6h_format, BYTE out[BC6H_COMPRESSED_BLOCK_S
             return;
         }
 
-        // Each format in the mode table can be uniquely identified by the mode bits. 
-        // The first ten modes are used for two-region tiles, and the mode bit field 
-        // can be either two or five bits long. These blocks also have fields for 
-        // the compressed color endpoints (72 or 75 bits), the partition (5 bits), 
+        // Each format in the mode table can be uniquely identified by the mode bits.
+        // The first ten modes are used for two-region tiles, and the mode bit field
+        // can be either two or five bits long. These blocks also have fields for
+        // the compressed color endpoints (72 or 75 bits), the partition (5 bits),
         // and the partition indices (46 bits).
 
         if (bc6h_format.m_mode >= MIN_MODE_FOR_ONE_REGION)
@@ -409,11 +409,11 @@ static void decompress_endpts(const int in[MAX_SUBSETS][MAX_END_POINTS][MAX_DIME
             t = SIGN_EXTEND(R_1(in), ModePartition[mode].prec[i]);
             t = (t + R_0(in)) & MASK(ModePartition[mode].nbits);
             R_1(out) = issigned ? SIGN_EXTEND(t,ModePartition[mode].nbits) : t;
-            
+
             t = SIGN_EXTEND(R_2(in), ModePartition[mode].prec[i]);
             t = (t + R_0(in)) & MASK(ModePartition[mode].nbits);
             R_2(out) = issigned ? SIGN_EXTEND(t,ModePartition[mode].nbits) : t;
-            
+
             t = SIGN_EXTEND(R_3(in), ModePartition[mode].prec[i]);
             t = (t + R_0(in)) & MASK(ModePartition[mode].nbits);
             R_3(out) = issigned ? SIGN_EXTEND(t,ModePartition[mode].nbits) : t;
@@ -437,7 +437,7 @@ static bool endpts_fit(const int orig[MAX_SUBSETS][MAX_END_POINTS][MAX_DIMENSION
     int uncompressed[MAX_SUBSETS][MAX_END_POINTS][MAX_DIMENSION_BIG];
 
     decompress_endpts(compressed, uncompressed, mode, issigned);
-    
+
     for (int j=0; j<max_subsets; ++j)
     for (int i=0; i<3; ++i)
     {
@@ -490,20 +490,20 @@ void BC6HBlockEncoder::QuantizeEndPointToF16Prec(float EndPoints[MAX_SUBSETS][MA
 }
 
 /*=================================================================
-    Swap Indices 
+    Swap Indices
     so that indices at fix up points have higher order bit set to 0
 ==================================================================*/
 
 void BC6HBlockEncoder::SwapIndices(int iEndPoints[MAX_SUBSETS][MAX_END_POINTS][MAX_DIMENSION_BIG], int iIndices[3][BC6H_MAX_SUBSET_SIZE], int  entryCount[BC6H_MAX_SUBSETS], int max_subsets, int mode, int shape_pattern)
 {
-    
+
     unsigned int uNumIndices    = 1 << ModePartition[mode].IndexPrec;
     unsigned int uHighIndexBit    = uNumIndices >> 1;
-    
+
     for(int subset = 0; subset < max_subsets; ++subset)
     {
         // region 0 (subset = 0) The fix-up index for this subset is allways index 0
-        // region 1 (subset = 1) The fix-up index for this subset varies based on the shape 
+        // region 1 (subset = 1) The fix-up index for this subset varies based on the shape
         size_t i = subset?g_Region2FixUp[shape_pattern]:0;
 
         if(iIndices[subset][i] & uHighIndexBit)
@@ -550,7 +550,7 @@ bool BC6HBlockEncoder::TransformEndPoints(AMD_BC6H_Format &BC6H_data, int iEndPo
         {
             Mask = MASK(ModePartition[mode].nbits);
             oEndPoints[0][0][i] = iEndPoints[0][0][i] & Mask;    // [0][A]
-            
+
             Mask = MASK(ModePartition[mode].prec[i]);
             oEndPoints[0][1][i] = iEndPoints[0][1][i]- iEndPoints[0][0][i]; // [0][B] - [0][A]
 
@@ -558,7 +558,7 @@ bool BC6HBlockEncoder::TransformEndPoints(AMD_BC6H_Format &BC6H_data, int iEndPo
                 return false;
 
             oEndPoints[0][1][i] = (oEndPoints[0][1][i] & Mask);
-            
+
             if (max_subsets > 1)
             {
                 oEndPoints[1][0][i] = iEndPoints[1][0][i] - iEndPoints[0][0][i];  // [1][A] - [0][A]
@@ -598,10 +598,10 @@ bool BC6HBlockEncoder::TransformEndPoints(AMD_BC6H_Format &BC6H_data, int iEndPo
 }
 
 
-void BC6HBlockEncoder::SaveCompressedBlockData( AMD_BC6H_Format &BC6H_data, 
+void BC6HBlockEncoder::SaveCompressedBlockData( AMD_BC6H_Format &BC6H_data,
                                             int oEndPoints[MAX_SUBSETS][MAX_END_POINTS][MAX_DIMENSION_BIG],
-                                            int iIndices[2][BC6H_MAX_SUBSET_SIZE], 
-                                            int max_subsets, 
+                                            int iIndices[2][BC6H_MAX_SUBSET_SIZE],
+                                            int max_subsets,
                                             int mode)
 {
         BC6H_data.m_mode    = (unsigned short)mode;
@@ -632,10 +632,10 @@ void BC6HBlockEncoder::SaveCompressedBlockData( AMD_BC6H_Format &BC6H_data,
         for (int i=0; i<BC6H_MAX_SUBSET_SIZE; i++)
         {
             if (max_subsets > 1)
-                asubset                = PARTITIONS[1][BC6H_data.d_shape_index][i]; // Two region shapes 
+                asubset                = PARTITIONS[1][BC6H_data.d_shape_index][i]; // Two region shapes
             else
-                asubset                = PARTITIONS[0][BC6H_data.d_shape_index][i]; // One region shapes 
-            BC6H_data.indices16[i]    = (byte)iIndices[asubset][pos[asubset]];
+                asubset                = PARTITIONS[0][BC6H_data.d_shape_index][i]; // One region shapes
+            BC6H_data.indices16[i]    = (BYTE)iIndices[asubset][pos[asubset]];
             pos[asubset]++;
         }
 
@@ -645,7 +645,7 @@ void BC6HBlockEncoder::SaveCompressedBlockData( AMD_BC6H_Format &BC6H_data,
 void palitizeEndPointsF(AMD_BC6H_Format &BC6H_data, float fEndPoints[MAX_SUBSETS][MAX_END_POINTS][MAX_DIMENSION_BIG])
 {
     // scale endpoints
-    int    r, g, b;            // really need a IntVec3...
+    //int    r, g, b;            // really need a IntVec3...
     float  Ar,Ag,Ab, Br,Bg,Bb;
 
 
@@ -805,11 +805,11 @@ void ReIndexShapef(AMD_BC6H_Format &BC6H_data, int shape_indices[BC6H_MAX_SUBSET
 }
 
 float    BC6HBlockEncoder::FindBestPattern(AMD_BC6H_Format &BC6H_data,
-                          bool TwoRegionShapes, 
+                          bool TwoRegionShapes,
                           int shape_pattern)
 {
-    // Index bit size for the patterns been used. 
-    // All two zone shapes have 3 bits per color, max index value < 8  
+    // Index bit size for the patterns been used.
+    // All two zone shapes have 3 bits per color, max index value < 8
     // All one zone shapes gave 4 bits per color, max index value < 16
     int        Index_BitSize = TwoRegionShapes ? 8 : 16;
     int     max_subsets = TwoRegionShapes ? 2 : 1;
@@ -841,15 +841,15 @@ float    BC6HBlockEncoder::FindBestPattern(AMD_BC6H_Format &BC6H_data,
     for (int subset = 0; subset < max_subsets; subset++)
     {
         error[0] += optQuantAnD_d(
-            BC6H_data.partition[subset],        // input data 
+            BC6H_data.partition[subset],        // input data
             BC6H_data.entryCount[subset],       // number of input points above (not clear about 1, better to avoid)
             Index_BitSize,                      // number of clusters on the ramp, 8  or 16
             shape_indicesB[0][subset],          // output index, if not all points of the ramp used, 0 may not be assigned
             outB[0][subset],                    // resulting quantization
-            direction,                          // direction vector of the ramp (check normalization) 
-            &step,                              // step size (check normalization) 
+            direction,                          // direction vector of the ramp (check normalization)
+            &step,                              // step size (check normalization)
             3,                                  // number of channels (always 3 = RGB for BC6H)
-            m_quality                           // Quality set number of retry to get good end points 
+            m_quality                           // Quality set number of retry to get good end points
                                                 // Max retries = MAX_TRY = 4000 when Quality is 1.0
                                                 // Min = 0 and default with quality 0.05 is 200 times
             );
@@ -971,7 +971,7 @@ void decompress_endpoints1(AMD_BC6H_Format& bc6h_format, int oEndPoints[MAX_SUBS
                 // Unquantize all points to nbits
                 out[0][0][i] = Unquantize(out[0][0][i], ModePartition[mode].nbits, false);
                 out[0][1][i] = Unquantize(out[0][1][i], ModePartition[mode].nbits, false);
-                
+
                 // F16 format
                 outf[0][0][i] = finish_unquantizeF16(out[0][0][i], false);
                 outf[0][1][i] = finish_unquantizeF16(out[0][1][i], false);
@@ -987,7 +987,7 @@ void decompress_endpoints1(AMD_BC6H_Format& bc6h_format, int oEndPoints[MAX_SUBS
                 // Unquantize all points to nbits
                 out[0][0][i] = Unquantize(out[0][0][i], ModePartition[mode].nbits, false);
                 out[0][1][i] = Unquantize(out[0][1][i], ModePartition[mode].nbits, false);
-                
+
                 // F16 format
                 outf[0][0][i] = finish_unquantizeF16(out[0][0][i],false);
                 outf[0][1][i] = finish_unquantizeF16(out[0][1][i],false);
@@ -1008,7 +1008,7 @@ void decompress_endpoints1(AMD_BC6H_Format& bc6h_format, int oEndPoints[MAX_SUBS
                 // Unquantize all points to nbits
                 out[0][0][i] = Unquantize(out[0][0][i], ModePartition[mode].nbits, false);
                 out[0][1][i] = Unquantize(out[0][1][i], ModePartition[mode].nbits, false);
-                
+
                 // F16 format
                 outf[0][0][i] = finish_unquantizeF16(out[0][0][i], false);
                 outf[0][1][i] = finish_unquantizeF16(out[0][1][i], false);
@@ -1024,7 +1024,7 @@ void decompress_endpoints1(AMD_BC6H_Format& bc6h_format, int oEndPoints[MAX_SUBS
                 // Unquantize all points to nbits
                 out[0][0][i] = Unquantize(out[0][0][i], ModePartition[mode].nbits, false);
                 out[0][1][i] = Unquantize(out[0][1][i], ModePartition[mode].nbits, false);
-                
+
                 // F16 format
                 outf[0][0][i] = finish_unquantizeF16(out[0][0][i], false);
                 outf[0][1][i] = finish_unquantizeF16(out[0][1][i], false);
@@ -1045,22 +1045,22 @@ void decompress_endpoints2(AMD_BC6H_Format& bc6h_format, int oEndPoints[MAX_SUBS
         {
             for (i = 0; i<NCHANNELS; i++)
             {
-                // get the quantized values 
+                // get the quantized values
                 out[0][0][i] = SIGN_EXTEND(oEndPoints[0][0][i], ModePartition[mode].nbits);
 
-                t = SIGN_EXTEND(oEndPoints[0][1][i], ModePartition[mode].prec[i]); 
+                t = SIGN_EXTEND(oEndPoints[0][1][i], ModePartition[mode].prec[i]);
                 t = (t + oEndPoints[0][0][i]) & MASK(ModePartition[mode].nbits);
                 out[0][1][i] = SIGN_EXTEND(t, ModePartition[mode].nbits);
 
-                t = SIGN_EXTEND(oEndPoints[1][0][i], ModePartition[mode].prec[i]); 
+                t = SIGN_EXTEND(oEndPoints[1][0][i], ModePartition[mode].prec[i]);
                 t = (t + oEndPoints[0][0][i]) & MASK(ModePartition[mode].nbits);
                 out[1][0][i] = SIGN_EXTEND(t, ModePartition[mode].nbits);
 
-                t = SIGN_EXTEND(oEndPoints[1][1][i], ModePartition[mode].prec[i]); 
+                t = SIGN_EXTEND(oEndPoints[1][1][i], ModePartition[mode].prec[i]);
                 t = (t + oEndPoints[0][0][i]) & MASK(ModePartition[mode].nbits);
                 out[1][1][i] = SIGN_EXTEND(t, ModePartition[mode].nbits);
 
-                // Unquantize all points to nbits 
+                // Unquantize all points to nbits
                 out[0][0][i] = Unquantize(out[0][0][i], ModePartition[mode].nbits, true);
                 out[0][1][i] = Unquantize(out[0][1][i], ModePartition[mode].nbits, true);
                 out[1][0][i] = Unquantize(out[1][0][i], ModePartition[mode].nbits, true);
@@ -1079,8 +1079,8 @@ void decompress_endpoints2(AMD_BC6H_Format& bc6h_format, int oEndPoints[MAX_SUBS
             for (i = 0; i<NCHANNELS; i++)
             {
                 out[0][0][i] = SIGN_EXTEND(oEndPoints[0][0][i], ModePartition[mode].nbits);
-                out[0][1][i] = SIGN_EXTEND(oEndPoints[0][1][i], ModePartition[mode].prec[i]); 
-                out[1][0][i] = SIGN_EXTEND(oEndPoints[1][0][i], ModePartition[mode].prec[i]); 
+                out[0][1][i] = SIGN_EXTEND(oEndPoints[0][1][i], ModePartition[mode].prec[i]);
+                out[1][0][i] = SIGN_EXTEND(oEndPoints[1][0][i], ModePartition[mode].prec[i]);
                 out[1][1][i] = SIGN_EXTEND(oEndPoints[1][1][i], ModePartition[mode].prec[i]);
 
                 // Unquantize all points to nbits
@@ -1088,7 +1088,7 @@ void decompress_endpoints2(AMD_BC6H_Format& bc6h_format, int oEndPoints[MAX_SUBS
                 out[0][1][i] = Unquantize(out[0][1][i], ModePartition[mode].nbits, false);
                 out[1][0][i] = Unquantize(out[1][0][i], ModePartition[mode].nbits, false);
                 out[1][1][i] = Unquantize(out[1][1][i], ModePartition[mode].nbits, false);
-                
+
                 // nbits to F16 format
                 outf[0][0][i] = finish_unquantizeF16(out[0][0][i], false);
                 outf[0][1][i] = finish_unquantizeF16(out[0][1][i], false);
@@ -1105,10 +1105,10 @@ void decompress_endpoints2(AMD_BC6H_Format& bc6h_format, int oEndPoints[MAX_SUBS
             for (i = 0; i<NCHANNELS; i++)
             {
                 out[0][0][i] = oEndPoints[0][0][i];
-                t = SIGN_EXTEND(oEndPoints[0][1][i], ModePartition[mode].prec[i]); 
+                t = SIGN_EXTEND(oEndPoints[0][1][i], ModePartition[mode].prec[i]);
                 out[0][1][i] = (t + oEndPoints[0][0][i]) & MASK(ModePartition[mode].nbits);
 
-                t = SIGN_EXTEND(oEndPoints[1][0][i], ModePartition[mode].prec[i]); 
+                t = SIGN_EXTEND(oEndPoints[1][0][i], ModePartition[mode].prec[i]);
                 out[1][0][i] = (t + oEndPoints[0][0][i]) & MASK(ModePartition[mode].nbits);
 
                 t = SIGN_EXTEND(oEndPoints[1][1][i], ModePartition[mode].prec[i]);
@@ -1119,7 +1119,7 @@ void decompress_endpoints2(AMD_BC6H_Format& bc6h_format, int oEndPoints[MAX_SUBS
                 out[0][1][i] = Unquantize(out[0][1][i], ModePartition[mode].nbits, false);
                 out[1][0][i] = Unquantize(out[1][0][i], ModePartition[mode].nbits, false);
                 out[1][1][i] = Unquantize(out[1][1][i], ModePartition[mode].nbits, false);
-                
+
                 // nbits to F16 format
                 outf[0][0][i] = finish_unquantizeF16(out[0][0][i], false);
                 outf[0][1][i] = finish_unquantizeF16(out[0][1][i], false);
@@ -1183,7 +1183,7 @@ void BC6HBlockEncoder::AverageEndPoint(float EndPoints[MAX_SUBSETS][MAX_END_POIN
             EndPoints[subset][0][1] +
             EndPoints[subset][0][2]) / 3.0f;
 
-        // determine average diff 
+        // determine average diff
         diff = (abs(EndPoints[subset][0][0] - avr) +
             abs(EndPoints[subset][0][1] - avr) +
             abs(EndPoints[subset][0][2] - avr)) / 3;
@@ -1229,12 +1229,12 @@ void BC6HBlockEncoder::AverageEndPoint(float EndPoints[MAX_SUBSETS][MAX_END_POIN
 // The order can be rearranged to set which modes gets processed first
 // for now it is set in order.
 //================================================
-static int ModeFitOrder[MAX_BC6H_PARTITIONS+1] = 
+static int ModeFitOrder[MAX_BC6H_PARTITIONS+1] =
                        {
                        0,                //0: N/A
                                          // ----  2 region lower bits ---
                        1,                // 10 5 5 5
-                       2,                // 7  6 6 6 
+                       2,                // 7  6 6 6
                        3,                // 11 5 4 5
                        4,                // 11 4 5 4
                        5,                // 11 4 4 5
@@ -1248,7 +1248,7 @@ static int ModeFitOrder[MAX_BC6H_PARTITIONS+1] =
                        12,               // 11 9  9  9
                        13,               // 12 8  8  8
                        14                // 16 4  4  4
-}; 
+};
 
 float    BC6HBlockEncoder::EncodePattern(AMD_BC6H_Format &BC6H_data, float  error)
 {
@@ -1260,14 +1260,14 @@ float    BC6HBlockEncoder::EncodePattern(AMD_BC6H_Format &BC6H_data, float  erro
 
     float SrcEndPoints[MAX_SUBSETS][MAX_END_POINTS][MAX_DIMENSION_BIG];                  // temp endpoints used during calculations
 
-    // Quantize the EndPoints 
+    // Quantize the EndPoints
     int F16EndPoints[MAX_BC6H_PARTITIONS + 1][MAX_SUBSETS][MAX_END_POINTS][MAX_DIMENSION_BIG];                    // temp endpoints used during calculations
     int quantEndPoints[MAX_BC6H_PARTITIONS + 1][MAX_SUBSETS][MAX_END_POINTS][MAX_DIMENSION_BIG];                    // endpoints to save for a given mode
 
     // ModePartition[] starts from 1 to 14
     // If we have a shape pattern set the loop to check modes from 1 to 10 else from 11 to 14
     // of the ModePartition table
-    int     min_mode = (BC6H_data.region == 2)?1:11; 
+    int     min_mode = (BC6H_data.region == 2)?1:11;
     int     max_mode = (BC6H_data.region == 2)?MAX_TWOREGION_PARTITIONS:MAX_BC6H_PARTITIONS;
 
     bool    fits[15];
@@ -1297,7 +1297,7 @@ float    BC6HBlockEncoder::EncodePattern(AMD_BC6H_Format &BC6H_data, float  erro
             // For some modes the differances between channels can be quite small
             // typically for 6 bits 0..32 an increment of 1 in a channel can cause
             // unwanted color artifacts.
-            // Check if computed channel endpoint have a wide spread between channels if not 
+            // Check if computed channel endpoint have a wide spread between channels if not
             // scale all the channels to a avarage so that the variance is not noticed at lower bit values
             //if (m_bAverageEndPoint)
             //{
@@ -1329,7 +1329,7 @@ float    BC6HBlockEncoder::EncodePattern(AMD_BC6H_Format &BC6H_data, float  erro
                 // Takes the end points and creates a pallet of colors
                 // based on preset weights along a vector formed by the two end points
                 palitizeEndPointsF(BC6H_data, uncompressed);
-                
+
                 // Once we have the pallet - recalculate the optimal indices using the pallet
                 // and the original image data stored in BC6H_data.din[]
                 if (!m_isSigned)
@@ -1369,7 +1369,7 @@ float    BC6HBlockEncoder::EncodePattern(AMD_BC6H_Format &BC6H_data, float  erro
 }
 
 //==================================================================================
-// CompressBlock 
+// CompressBlock
 // in[]  is half float32 data  [0..1] for unsigned and [-1..+1] for signed
 // it will be converted to 16 bit half CMP_HALF (short with signed component) for processing
 //
@@ -1489,7 +1489,7 @@ float BC6HBlockEncoder::CompressBlock(float in[MAX_SUBSET_SIZE][MAX_DIMENSION_BI
     if (shape_pattern == -1)
     {
         Error = FindBestPattern(BC6H_data,false,0);
-        
+
         // Save our first value
         if (Error < bestError)
         {
@@ -1497,7 +1497,7 @@ float BC6HBlockEncoder::CompressBlock(float in[MAX_SUBSET_SIZE][MAX_DIMENSION_BI
                 bestShape = -1;
                 memcpy(&best_BC6H_data,&BC6H_data,sizeof(BC6H_data));
         }
-    
+
         // now run through all two regions shapes to find the best pattern
         for (int shape=0; shape<32; shape++)
         {
@@ -1518,14 +1518,14 @@ float BC6HBlockEncoder::CompressBlock(float in[MAX_SUBSET_SIZE][MAX_DIMENSION_BI
 
 
     // used for debugging modes, set the value you want to debug with
-    if (best_BC6H_data.m_mode != 0) 
+    if (best_BC6H_data.m_mode != 0)
     {
         // do final encoding and save to output block
         SaveDataBlock(best_BC6H_data, out);
     }
     else
         memcpy(out, Cmp_Red_Block, 16);
-        
+
     // do final encoding and save to output block
     // SaveDataBlock(best_BC6H_data,out);
 

--- a/Compressonator/Source/Codec/BC6H/Codec_BC6H.cpp
+++ b/Compressonator/Source/Codec/BC6H/Codec_BC6H.cpp
@@ -8,10 +8,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -26,7 +26,9 @@
 //
 //////////////////////////////////////////////////////////////////////////////
 
+#ifdef _MSC_VER
 #pragma warning(disable:4100)    // Ignore warnings of unreferenced formal parameters
+#endif //_MSC_VER
 #include "Common.h"
 #include "Codec_BC6H.h"
 #include "BC7_Definitions.h"
@@ -198,8 +200,10 @@ CCodec_BC6H::~CCodec_BC6H()
                 // If we don't wait then there is a race condition here where we have
                 // told the thread to run but it hasn't yet been scheduled - if we set
                 // the exit flag before it runs then its block will not be processed.
+#ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable:4127) //warning C4127: conditional expression is constant
+#endif //_MSC_VER
                 while(1)
                 {
                     if (m_EncodeParameterStorage == NULL) break;
@@ -208,7 +212,9 @@ CCodec_BC6H::~CCodec_BC6H()
                         break;
                     }
                 }
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif //_MSC_VER
                 // Signal to the thread that it can exit
                 m_EncodeParameterStorage[i].exit = TRUE;
             }
@@ -240,7 +246,7 @@ CCodec_BC6H::~CCodec_BC6H()
             delete[] m_EncodeParameterStorage;
         m_EncodeParameterStorage = NULL;
 
-        
+
         for(int i=0; i < m_NumEncodingThreads; i++)
         {
             if (m_encoder[i])
@@ -273,7 +279,7 @@ CodecError CCodec_BC6H::CInitializeBC6HLibrary()
         m_LiveThreads = 0;
         m_LastThread  = 0;
         m_NumEncodingThreads = min(m_NumThreads, BC6H_MAX_THREADS);
-        if (m_NumEncodingThreads == 0) m_NumEncodingThreads = 1; 
+        if (m_NumEncodingThreads == 0) m_NumEncodingThreads = 1;
         m_Use_MultiThreading = m_NumEncodingThreads > 1;
 
         m_EncodeParameterStorage = new BC6HEncodeThreadParam[m_NumEncodingThreads];
@@ -306,7 +312,7 @@ CodecError CCodec_BC6H::CInitializeBC6HLibrary()
             user_options.bUsePatternRec = m_UsePatternRec;
 
             m_encoder[i] = new BC6HBlockEncoder(user_options);
-                        
+
             // Cleanup if problem!
             if(!m_encoder[i])
             {
@@ -325,7 +331,7 @@ CodecError CCodec_BC6H::CInitializeBC6HLibrary()
 
                 return CE_Unknown;
             }
-            
+
             #ifdef USE_DBGTRACE
                 DbgTrace(("Encoder[%d]:ModeMask %X, Quality %f\n",i,m_ModeMask,m_Quality));
             #endif
@@ -412,7 +418,7 @@ if (m_Use_MultiThreading)
     // Tell the thread to start working
     m_EncodeParameterStorage[threadIndex].run = TRUE;
 }
-else 
+else
 {
         // Copy the input data into the thread storage
         memcpy(m_EncodeParameterStorage[0].in, in, BC6H_MAX_SUBSET_SIZE * MAX_DIMENSION_BIG * sizeof(float));
@@ -490,7 +496,7 @@ CodecError CCodec_BC6H::Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut
 
     DbgTrace(("OUT: BufferType %d ChannelCount %d ChannelDepth %d",bufferOut.GetBufferType(),bufferOut.GetChannelCount(),bufferOut.GetChannelDepth()));
     DbgTrace(("   : Height %d Width %d Pitch %d isFloat %d",bufferOut.GetHeight(),bufferOut.GetWidth(),bufferOut.GetWidth(),bufferOut.IsFloat()));
-#endif;
+#endif
 
     char            row,col,srcIndex;
 
@@ -544,7 +550,7 @@ CodecError CCodec_BC6H::Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut
 
             memset(data.in,0,sizeof(data));
             CEncodeBC6HBlock(blockToEncode,pOutBuffer+block);
-            
+
 #ifdef _SAVE_AS_BC6
             if (fwrite(pOutBuffer+block, sizeof(char), 16, bc6file) != 16)
                 throw "File error on write";
@@ -559,7 +565,7 @@ CodecError CCodec_BC6H::Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut
                     float            blockToSave[16][4];
                     float            block[64];
                 } savedata;
-        
+
                 CMP_BYTE destBlock[BLOCK_SIZE_4X4X4];
                 memset(savedata.block,0,sizeof(savedata));
                 m_decoder->DecompressBlock(savedata.blockToSave,data.in);
@@ -606,7 +612,7 @@ CodecError CCodec_BC6H::Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut
         float fProgress = 100.f;
         pFeedbackProc(fProgress, pUser1, pUser2);
     }
-        
+
     return CFinishBC6HEncoding();
 }
 
@@ -614,10 +620,10 @@ CodecError CCodec_BC6H::Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferO
 {
     assert(bufferIn.GetWidth() == bufferOut.GetWidth());
     assert(bufferIn.GetHeight() == bufferOut.GetHeight());
-    
+
     CodecError err = CInitializeBC6HLibrary();
     if (err != CE_OK) return err;
-    
+
     if(bufferIn.GetWidth() != bufferOut.GetWidth() || bufferIn.GetHeight() != bufferOut.GetHeight())
         return CE_Unknown;
 
@@ -643,7 +649,7 @@ CodecError CCodec_BC6H::Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferO
             } CompData;
 
             CMP_FLOAT destBlock[BLOCK_SIZE_4X4X4];
-            
+
             bufferIn.ReadBlock(i*4, j*4, CompData.compressedBlock, 4);
 
             // Encode to the appropriate location in the compressed image
@@ -661,14 +667,14 @@ CodecError CCodec_BC6H::Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferO
             {
                 for(int col=0; col<BLOCK_SIZE_4; col++)
                 {
-                    R = (CMP_FLOAT)DecData.decodedBlock[row*BLOCK_SIZE_4+col][BC6H_COMP_RED];         
-                    G = (CMP_FLOAT)DecData.decodedBlock[row*BLOCK_SIZE_4+col][BC6H_COMP_GREEN];     
-                    B = (CMP_FLOAT)DecData.decodedBlock[row*BLOCK_SIZE_4+col][BC6H_COMP_BLUE];     
-                    A = (CMP_FLOAT)DecData.decodedBlock[row*BLOCK_SIZE_4+col][BC6H_COMP_ALPHA];     
-                    destBlock[srcIndex]   = R;         
-                    destBlock[srcIndex+1] = G;     
-                    destBlock[srcIndex+2] = B;     
-                    destBlock[srcIndex+3] = A;     
+                    R = (CMP_FLOAT)DecData.decodedBlock[row*BLOCK_SIZE_4+col][BC6H_COMP_RED];
+                    G = (CMP_FLOAT)DecData.decodedBlock[row*BLOCK_SIZE_4+col][BC6H_COMP_GREEN];
+                    B = (CMP_FLOAT)DecData.decodedBlock[row*BLOCK_SIZE_4+col][BC6H_COMP_BLUE];
+                    A = (CMP_FLOAT)DecData.decodedBlock[row*BLOCK_SIZE_4+col][BC6H_COMP_ALPHA];
+                    destBlock[srcIndex]   = R;
+                    destBlock[srcIndex+1] = G;
+                    destBlock[srcIndex+2] = B;
+                    destBlock[srcIndex+3] = A;
                     srcIndex+=4;
                 }
             }

--- a/Compressonator/Source/Codec/BC7/3dquant_vpc.cpp
+++ b/Compressonator/Source/Codec/BC7/3dquant_vpc.cpp
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -41,14 +41,16 @@ FILE *fp;
 
 #define EPSILON        0.000001
 #define MAX_TRY        20
+#ifndef DBL_MAX_EXP
 #define DBL_MAX_EXP 1024
+#endif //DBL_MAX_EXP
 #undef  TRACE
 
 #define MAX_TRACE    250000
 
-struct TRACE          
+struct TRACE
 {
-  int  k;  
+  int  k;
   double d;
 };
 
@@ -77,7 +79,7 @@ void Quant_Init(void)
         return;
     }
     if (amd_codes[0][0])  return;
-    
+
     mtx.lock();
 
     for ( int numClusters = 0; numClusters < MAX_CLUSTERS; numClusters++ )
@@ -87,16 +89,16 @@ void Quant_Init(void)
             #ifdef USE_TRACE_WITH_DYNAMIC_MEM
                 amd_codes[ numClusters][ numEntries ]    = new int[ MAX_TRACE ];
                 amd_trs[ numClusters ][ numEntries ]    = new TRACE[ MAX_TRACE ];
-            
+
                 assert(amd_codes[ numClusters][ numEntries ]);
                 assert(amd_trs[ numClusters ][ numEntries ]);
             #endif
 
-            traceBuilder (  numEntries+1,  
-                            numClusters+1, 
+            traceBuilder (  numEntries+1,
+                            numClusters+1,
                             amd_trs[numClusters][numEntries],
                             amd_codes[numClusters][numEntries],
-                            trcnts[numClusters]+(numEntries)); 
+                            trcnts[numClusters]+(numEntries));
         }
     }
 
@@ -143,7 +145,7 @@ void Quant_DeInit(void)
 
 //=========================================================================================
 
-void sugar(void){ 
+void sugar(void){
 #ifdef USE_DBGTRACE
     DbgTrace(("sugar!"))
 #endif
@@ -162,24 +164,24 @@ inline int a_compare( const void *arg1, const void *arg2 )
 //
 // We ignore the issue of ordering equal elements here, though it can affect results abit
 //
-void sortProjection(double projection[MAX_ENTRIES], int order[MAX_ENTRIES], int numEntries) 
+void sortProjection(double projection[MAX_ENTRIES], int order[MAX_ENTRIES], int numEntries)
 {
 #ifdef USE_DBGTRACE
     DbgTrace(());
 #endif
     int i;
     a what[MAX_ENTRIES+MAX_PARTITIONS_TABLE];
-         
-    for (i=0; i < numEntries;i++) 
+
+    for (i=0; i < numEntries;i++)
         what[what[i].i=i].d = projection[i];
 
     qsort((void*)&what, numEntries, sizeof(a),a_compare);
 
-    for (i=0; i < numEntries;i++) 
+    for (i=0; i < numEntries;i++)
         order[i]=what[i].i;
 };
 
-void covariance(double data[][DIMENSION], int numEntries, double cov[DIMENSION][DIMENSION]) 
+void covariance(double data[][DIMENSION], int numEntries, double cov[DIMENSION][DIMENSION])
 {
 #ifdef USE_DBGTRACE
     DbgTrace(());
@@ -192,12 +194,12 @@ void covariance(double data[][DIMENSION], int numEntries, double cov[DIMENSION][
             for(k=0;k<numEntries;k++)
                 cov[i][j]+=data[k][i]*data[k][j];
         }
-        
+
     for(i=0;i<DIMENSION;i++)
         for(j=i+1;j<DIMENSION;j++)
             cov[i][j] = cov[j][i];
 }
- 
+
 void covariance_d(double data[][MAX_DIMENSION_BIG], int numEntries, double cov[MAX_DIMENSION_BIG][MAX_DIMENSION_BIG], int dimension)
 {
 #ifdef USE_DBGTRACE
@@ -213,13 +215,13 @@ void covariance_d(double data[][MAX_DIMENSION_BIG], int numEntries, double cov[M
             for(k=0;k<numEntries;k++)
                 cov[i][j]+=data[k][i]*data[k][j];
         }
-        
+
     for(i=0;i<dimension;i++)
         for(j=i+1;j<dimension;j++)
             cov[i][j] = cov[j][i];
 }
 
-void centerInPlace(double data[][DIMENSION], int numEntries, double mean[DIMENSION]) 
+void centerInPlace(double data[][DIMENSION], int numEntries, double mean[DIMENSION])
 {
 #ifdef USE_DBGTRACE
     DbgTrace(());
@@ -267,7 +269,7 @@ void centerInPlace_d(double data[][MAX_DIMENSION_BIG], int numEntries, double me
     }
 }
 
-void project(double data[][DIMENSION], int numEntries, double vector[DIMENSION], double projection[MAX_ENTRIES]) 
+void project(double data[][DIMENSION], int numEntries, double vector[DIMENSION], double projection[MAX_ENTRIES])
 {
 #ifdef USE_DBGTRACE
     DbgTrace(());
@@ -301,7 +303,7 @@ void project_d(double data[][MAX_DIMENSION_BIG], int numEntries, double vector[M
     }
 }
 
-void eigenVector(double cov[DIMENSION][DIMENSION], double vector[DIMENSION]) 
+void eigenVector(double cov[DIMENSION][DIMENSION], double vector[DIMENSION])
 {
 #ifdef USE_DBGTRACE
     DbgTrace(());
@@ -310,7 +312,7 @@ void eigenVector(double cov[DIMENSION][DIMENSION], double vector[DIMENSION])
     // will work for non-zero non-negative matricies only
 
     #define EV_ITERATION_NUMBER 20
-    #define EV_SLACK            2        /* additive for exp base 2)*/    
+    #define EV_SLACK            2        /* additive for exp base 2)*/
 
 
     int i,j,k,l, m, n,p,q;
@@ -321,7 +323,7 @@ void eigenVector(double cov[DIMENSION][DIMENSION], double vector[DIMENSION])
         for(j=0;j<DIMENSION;j++)
             c[0][i][j] =cov[i][j];
 
-    p = (int) floor(log( (DBL_MAX_EXP - EV_SLACK) / ceil (log((double)DIMENSION)/log(2.)) )/log(2.)); 
+    p = (int) floor(log( (DBL_MAX_EXP - EV_SLACK) / ceil (log((double)DIMENSION)/log(2.)) )/log(2.));
 
     assert(p>0);
 
@@ -329,7 +331,7 @@ void eigenVector(double cov[DIMENSION][DIMENSION], double vector[DIMENSION])
 
     q =  (EV_ITERATION_NUMBER+p-1) / p;
 
-    
+
     l=0;
 
     for(n=0;n<q; n++) {
@@ -345,7 +347,7 @@ void eigenVector(double cov[DIMENSION][DIMENSION], double vector[DIMENSION])
             return;
         }
         assert(maxDiag > 0);
-    
+
         for(i=0;i<DIMENSION;i++)
             for(j=0;j<DIMENSION;j++)
                 c[l][i][j] /=maxDiag;
@@ -360,7 +362,7 @@ void eigenVector(double cov[DIMENSION][DIMENSION], double vector[DIMENSION])
             l=1-l;
         }
     }
-    
+
     maxDiag = 0;
     k =0;
 
@@ -383,7 +385,7 @@ void eigenVector(double cov[DIMENSION][DIMENSION], double vector[DIMENSION])
         return;
     }
 
-    for(i=0;i<DIMENSION;i++) 
+    for(i=0;i<DIMENSION;i++)
         vector[i]/=t;
 }
 
@@ -397,7 +399,7 @@ void eigenVector_d(double cov[MAX_DIMENSION_BIG][MAX_DIMENSION_BIG], double vect
     // will work for non-zero non-negative matricies only
 
     #define EV_ITERATION_NUMBER 20
-    #define EV_SLACK            2        /* additive for exp base 2)*/    
+    #define EV_SLACK            2        /* additive for exp base 2)*/
 
 
     int i,j,k,l, m, n,p,q;
@@ -408,14 +410,14 @@ void eigenVector_d(double cov[MAX_DIMENSION_BIG][MAX_DIMENSION_BIG], double vect
         for(j=0;j<dimension;j++)
             c[0][i][j] =cov[i][j];
 
-    p = (int) floor(log( (DBL_MAX_EXP - EV_SLACK) / ceil (log((double)dimension)/log(2.)) )/log(2.)); 
+    p = (int) floor(log( (DBL_MAX_EXP - EV_SLACK) / ceil (log((double)dimension)/log(2.)) )/log(2.));
 
     assert(p>0);
 
     p = p >0 ? p : 1;
 
     q =  (EV_ITERATION_NUMBER+p-1) / p;
-    
+
     l=0;
 
     for(n=0;n<q; n++)
@@ -431,7 +433,7 @@ void eigenVector_d(double cov[MAX_DIMENSION_BIG][MAX_DIMENSION_BIG], double vect
             return;
         }
         assert(maxDiag >0);
-    
+
         for(i=0;i<dimension;i++)
             for(j=0;j<dimension;j++)
                 c[l][i][j] /=maxDiag;
@@ -442,16 +444,16 @@ void eigenVector_d(double cov[MAX_DIMENSION_BIG][MAX_DIMENSION_BIG], double vect
                     double temp=0;
                     for(k=0;k<dimension;k++)
                     {
-                        // Notes: 
+                        // Notes:
                         // This is the most consuming portion of the code and needs optimizing for perfromance
                         temp += c[l][i][k]*c[l][k][j];
                      }
-                    c[1-l][i][j]=temp; 
+                    c[1-l][i][j]=temp;
                 }
             l=1-l;
         }
     }
-    
+
     maxDiag = 0;
     k =0;
 
@@ -474,8 +476,8 @@ void eigenVector_d(double cov[MAX_DIMENSION_BIG][MAX_DIMENSION_BIG], double vect
     {
         sugar();
         return;
-    }    
-    for(i=0;i<dimension;i++) 
+    }
+    for(i=0;i<dimension;i++)
         vector[i]/=t;
 }
 
@@ -501,20 +503,20 @@ double partition2(double data[][DIMENSION], int numEntries,int index[])
                 center[index[k]][i]+=data[k][i];
         }
 
-    
+
     for(i=0;i<DIMENSION;i++)
         for(j=0;j<=i;j++) {
             cov[0][i][j]=cov[1][i][j]=0;
             for(k=0;k<numEntries;k++)
                 cov[index[k]][i][j]+=data[k][i]*data[k][j];
         }
-    
+
     for(i=0;i<DIMENSION;i++)
-        for(j=0;j<=i;j++) 
+        for(j=0;j<=i;j++)
             for (k=0;k<2;k++)
                 if (cnt[k]!=0)
                     cov[k][i][j] -=center[k][i]*center[k][j]/(double)cnt[k];
-            
+
 
     for(i=0;i<DIMENSION;i++)
         for(j=i+1;j<DIMENSION;j++)
@@ -524,7 +526,7 @@ double partition2(double data[][DIMENSION], int numEntries,int index[])
 
     for(k=0;k<2;k++)
         eigenVector(cov[k], vector[k]); // assume the returned vector is nomalized
-    
+
 
 
     for(i=0;i<DIMENSION;i++)
@@ -538,8 +540,8 @@ double partition2(double data[][DIMENSION], int numEntries,int index[])
 
     return(acc);
 }
-    
-void quantEven(double data[MAX_ENTRIES][DIMENSION],int numEntries, int numClusters, int index[MAX_ENTRIES]) 
+
+void quantEven(double data[MAX_ENTRIES][DIMENSION],int numEntries, int numClusters, int index[MAX_ENTRIES])
 {
 #ifdef USE_DBGTRACE
     DbgTrace(());
@@ -551,18 +553,18 @@ void quantEven(double data[MAX_ENTRIES][DIMENSION],int numEntries, int numCluste
     // First cluster is always used, (without loss of generality)
     // Ramp should be shifted such, that the first element ramp[0] is 0
     int i,k;
-    
+
     int level;
 
     double t,s;
     int c =1;
-    
+
     int cluster[MAX_CLUSTERS];
 
     int bestCluster[MAX_CLUSTERS];
     // stores the las index for the cluster
 
-      
+
     double  dpAcc       [MAX_CLUSTERS][DIMENSION];
     double  index2Acc   [MAX_CLUSTERS];     // for backtraking
     double  indexAcc    [MAX_CLUSTERS];
@@ -573,7 +575,7 @@ void quantEven(double data[MAX_ENTRIES][DIMENSION],int numEntries, int numCluste
 
     double nErrorNum=0;   // not the actual error, but some (decreasing) linear functional of it represented
                           // as numerator and denominator
-    double nErrorDen=1;   
+    double nErrorDen=1;
 
     level=1;
 
@@ -582,7 +584,7 @@ void quantEven(double data[MAX_ENTRIES][DIMENSION],int numEntries, int numCluste
 
     indexAcc[0]=index2Acc[0]=indexAcc[1]=index2Acc[1]=0;
 
-    for(i=0;i<DIMENSION;i++) 
+    for(i=0;i<DIMENSION;i++)
         dpAcc[0][i]=dpAcc[1][i]=0;
 
     S =  1/sqrt((double) numEntries);
@@ -596,13 +598,13 @@ void quantEven(double data[MAX_ENTRIES][DIMENSION],int numEntries, int numCluste
     do {
             k = --cluster[level-1];
 
-            indexAcc    [level] += S; 
-            index2Acc   [level] += dRamp2 [level]; 
+            indexAcc    [level] += S;
+            index2Acc   [level] += dRamp2 [level];
 
             t=0;
             for(i=0;i<DIMENSION;i++) {
-            // using scaled ramp instead of non-scaled here effectively scales the data, so 
-            // the resulting quantisation will be the same, but the error metric value  will be different   
+            // using scaled ramp instead of non-scaled here effectively scales the data, so
+            // the resulting quantisation will be the same, but the error metric value  will be different
 
                 dpAcc [level][i] += data[k][i];
                 t += dpAcc[level][i] * dpAcc[level][i];
@@ -612,7 +614,7 @@ void quantEven(double data[MAX_ENTRIES][DIMENSION],int numEntries, int numCluste
                 nErrorNum * (s=index2Acc[level]-indexAcc[level] * indexAcc[level]) < nErrorDen * t) {
                 nErrorNum=t;
                 nErrorDen=s;
-                for(i=0;i<=level;i++) 
+                for(i=0;i<=level;i++)
                     bestCluster[i]=cluster[i];
             }
             c++;
@@ -623,19 +625,19 @@ void quantEven(double data[MAX_ENTRIES][DIMENSION],int numEntries, int numCluste
                 indexAcc [level]=indexAcc [level-1];
                 index2Acc[level]=index2Acc[level-1];
 
-                for(i=0;i<DIMENSION;i++) 
+                for(i=0;i<DIMENSION;i++)
                     dpAcc [level][i]=dpAcc    [level-1][i];
-                
-            } 
-            else while ((level-1) && cluster[level-1]==cluster[level-2]) 
+
+            }
+            else while ((level-1) && cluster[level-1]==cluster[level-2])
                 level--;
 
             cluster[level]=numEntries;
 
-    } while (level != 1 || cluster[level-1] != 0);  
+    } while (level != 1 || cluster[level-1] != 0);
 
     for (level=i=0;i< numEntries;i++) {
-        while (i==bestCluster[level]) 
+        while (i==bestCluster[level])
               level++;
         index[i]=level;
     }
@@ -652,11 +654,11 @@ void quantLineConstr(double data[][DIMENSION], int order[MAX_ENTRIES],int numEnt
     //   binomial(numEntries+numClusters-2, numClusters-1)
     // Index just defines which points should be combined in a cluster
     int i,j,k;
-    
+
     int level;
 
     double t,s;
-    
+
     // We need paddingof 0 on -1 index
     int  cluster_[MAX_CLUSTERS+1]={0};
     int *cluster = cluster_+1;
@@ -668,8 +670,8 @@ void quantLineConstr(double data[][DIMENSION], int order[MAX_ENTRIES],int numEnt
     double dir[DIMENSION];
 
 
-    double gcAcc[MAX_CLUSTERS][DIMENSION];// Clusters' graviti centers     
-    double gcSAcc[MAX_CLUSTERS][DIMENSION];// Clusters' graviti centers    
+    double gcAcc[MAX_CLUSTERS][DIMENSION];// Clusters' graviti centers
+    double gcSAcc[MAX_CLUSTERS][DIMENSION];// Clusters' graviti centers
 
 
     double nError=0;   // not the actual error, but some (decreasing) linear functional of it represented
@@ -681,7 +683,7 @@ void quantLineConstr(double data[][DIMENSION], int order[MAX_ENTRIES],int numEnt
     bestCluster[0]=cluster[0]=cluster[1]=numEntries;
 
 
-    for(i=0;i<DIMENSION;i++) 
+    for(i=0;i<DIMENSION;i++)
         gcAcc[0][i]=gcAcc[1][i]=0;
 
 
@@ -692,9 +694,9 @@ void quantLineConstr(double data[][DIMENSION], int order[MAX_ENTRIES],int numEnt
 
             k = order[--cluster[level-1]];
 
-            s=(cluster[level-1]-cluster[level-2]) == 0 ? 0: 1/sqrt( (double) (cluster[level-1]-cluster[level-2])); // see cluster_ decl for 
+            s=(cluster[level-1]-cluster[level-2]) == 0 ? 0: 1/sqrt( (double) (cluster[level-1]-cluster[level-2])); // see cluster_ decl for
                                                                                                                  // cluster[-1] value
-            t=1/sqrt((double) (numEntries-cluster[level-1])); 
+            t=1/sqrt((double) (numEntries-cluster[level-1]));
 
             for(i=0;i<DIMENSION;i++) {
                 gcAcc[level  ][i] += data[k][i];
@@ -707,52 +709,52 @@ void quantLineConstr(double data[][DIMENSION], int order[MAX_ENTRIES],int numEnt
             eigenVector(cov, dir);
             // assume the vector is normalized here
             t=0;
-            for(i=0;i<DIMENSION;i++) 
-                for(j=0;j<DIMENSION;j++) 
+            for(i=0;i<DIMENSION;i++)
+                for(j=0;j<DIMENSION;j++)
                     t+= cov[i][j]*dir[i]*dir[j];
 
            if (t>nError) {
 
                 nError=t;
 
-                for(i=0;i<=level;i++) 
+                for(i=0;i<=level;i++)
                     bestCluster[i]=cluster[i];
             }
 
             if (level < numClusters - 1 ) {
                 // go up
                 level++;
-                for(i=0;i<DIMENSION;i++) 
+                for(i=0;i<DIMENSION;i++)
                     gcAcc [level][i]=0;
-                
-            } 
+
+            }
             else while ((level-1) && cluster[level-1]==cluster[level-2]) {
                 level--;
-                for(i=0;i<DIMENSION;i++) 
+                for(i=0;i<DIMENSION;i++)
                     gcAcc [level][i]+=gcAcc [level+1][i];
             }
 
 
             cluster[level]=numEntries;
 
-    } while (level != 1 || cluster[level-1] != 1);                
+    } while (level != 1 || cluster[level-1] != 1);
 
     for (level=i=0;i< numEntries;i++) {
-        while (i==bestCluster[level]) 
+        while (i==bestCluster[level])
               level++;
         index[order[i]]=level;
     }
-}           
+}
 
-double totalError(double data[MAX_ENTRIES][DIMENSION],double data2[MAX_ENTRIES][DIMENSION],int numEntries) 
+double totalError(double data[MAX_ENTRIES][DIMENSION],double data2[MAX_ENTRIES][DIMENSION],int numEntries)
 {
 #ifdef USE_DBGTRACE
     DbgTrace(());
 #endif
     int i,j;
     double t=0;
-    for (i=0;i<numEntries;i++) 
-       for (j=0;j<DIMENSION;j++) 
+    for (i=0;i<numEntries;i++)
+       for (j=0;j<DIMENSION;j++)
            t+= (data[i][j]-data2[i][j])*(data[i][j]-data2[i][j]);
     return t;
 };
@@ -764,19 +766,19 @@ double totalError_d(double data[MAX_ENTRIES][MAX_DIMENSION_BIG],double data2[MAX
 #endif
     int i,j;
     double t=0;
-    for (i=0;i<numEntries;i++) 
-       for (j=0;j<dimension;j++) 
+    for (i=0;i<numEntries;i++)
+       for (j=0;j<dimension;j++)
            t+= (data[i][j]-data2[i][j])*(data[i][j]-data2[i][j]);
 
     return t;
 };
 
 double optQuantEven(
-    double data[MAX_ENTRIES][DIMENSION], 
+    double data[MAX_ENTRIES][DIMENSION],
     int numEntries, int numClusters, int index[MAX_ENTRIES],
     double out[MAX_ENTRIES][DIMENSION],
     double direction [DIMENSION],double *step
-    )    
+    )
 {
 #ifdef USE_DBGTRACE
     DbgTrace(());
@@ -792,30 +794,30 @@ double optQuantEven(
 
     int order[MAX_ENTRIES];
 
-    for (i=0;i<numEntries;i++) 
-       for (j=0;j<DIMENSION;j++) 
+    for (i=0;i<numEntries;i++)
+       for (j=0;j<DIMENSION;j++)
             centered[i][j]=data[i][j];
 
     centerInPlace(centered, numEntries, mean);
     covariance(centered, numEntries, cov);
 
-    // check if they all are the same 
+    // check if they all are the same
 
     t=0;
-    for (j=0;j<DIMENSION;j++) 
+    for (j=0;j<DIMENSION;j++)
          t+= cov[j][j];
 
     if (t==0 || numEntries==0) {
         for (i=0;i<numEntries;i++) {
             index[i]=0;
-            for (j=0;j<DIMENSION;j++) 
+            for (j=0;j<DIMENSION;j++)
                 out[i][j]=mean[j];
         }
         return 0.;
     }
 
-    eigenVector(cov, direction);    
-    project(centered, numEntries, direction, projected); 
+    eigenVector(cov, direction);
+    project(centered, numEntries, direction, projected);
 
     for (i=0;i<maxTry;i++) {
 
@@ -823,12 +825,12 @@ double optQuantEven(
             t=0;
             for (j=0;j<DIMENSION;j++) {
                 direction[j]=0;
-                for (k=0;k<numEntries;k++) 
-                   direction[j]+=ordered[k][j]*index[k]; 
+                for (k=0;k<numEntries;k++)
+                   direction[j]+=ordered[k][j]*index[k];
                 t+=direction[j]*direction[j];
             }
 
-            // Actually we don't need to normailize direction here, as the 
+            // Actually we don't need to normailize direction here, as the
             // optimal quntization (index) is invariant of the scale.
             // Hence we don't care about possible degenration of the <direction> either
             // though normally it should not happen
@@ -837,10 +839,10 @@ double optQuantEven(
 
             t = sqrt(t)*EPSILON;
 
-            project(centered, numEntries, direction, projected); 
+            project(centered, numEntries, direction, projected);
 
-            for (j=1; j < numEntries;j++) 
-                if (projected[order[j]] < projected[order[j-1]]-t /*EPSILON*/) 
+            for (j=1; j < numEntries;j++)
+                if (projected[order[j]] < projected[order[j-1]]-t /*EPSILON*/)
                     break;
 
             if (j >= numEntries)
@@ -849,62 +851,62 @@ double optQuantEven(
 
         sortProjection(projected, order, numEntries);
 
-        for (k=0;k<numEntries;k++)     
-        for (j=0;j<DIMENSION;j++) 
+        for (k=0;k<numEntries;k++)
+        for (j=0;j<DIMENSION;j++)
         ordered[k][j]=centered[order[k]][j];
 
         quantEven(ordered, numEntries, numClusters, index);
 
     }
     s=t=0;
-    
+
     double q=0;
 
-    for (k=0;k<numEntries;k++) { 
+    for (k=0;k<numEntries;k++) {
         s+= index[k];
         t+= index[k]*index[k];
     }
 
     for (j=0;j<DIMENSION;j++) {
         direction[j]=0;
-        for (k=0;k<numEntries;k++) 
+        for (k=0;k<numEntries;k++)
             direction[j]+=ordered[k][j]*index[k];
     q+= direction[j]* direction[j];
 
     }
 
-    
+
 
     s /= (double) numEntries;
 
     t = t - s * s * (double) numEntries;
 
 #ifdef USE_DBGTRACE
-   if (t==0) 
+   if (t==0)
         DbgTrace(("l;lkjk"));
 #endif
 
     assert(t !=0);
-    
+
 
     t = (t == 0 ? 0. : 1/t);
-    
-    for (i=0;i<numEntries;i++) 
-            for (j=0;j<DIMENSION;j++) 
+
+    for (i=0;i<numEntries;i++)
+            for (j=0;j<DIMENSION;j++)
                 out[order[i]][j]=mean[j]+direction[j]*t*(index[i]-s);
 
     // normalize direction for output
-    
+
     q=sqrt(q);
     *step=t*q;
-    for (j=0;j<DIMENSION;j++) 
+    for (j=0;j<DIMENSION;j++)
         direction[j]/=q;
     return totalError(data,out,numEntries);
 };
 
 
 int requantize(double data[MAX_ENTRIES][DIMENSION],
-    double centers[MAX_CLUSTERS][DIMENSION], int numEntries, int numClusters,int index[MAX_ENTRIES] ) 
+    double centers[MAX_CLUSTERS][DIMENSION], int numEntries, int numClusters,int index[MAX_ENTRIES] )
 {
 #ifdef USE_DBGTRACE
     DbgTrace(());
@@ -932,19 +934,19 @@ int requantize(double data[MAX_ENTRIES][DIMENSION],
         }
     }
 
-    for(j=0;j<numClusters;j++) 
+    for(j=0;j<numClusters;j++)
                 cnt[j]=0;
 
-    for(j=0;j<numClusters;j++) 
+    for(j=0;j<numClusters;j++)
             for(k=0;k<DIMENSION;k++)
                 centers[j][k]=0;
 
     for (i=0;i<numEntries;i++) {
         cnt[index[i]]++;
-        for(k=0;k<DIMENSION;k++) 
+        for(k=0;k<DIMENSION;k++)
         centers[index[i]][k]+=data[i][k];
     }
-    for(j=0;j<numClusters;j++) 
+    for(j=0;j<numClusters;j++)
             for(k=0;k<DIMENSION;k++)
         centers[j][k]/=(double) cnt[j];
 
@@ -952,10 +954,10 @@ int requantize(double data[MAX_ENTRIES][DIMENSION],
 }
 
 double optQuantLineConstr(
-    double data[MAX_ENTRIES][DIMENSION], 
+    double data[MAX_ENTRIES][DIMENSION],
     int numEntries, int numClusters, int index[MAX_ENTRIES],
-    double out[MAX_ENTRIES][DIMENSION] 
-    )    
+    double out[MAX_ENTRIES][DIMENSION]
+    )
 {
 #ifdef USE_DBGTRACE
     DbgTrace(());
@@ -977,30 +979,30 @@ double optQuantLineConstr(
 
     int order[MAX_ENTRIES];
 
-    for (i=0;i<numEntries;i++) 
-       for (j=0;j<DIMENSION;j++) 
+    for (i=0;i<numEntries;i++)
+       for (j=0;j<DIMENSION;j++)
             centered[i][j]=data[i][j];
 
     centerInPlace(centered, numEntries, mean);
     covariance(centered, numEntries, cov);
 
-    // check if they all are the same 
+    // check if they all are the same
 
     t=0;
-    for (j=0;j<DIMENSION;j++) 
+    for (j=0;j<DIMENSION;j++)
          t+= cov[j][j];
 
     if (t==0 || numEntries==0) {
         for (i=0;i<numEntries;i++) {
             index[i]=0;
-            for (j=0;j<DIMENSION;j++) 
+            for (j=0;j<DIMENSION;j++)
                 out[i][j]=mean[j];
         }
         return 0.;
     }
 
-    eigenVector(cov, direction);    
-    project(centered, numEntries, direction, projected); 
+    eigenVector(cov, direction);
+    project(centered, numEntries, direction, projected);
 
     for (i=0;i<maxTry;i++) {
 
@@ -1008,12 +1010,12 @@ double optQuantLineConstr(
             t=0;
             for (j=0;j<DIMENSION;j++) {
                 direction[j]=0;
-                for (k=0;k<numEntries;k++) 
+                for (k=0;k<numEntries;k++)
                     direction[j]+=centered[k][j]*index[k];
                 t=direction[j]*direction[j];
             }
 
-            // Actually we don't need to normailize direction here, as the 
+            // Actually we don't need to normailize direction here, as the
             // optimal quntization (index) is invariant of the scale.
             // Hence we don't care about possible degenration of the <direction> either
             // though normally it should not happen
@@ -1022,10 +1024,10 @@ double optQuantLineConstr(
 
             t = sqrt(t)*EPSILON;
 
-            project(centered, numEntries, direction, projected); 
+            project(centered, numEntries, direction, projected);
 
-            for (j=1; j < numEntries;j++) 
-                if (projected[order[j]] < projected[order[j-1]]-t /*EPSILON*/) 
+            for (j=1; j < numEntries;j++)
+                if (projected[order[j]] < projected[order[j-1]]-t /*EPSILON*/)
                     break;
 
             if (j >= numEntries)
@@ -1044,23 +1046,23 @@ double optQuantLineConstr(
 
     for(i=0;i<MAX_CLUSTERS;i++) {
         gcS[i]=0;
-        for(j=0;j<DIMENSION;j++) 
+        for(j=0;j<DIMENSION;j++)
             gcAcc[i][j]=0;
     }
 
-    for (k=0;k<numEntries;k++) {  
+    for (k=0;k<numEntries;k++) {
         gcS[index[k]]+=1;
-        for (j=0;j<DIMENSION;j++) 
+        for (j=0;j<DIMENSION;j++)
             gcAcc[index[k]][j]+=centered[k][j];
 
     }
 
-    for(i=0;i<numClusters;i++) 
-        for (j=0;j<DIMENSION;j++) 
+    for(i=0;i<numClusters;i++)
+        for (j=0;j<DIMENSION;j++)
             if (gcS[i]!=0) {
                 gcSAcc[i][j] = gcAcc[i][j]/sqrt((double)gcS[i]);
                 gcAcc[i][j] /= ((double)gcS[i]);
-            } 
+            }
             else
                 gcSAcc[i][j] = 0;
 
@@ -1071,12 +1073,12 @@ double optQuantLineConstr(
 
     for(i=0;i<numClusters;i++) {
         gcS[i]=0;
-        for (j=0;j<DIMENSION;j++) 
+        for (j=0;j<DIMENSION;j++)
             gcS[i]+=direction[j]*gcAcc[i][j];
     }
-        
-    for (i=0;i<numEntries;i++) 
-            for (j=0;j<DIMENSION;j++) 
+
+    for (i=0;i<numEntries;i++)
+            for (j=0;j<DIMENSION;j++)
                 out[i][j]=mean[j]+direction[j]*gcS[index[i]];
 
     return totalError(data,out,numEntries);
@@ -1089,13 +1091,13 @@ void quantTrace(double data[MAX_ENTRIES_QUANT_TRACE][DIMENSION],int numEntries, 
     double  dpAcc [DIMENSION];
     double M =0;
     struct TRACE  *tr ;
-   
+
     tr=amd_trs[numClusters-1][numEntries-1];
 
     int trcnt =trcnts[numClusters-1][numEntries-1];
 
     int *code;
-    code=amd_codes[numClusters-1][numEntries-1]; 
+    code=amd_codes[numClusters-1][numEntries-1];
 
     for (i=0;i<numEntries;i++)
     for (j=0;j<DIMENSION;j++) {
@@ -1103,7 +1105,7 @@ void quantTrace(double data[MAX_ENTRIES_QUANT_TRACE][DIMENSION],int numEntries, 
         sdata[2*i+1][j]=-data[i][j];
     }
 
-    for (j=0;j<DIMENSION;j++) 
+    for (j=0;j<DIMENSION;j++)
     dpAcc[j]=0;
 
     k=-1;
@@ -1160,10 +1162,10 @@ void quantTrace_d(double data[MAX_ENTRIES_QUANT_TRACE][MAX_DIMENSION_BIG],int nu
 #ifdef USE_DBGTRACE
     DbgTrace(());
 #endif
-    // Data should be centered, otherwise will not work  
+    // Data should be centered, otherwise will not work
 
     int i,j,k;
-         
+
     double sdata[2*MAX_ENTRIES][MAX_DIMENSION_BIG];
 
     double  dpAcc [MAX_DIMENSION_BIG];
@@ -1176,7 +1178,7 @@ void quantTrace_d(double data[MAX_ENTRIES_QUANT_TRACE][MAX_DIMENSION_BIG],int nu
     int trcnt =trcnts[numClusters-1][numEntries-1];
 
     int *code;
-    code=amd_codes[numClusters-1][numEntries-1];    
+    code=amd_codes[numClusters-1][numEntries-1];
 
     for (i=0;i<numEntries;i++)
         for (j=0;j<dimension;j++)
@@ -1185,7 +1187,7 @@ void quantTrace_d(double data[MAX_ENTRIES_QUANT_TRACE][MAX_DIMENSION_BIG],int nu
             sdata[2*i+1][j]=-data[i][j];
         }
 
-    for (j=0;j<dimension;j++) 
+    for (j=0;j<dimension;j++)
         dpAcc[j]=0;
 
     k=-1;
@@ -1295,7 +1297,7 @@ void quantTrace_d(double data[MAX_ENTRIES_QUANT_TRACE][MAX_DIMENSION_BIG],int nu
     }
 }
 
-void quant_AnD_Shell(double* v_, int k, int n, int *idx) { 
+void quant_AnD_Shell(double* v_, int k, int n, int *idx) {
 #ifdef USE_DBGTRACE
     DbgTrace(());
 #endif
@@ -1323,14 +1325,14 @@ void quant_AnD_Shell(double* v_, int k, int n, int *idx) {
     assert((v_ != NULL) && (n>1) && (k>1));
 
     double m, M, s, dm=0.;
-    m=M=v_[0]; 
-    
+    m=M=v_[0];
+
     for (i=1; i < n;i++) {
         m = m < v_[i] ? m : v_[i];
         M = M > v_[i] ? M : v_[i];
     }
     if (M==m) {
-        for (i=0; i < n;i++) 
+        for (i=0; i < n;i++)
             idx[i]=0;
         return;
     }
@@ -1343,22 +1345,22 @@ void quant_AnD_Shell(double* v_, int k, int n, int *idx) {
         idx[i]=(int)(z[i] = floor(v[i] +0.5 /* stabilizer*/ - m *s));
 
         d[i].d = v[i]-z[i]- m *s;
-        d[i].i = i; 
+        d[i].i = i;
         dm+= d[i].d;
         r += d[i].d*d[i].d;
     }
-    if (n*r- dm*dm >= (double)(n-1)/4 /*slack*/ /2) { 
+    if (n*r- dm*dm >= (double)(n-1)/4 /*slack*/ /2) {
 
         dm /= (double)n;
 
-        for (i=0; i < n;i++) 
+        for (i=0; i < n;i++)
             d[i].d -= dm;
 
         qsort((void*)&d, n, sizeof(a),a_compare);
 
     // got into fundamental simplex
     // move coordinate system origin to its center
-        for (i=0; i < n;i++) 
+        for (i=0; i < n;i++)
             d[i].d -= (2.*(double)i+1-(double)n)/2./(double)n;
 
         mm=l=0.;
@@ -1371,27 +1373,28 @@ void quant_AnD_Shell(double* v_, int k, int n, int *idx) {
             }
         }
 
-    // position which should be in 0 
-        j = ++j % n;
+    // position which should be in 0
+        j++;
+        j = j % n;
 
-        for (i=j; i < n;i++) 
+        for (i=j; i < n;i++)
             idx[d[i].i]++;
     }
 // get rid of an offset in idx
     mi=idx[0];
-    for (i=1; i < n;i++) 
+    for (i=1; i < n;i++)
         mi = mi < idx[i]? mi :idx[i];
 
-    for (i=0; i < n;i++) 
+    for (i=0; i < n;i++)
         idx[i]-=mi;
 }
 
 double optQuantTrace(
-    double data[MAX_ENTRIES][DIMENSION], 
+    double data[MAX_ENTRIES][DIMENSION],
     int numEntries, int numClusters, int index_[MAX_ENTRIES],
     double out[MAX_ENTRIES][DIMENSION],
     double direction [DIMENSION],double *step
-    )    
+    )
 {
 
 #ifdef USE_DBGTRACE
@@ -1418,31 +1421,31 @@ double optQuantTrace(
     int order[MAX_ENTRIES];
 
 
-    for (i=0;i<numEntries;i++) 
-       for (j=0;j<DIMENSION;j++) 
+    for (i=0;i<numEntries;i++)
+       for (j=0;j<DIMENSION;j++)
             centered[i][j]=data[i][j];
 
     centerInPlace(centered, numEntries, mean);
     covariance(centered, numEntries, cov);
 
-    // check if they all are the same 
+    // check if they all are the same
 
     t=0;
-    for (j=0;j<DIMENSION;j++) 
+    for (j=0;j<DIMENSION;j++)
          t+= cov[j][j];
 
     if (t==0 || numEntries==0) {
         for (i=0;i<numEntries;i++) {
             index_[i]=0;
-            for (j=0;j<DIMENSION;j++) 
+            for (j=0;j<DIMENSION;j++)
                 out[i][j]=mean[j];
         }
         return 0.;
     }
 
 
-    eigenVector(cov, direction);    
-    project(centered, numEntries, direction, projected); 
+    eigenVector(cov, direction);
+    project(centered, numEntries, direction, projected);
 
 
     for (i=0;i<maxTry;i++) {
@@ -1451,12 +1454,12 @@ double optQuantTrace(
             t=0;
             for (j=0;j<DIMENSION;j++) {
                 direction[j]=0;
-                for (k=0;k<numEntries;k++) 
-                   direction[j]+=ordered[k][j]*index[k]; 
+                for (k=0;k<numEntries;k++)
+                   direction[j]+=ordered[k][j]*index[k];
                 t+=direction[j]*direction[j];
             }
 
-            // Actually we don't need to normailize direction here, as the 
+            // Actually we don't need to normailize direction here, as the
             // optimal quntization (index) is invariant of the scale.
             // Hence we don't care about possible degenration of the <direction> either
             // though normally it should not happen
@@ -1465,10 +1468,10 @@ double optQuantTrace(
 
             t = sqrt(t)*EPSILON;
 
-            project(centered, numEntries, direction, projected); 
+            project(centered, numEntries, direction, projected);
 
-            for (j=1; j < numEntries;j++) 
-                if (projected[order[j]] < projected[order[j-1]]-t /*EPSILON*/) 
+            for (j=1; j < numEntries;j++)
+                if (projected[order[j]] < projected[order[j-1]]-t /*EPSILON*/)
                     break;
 
             if (j >= numEntries)
@@ -1477,24 +1480,24 @@ double optQuantTrace(
 
         sortProjection(projected, order, numEntries);
 
-        for (k=0;k<numEntries;k++)     
-        for (j=0;j<DIMENSION;j++) 
+        for (k=0;k<numEntries;k++)
+        for (j=0;j<DIMENSION;j++)
         ordered[k][j]=centered[order[k]][j];
 
-    quantTrace(ordered, numEntries, numClusters, index); 
+    quantTrace(ordered, numEntries, numClusters, index);
     }
     s=t=0;
-    
+
     double q=0;
 
-    for (k=0;k<numEntries;k++) { 
+    for (k=0;k<numEntries;k++) {
         s+= index[k];
         t+= index[k]*index[k];
     }
 
     for (j=0;j<DIMENSION;j++) {
         direction[j]=0;
-        for (k=0;k<numEntries;k++) 
+        for (k=0;k<numEntries;k++)
             direction[j]+=ordered[k][j]*index[k];
     q+= direction[j]* direction[j];
 
@@ -1506,34 +1509,34 @@ double optQuantTrace(
     t = t - s * s * (double) numEntries;
 
 #ifdef USE_DBGTRACE
-    if (t==0) 
+    if (t==0)
         DbgTrace(("l;lkjk"));
 #endif
 
     assert(t !=0);
-    
+
 
     t = (t == 0 ? 0. : 1/t);
-    
+
     for (i=0;i<numEntries;i++) {
-            for (j=0;j<DIMENSION;j++) 
+            for (j=0;j<DIMENSION;j++)
                 out[order[i]][j]=mean[j]+direction[j]*t*(index[i]-s);
             index_[order[i]]=index[i];
     }
 
 
     // normalize direction for output
-    
+
     q=sqrt(q);
     *step=t*q;
-    for (j=0;j<DIMENSION;j++) 
+    for (j=0;j<DIMENSION;j++)
         direction[j]/=q;
-  
+
     return totalError(data,out,numEntries);
 }
 
 double optQuantTrace_d(
-    double data[MAX_ENTRIES][MAX_DIMENSION_BIG], 
+    double data[MAX_ENTRIES][MAX_DIMENSION_BIG],
     int numEntries, int numClusters, int index_[MAX_ENTRIES],
     double out[MAX_ENTRIES][MAX_DIMENSION_BIG],
     double direction [MAX_DIMENSION_BIG],double *step,
@@ -1554,31 +1557,31 @@ double optQuantTrace_d(
     double projected[MAX_ENTRIES];
     int order[MAX_ENTRIES];
 
-    for (i=0;i<numEntries;i++) 
-       for (j=0;j<dimension;j++) 
+    for (i=0;i<numEntries;i++)
+       for (j=0;j<dimension;j++)
             centered[i][j]=data[i][j];
 
     centerInPlace_d(centered, numEntries, mean, dimension);
     covariance_d(centered, numEntries, cov, dimension);
 
-    // check if they all are the same 
+    // check if they all are the same
 
     t=0;
-    for (j=0;j<dimension;j++) 
+    for (j=0;j<dimension;j++)
          t+= cov[j][j];
 
     if (t<EPSILON || numEntries==0) {
         for (i=0;i<numEntries;i++) {
             index_[i]=0;
-            for (j=0;j<dimension;j++) 
+            for (j=0;j<dimension;j++)
                 out[i][j]=mean[j];
         }
         return 0.;
     }
 
 
-    eigenVector_d(cov, direction, dimension);    
-    project_d(centered, numEntries, direction, projected, dimension); 
+    eigenVector_d(cov, direction, dimension);
+    project_d(centered, numEntries, direction, projected, dimension);
 
     for (i=0;i<maxTry;i++)
     {
@@ -1588,12 +1591,12 @@ double optQuantTrace_d(
             for (j=0;j<dimension;j++)
             {
                 direction[j]=0;
-                for (k=0;k<numEntries;k++) 
-                   direction[j]+=ordered[k][j]*index[k]; 
+                for (k=0;k<numEntries;k++)
+                   direction[j]+=ordered[k][j]*index[k];
                 t+=direction[j]*direction[j];
             }
 
-            // Actually we don't need to normailize direction here, as the 
+            // Actually we don't need to normailize direction here, as the
             // optimal quntization (index) is invariant of the scale.
             // Hence we don't care about possible degenration of the <direction> either
             // though normally it should not happen
@@ -1602,10 +1605,10 @@ double optQuantTrace_d(
 
             t = sqrt(t)*EPSILON;
 
-            project_d(centered, numEntries, direction, projected, dimension); 
+            project_d(centered, numEntries, direction, projected, dimension);
 
-            for (j=1; j < numEntries;j++) 
-                if (projected[order[j]] < projected[order[j-1]]-t /*EPSILON*/) 
+            for (j=1; j < numEntries;j++)
+                if (projected[order[j]] < projected[order[j-1]]-t /*EPSILON*/)
                     break;
 
             if (j >= numEntries)
@@ -1614,19 +1617,19 @@ double optQuantTrace_d(
 
         sortProjection(projected, order, numEntries);
 
-        for (k=0;k<numEntries;k++)     
-            for (j=0;j<dimension;j++) 
+        for (k=0;k<numEntries;k++)
+            for (j=0;j<dimension;j++)
                 ordered[k][j]=centered[order[k]][j];
 
-        quantTrace_d(ordered, numEntries, numClusters, index, dimension); 
+        quantTrace_d(ordered, numEntries, numClusters, index, dimension);
     }
 
     s=t=0;
-    
+
     double q=0;
 
     for (k=0;k<numEntries;k++)
-    { 
+    {
         s+= index[k];
         t+= index[k]*index[k];
     }
@@ -1634,40 +1637,40 @@ double optQuantTrace_d(
     for (j=0;j<dimension;j++)
     {
         direction[j]=0;
-        for (k=0;k<numEntries;k++) 
+        for (k=0;k<numEntries;k++)
             direction[j]+=ordered[k][j]*index[k];
         q+= direction[j]* direction[j];
 
-    }   
+    }
 
     s /= (double) numEntries;
 
     t = t - s * s * (double) numEntries;
 
-    assert(t !=0);   
+    assert(t !=0);
 
     t = (t == 0 ? 0. : 1/t);
-    
+
     for (i=0;i<numEntries;i++)
     {
-        for (j=0;j<dimension;j++) 
+        for (j=0;j<dimension;j++)
             out[order[i]][j]=mean[j]+direction[j]*t*(index[i]-s);
         index_[order[i]]=index[i];
     }
 
     // normalize direction for output
-    
+
     q=sqrt(q);
     *step=t*q;
 
-    for (j=0;j<dimension;j++) 
+    for (j=0;j<dimension;j++)
         direction[j]/=q;
-    
-    return totalError_d(data,out,numEntries, dimension);  
+
+    return totalError_d(data,out,numEntries, dimension);
 }
 
 
-void traceBuilder (int numEntries, int numClusters,struct TRACE tr [], int code[], int *trcnt ) 
+void traceBuilder (int numEntries, int numClusters,struct TRACE tr [], int code[], int *trcnt )
 {
     //=================
     #define DIG(J_IN,I,N,J_OUT,DIR,NC,NCC)            \
@@ -1675,10 +1678,10 @@ void traceBuilder (int numEntries, int numClusters,struct TRACE tr [], int code[
             J_OUT = ((((J_IN) & 0x1)==DIR) ? I : N-1-(I-(J_IN)));    \
 
     //=================
-    
-    int i[7];    
-    int j[7];    
-    int k[7]={0,1,2,3,4,5,6};    
+
+    int i[7];
+    int j[7];
+    int k[7]={0,1,2,3,4,5,6};
     int n;
     int c  =0;
     int c0 =0;
@@ -1693,7 +1696,7 @@ void traceBuilder (int numEntries, int numClusters,struct TRACE tr [], int code[
         *trcnt=0;
         return;
     }
-    
+
     h[numClusters-1]=numEntries;
 
     int q  = numEntries*(numClusters-1);
@@ -1710,17 +1713,17 @@ void traceBuilder (int numEntries, int numClusters,struct TRACE tr [], int code[
     DIG(j[3]+1,i[4],n,j[4],0,numClusters,6)
     DIG(j[4]+1,i[5],n,j[5],1,numClusters,7)
     DIG(j[5]+1,i[6],n,j[6],0,numClusters,8)
-    
-    int rescan; 
-    do { 
-        rescan=0; 
+
+    int rescan;
+    do {
+        rescan=0;
     for (p=0;p<numClusters-1;p++) {
 
         if (abs(j[p]-k[p]) >1 )  {
 
 #ifdef USE_DBGTRACE
         DbgTrace(("Driving trace generation error\n"));
-        for (p=0;p<numClusters-1;p++) 
+        for (p=0;p<numClusters-1;p++)
             DbgTrace(("%d %d %d\n",k[p],j[p],n));
 #endif
         return;
@@ -1733,7 +1736,7 @@ void traceBuilder (int numEntries, int numClusters,struct TRACE tr [], int code[
         h[cn]--;
         h[cn-1]++;
 
-        if (h[cn] < 0 || h[cn-1]>= numEntries) { 
+        if (h[cn] < 0 || h[cn-1]>= numEntries) {
             rescan =1;
             h[cn]++;
             h[cn-1]--;
@@ -1746,16 +1749,16 @@ void traceBuilder (int numEntries, int numClusters,struct TRACE tr [], int code[
             q--;
 
             {
-            int i1,cc=0; for(i1=0;i1<numClusters;i1++) cc += i1*i1*h[i1]; 
+            int i1,cc=0; for(i1=0;i1<numClusters;i1++) cc += i1*i1*h[i1];
     #ifdef USE_DBGTRACE
             if (cc !=q2)
                 DbgTrace(("1 - q2 %d %d\n", cc,q2));
     #endif
-            }; 
+            };
 
     #ifdef USE_DBGTRACE
             if (ci <0 || ci>=numEntries || cn <1 || cn >= numClusters || h[cn] < 0 || h[cn-1]>= numEntries)
-                DbgTrace(("tre1 %d %d %d %d %d  %d \n",ci,cn,numEntries,numClusters,h[cn],h[cn-1])); 
+                DbgTrace(("tre1 %d %d %d %d %d  %d \n",ci,cn,numEntries,numClusters,h[cn],h[cn-1]));
     #endif
 
             cd |=  (1<<k[p]);
@@ -1780,7 +1783,7 @@ void traceBuilder (int numEntries, int numClusters,struct TRACE tr [], int code[
                 k[p]=j[p];
             }
         }
-        else if (j[p]-k[p]==-1 ) 
+        else if (j[p]-k[p]==-1 )
         {
         int ci=j[p]-p;                    // move it up
                 int cn =p;
@@ -1798,17 +1801,17 @@ void traceBuilder (int numEntries, int numClusters,struct TRACE tr [], int code[
 
         q2+= 2*cn+1;
         q++;
-        { int i1,cc=0; for(i1=0;i1<numClusters;i1++) cc += i1*i1*h[i1]; 
+        { int i1,cc=0; for(i1=0;i1<numClusters;i1++) cc += i1*i1*h[i1];
 
 #ifdef USE_DBGTRACE
         if (cc !=q2)
             DbgTrace(("2- q2 %d %d\n", cc,q2));
 #endif
-        }; 
+        };
 
 #ifdef USE_DBGTRACE
         if (ci <0 || ci>=numEntries ||  cn >= numClusters-1 || h[cn] < 0 || h[cn+1]>= numEntries)
-            DbgTrace(("tre2 %d %d %d %d %d  %d \n",ci,cn,numEntries,numClusters,h[cn],h[cn+1])); 
+            DbgTrace(("tre2 %d %d %d %d %d  %d \n",ci,cn,numEntries,numClusters,h[cn],h[cn+1]));
 #endif
 
 
@@ -1850,11 +1853,11 @@ void traceBuilder (int numEntries, int numClusters,struct TRACE tr [], int code[
 }
 
 double optQuantAnD(
-    double data[MAX_ENTRIES][DIMENSION], 
+    double data[MAX_ENTRIES][DIMENSION],
     int numEntries, int numClusters, int index[MAX_ENTRIES],
     double out[MAX_ENTRIES][DIMENSION],
     double direction [DIMENSION],double *step
-    )   
+    )
 {
 #ifdef USE_DBGTRACE
     DbgTrace(());
@@ -1872,33 +1875,33 @@ double optQuantAnD(
     int order_[MAX_ENTRIES];
 
 
-    for (i=0;i<numEntries;i++) 
-       for (j=0;j<DIMENSION;j++) 
+    for (i=0;i<numEntries;i++)
+       for (j=0;j<DIMENSION;j++)
             centered[i][j]=data[i][j];
 
     centerInPlace(centered, numEntries, mean);
     covariance(centered, numEntries, cov);
 
-    // check if they all are the same 
+    // check if they all are the same
 
     t=0;
-    for (j=0;j<DIMENSION;j++) 
+    for (j=0;j<DIMENSION;j++)
          t+= cov[j][j];
 
     if (t==0 || numEntries==0) {
         for (i=0;i<numEntries;i++) {
             index[i]=0;
-            for (j=0;j<DIMENSION;j++) 
+            for (j=0;j<DIMENSION;j++)
                 out[i][j]=mean[j];
         }
         return 0.;
     }
 
 
-    eigenVector(cov, direction);    
-    project(centered, numEntries, direction, projected); 
+    eigenVector(cov, direction);
+    project(centered, numEntries, direction, projected);
 
-    
+
 
     for (i=0;i<maxTry;i++) {
             int done =0;
@@ -1907,15 +1910,15 @@ double optQuantAnD(
             do {
                 double q;
                 q=s=t=0;
-                
-                for (k=0;k<numEntries;k++) { 
+
+                for (k=0;k<numEntries;k++) {
                     s+= index[k];
                     t+= index[k]*index[k];
                 }
 
                 for (j=0;j<DIMENSION;j++) {
                     direction[j]=0;
-                    for (k=0;k<numEntries;k++) 
+                    for (k=0;k<numEntries;k++)
                         direction[j]+=centered[k][j]*index[k];
                     q+= direction[j]* direction[j];
 
@@ -1925,18 +1928,18 @@ double optQuantAnD(
                 t = t - s * s * (double) numEntries;
                 assert(t !=0);
                 t = (t == 0 ? 0. : 1/t);
-                // We need to requantize 
-                
-                q = sqrt(q); 
+                // We need to requantize
+
+                q = sqrt(q);
                 t *=q;
 
                 if (q !=0)
-                    for (j=0;j<DIMENSION;j++) 
+                    for (j=0;j<DIMENSION;j++)
                         direction[j]/=q;
 
                 // direction normalized
 
-                project(centered, numEntries, direction, projected); 
+                project(centered, numEntries, direction, projected);
                 sortProjection(projected, order_, numEntries);
 
                 int index__[MAX_ENTRIES];
@@ -1944,7 +1947,7 @@ double optQuantAnD(
                 // it's projected and centered; cluster centers are (index[i]-s)*t (*dir)
                 k=0;
                 for (j=0; j < numEntries;j++) {
-                    while (projected[order_[j]] > (k+0.5 -s)*t  && k < numClusters-1) 
+                    while (projected[order_[j]] > (k+0.5 -s)*t  && k < numClusters-1)
                         k++;
                     index__[order_[j]]=k;
                 }
@@ -1954,8 +1957,8 @@ double optQuantAnD(
                     index[j]=index__[j];
                 }
             } while (! done && try_two--);
-            if (i==1) 
-                for (j=0; j < numEntries;j++) 
+            if (i==1)
+                for (j=0; j < numEntries;j++)
                     index_[j]=index[j];
             else {
                 done =1;
@@ -1963,27 +1966,27 @@ double optQuantAnD(
                     done = (done && (index_[j]==index[j]));
                     index_[j]=index_[j];
                 }
-                if (done) 
+                if (done)
                     break;
 
             }
         }
-   
-        quant_AnD_Shell(projected,  numClusters,numEntries, index);  
-    
+
+        quant_AnD_Shell(projected,  numClusters,numEntries, index);
+
     }
     s=t=0;
-    
+
     double q=0;
 
-    for (k=0;k<numEntries;k++) { 
+    for (k=0;k<numEntries;k++) {
         s+= index[k];
         t+= index[k]*index[k];
     }
 
     for (j=0;j<DIMENSION;j++) {
         direction[j]=0;
-        for (k=0;k<numEntries;k++) 
+        for (k=0;k<numEntries;k++)
             direction[j]+=centered[k][j]*index[k];
     q+= direction[j]* direction[j];
 
@@ -1994,31 +1997,31 @@ double optQuantAnD(
     t = t - s * s * (double) numEntries;
 
 #ifdef USE_DBGTRACE
-    if (t==0) 
+    if (t==0)
         DbgTrace(("l;lkjk"));
 #endif
     assert(t !=0);
-    
+
 
     t = (t == 0 ? 0. : 1/t);
-    
-    for (i=0;i<numEntries;i++) 
-            for (j=0;j<DIMENSION;j++) 
+
+    for (i=0;i<numEntries;i++)
+            for (j=0;j<DIMENSION;j++)
                 out[i][j]=mean[j]+direction[j]*t*(index[i]-s);
 
     // normalize direction for output
-    
+
     q=sqrt(q);
     *step=t*q;
-    for (j=0;j<DIMENSION;j++) 
+    for (j=0;j<DIMENSION;j++)
         direction[j]/=q;
-    
+
 
     return totalError(data,out,numEntries);
 }
 
 double optQuantAnD_d(
-    double data[MAX_ENTRIES][MAX_DIMENSION_BIG], 
+    double data[MAX_ENTRIES][MAX_DIMENSION_BIG],
     int numEntries, int numClusters, int index[MAX_ENTRIES],
     double out[MAX_ENTRIES][MAX_DIMENSION_BIG],
     double direction [MAX_DIMENSION_BIG],double *step,
@@ -2044,30 +2047,30 @@ double optQuantAnD_d(
     int order_[MAX_ENTRIES];
 
 
-    for (i=0;i<numEntries;i++) 
-       for (j=0;j<dimension;j++) 
+    for (i=0;i<numEntries;i++)
+       for (j=0;j<dimension;j++)
             centered[i][j]=data[i][j];
 
     centerInPlace_d(centered, numEntries, mean, dimension);
     covariance_d(centered, numEntries, cov, dimension);
 
-    // check if they all are the same 
+    // check if they all are the same
 
     t=0;
-    for (j=0;j<dimension;j++) 
+    for (j=0;j<dimension;j++)
          t+= cov[j][j];
 
     if (t<(1./256.) || numEntries==0) {
         for (i=0;i<numEntries;i++) {
             index[i]=0;
-            for (j=0;j<dimension;j++) 
+            for (j=0;j<dimension;j++)
                 out[i][j]=mean[j];
         }
         return 0.;
     }
 
-    eigenVector_d(cov, direction, dimension);    
-    project_d(centered, numEntries, direction, projected, dimension); 
+    eigenVector_d(cov, direction, dimension);
+    project_d(centered, numEntries, direction, projected, dimension);
 
     for (i=0;i<maxTry;i++)
     {
@@ -2079,9 +2082,9 @@ double optQuantAnD_d(
             {
                 double q;
                 q=s=t=0;
-                
+
                 for (k=0;k<numEntries;k++)
-                { 
+                {
                     s+= index[k];
                     t+= index[k]*index[k];
                 }
@@ -2089,7 +2092,7 @@ double optQuantAnD_d(
                 for (j=0;j<dimension;j++)
                 {
                     direction[j]=0;
-                    for (k=0;k<numEntries;k++) 
+                    for (k=0;k<numEntries;k++)
                         direction[j]+=centered[k][j]*index[k];
                     q+= direction[j]* direction[j];
 
@@ -2099,18 +2102,18 @@ double optQuantAnD_d(
                 t = t - s * s * (double) numEntries;
                 assert(t !=0);
                 t = (t == 0 ? 0. : 1/t);
-                // We need to requantize 
-                
-                q = sqrt(q); 
+                // We need to requantize
+
+                q = sqrt(q);
                 t *=q;
 
                 if (q !=0)
-                    for (j=0;j<dimension;j++) 
+                    for (j=0;j<dimension;j++)
                         direction[j]/=q;
 
                 // direction normalized
 
-                project_d(centered, numEntries, direction, projected, dimension); 
+                project_d(centered, numEntries, direction, projected, dimension);
                 sortProjection(projected, order_, numEntries);
 
                 int index__[MAX_ENTRIES];
@@ -2119,7 +2122,7 @@ double optQuantAnD_d(
                 k=0;
                 for (j=0; j < numEntries;j++)
                 {
-                    while (projected[order_[j]] > (k+0.5 -s)*t  && k < numClusters-1) 
+                    while (projected[order_[j]] > (k+0.5 -s)*t  && k < numClusters-1)
                         k++;
                     index__[order_[j]]=k;
                 }
@@ -2131,8 +2134,8 @@ double optQuantAnD_d(
                 }
             } while (! done && try_two--);
 
-            if (i==1) 
-                for (j=0; j < numEntries;j++) 
+            if (i==1)
+                for (j=0; j < numEntries;j++)
                     index_[j]=index[j];
             else
             {
@@ -2142,20 +2145,20 @@ double optQuantAnD_d(
                     done = (done && (index_[j]==index[j]));
                     index_[j]=index_[j];
                 }
-                if (done) 
+                if (done)
                     break;
 
             }
         }
-   
-        quant_AnD_Shell(projected,  numClusters,numEntries, index);  
+
+        quant_AnD_Shell(projected,  numClusters,numEntries, index);
     }
     s=t=0;
-    
+
     double q=0;
 
     for (k=0;k<numEntries;k++)
-    { 
+    {
         s+= index[k];
         t+= index[k]*index[k];
     }
@@ -2163,7 +2166,7 @@ double optQuantAnD_d(
     for (j=0;j<dimension;j++)
     {
         direction[j]=0;
-        for (k=0;k<numEntries;k++) 
+        for (k=0;k<numEntries;k++)
             direction[j]+=centered[k][j]*index[k];
         q+= direction[j]* direction[j];
     }
@@ -2172,21 +2175,21 @@ double optQuantAnD_d(
 
     t = t - s * s * (double) numEntries;
 
-    assert(t !=0);   
+    assert(t !=0);
 
     t = (t == 0 ? 0. : 1/t);
-    
-    for (i=0;i<numEntries;i++) 
-            for (j=0;j<dimension;j++) 
+
+    for (i=0;i<numEntries;i++)
+            for (j=0;j<dimension;j++)
                 out[i][j]=mean[j]+direction[j]*t*(index[i]-s);
 
     // normalize direction for output
-    
+
     q=sqrt(q);
     *step=t*q;
-    for (j=0;j<dimension;j++) 
+    for (j=0;j<dimension;j++)
         direction[j]/=q;
-    
+
     return totalError_d(data,out,numEntries, dimension);
 }
 

--- a/Compressonator/Source/Codec/BC7/BC7_Decode.cpp
+++ b/Compressonator/Source/Codec/BC7/BC7_Decode.cpp
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -80,7 +80,7 @@ void BC7BlockDecoder::DecompressDualIndexBlock(double  out[MAX_SUBSET_SIZE][MAX_
     DWORD   blockIndices[2][MAX_SUBSET_SIZE];
 
     DWORD   clusters[2];
-    clusters[0] = 1 << bti[m_blockMode].indexBits[0];       
+    clusters[0] = 1 << bti[m_blockMode].indexBits[0];
     clusters[1] = 1 << bti[m_blockMode].indexBits[1];
     if(m_indexSwap)
     {
@@ -235,7 +235,7 @@ void BC7BlockDecoder::DecompressBlock(double  out[MAX_SUBSET_SIZE][MAX_DIMENSION
     for(component=0; component < MAX_DIMENSION_BIG; component++)
     {
         // loop over subsets
-        for(subset=0; subset<(int)bti[m_blockMode].subsetCount; subset++)
+        for(subset=0; subset<(DWORD)bti[m_blockMode].subsetCount; subset++)
         {
             // Loop over endpoints
             for(ep=0; ep<2; ep++)
@@ -252,7 +252,7 @@ void BC7BlockDecoder::DecompressBlock(double  out[MAX_SUBSET_SIZE][MAX_DIMENSION
     // Now get any parity bits
     if(bti[m_blockMode].pBitType != NO_PBIT)
     {
-        for(subset=0; subset<(int)bti[m_blockMode].subsetCount; subset++)
+        for(subset=0; subset<(DWORD)bti[m_blockMode].subsetCount; subset++)
         {
             DWORD   pBit[2];
             if(bti[m_blockMode].pBitType == ONE_PBIT)
@@ -342,7 +342,7 @@ void BC7BlockDecoder::DecompressBlock(double  out[MAX_SUBSET_SIZE][MAX_DIMENSION
     // Colour Ramps
     double          c[MAX_SUBSETS][MAX_DIMENSION_BIG][1<<MAX_INDEX_BITS];
 
-    for(i=0; i<(int)bti[m_blockMode].subsetCount; i++)
+    for(i=0; i<(DWORD)bti[m_blockMode].subsetCount; i++)
     {
         // Unpack the colours
         GetRamp(endpoint[i],

--- a/Compressonator/Source/Codec/BC7/BC7_Definitions.cpp
+++ b/Compressonator/Source/Codec/BC7/BC7_Definitions.cpp
@@ -29,7 +29,7 @@
 // {Component Encoding, PartitionBits, RotationBits, indexSwapBits,
 //  scalarBits, vectorBits, pBitType, subsetCount, {index0Bits, index1Bits}}
 //
-BTI bti[NUM_BLOCK_TYPES] =
+CMP_BTI bti[NUM_BLOCK_TYPES] =
 {
     {NO_ALPHA,          4, 0, 0, 0, 12, TWO_PBIT, 3, {3, 0}},  // Format Mode 0
     {NO_ALPHA,          6, 0, 0, 0, 18, ONE_PBIT, 2, {3, 0}},  // Format Mode 1	

--- a/Compressonator/Source/Codec/BC7/BC7_Encode.cpp
+++ b/Compressonator/Source/Codec/BC7/BC7_Encode.cpp
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -48,7 +48,7 @@
 // Default FQuality is at 0.1 < g_qFAST_THRESHOLD which will cause the SingleIndex compression to start skipping shape blocks
 // during compression
 // if user sets a value above this then all shapes will be used for compression scan for quality
-double g_qFAST_THRESHOLD  = 0.5;    
+double g_qFAST_THRESHOLD  = 0.5;
 
 // This limit is used for DualIndex Block and if fQuality is above this limit then Quantization shaking will always be performed
 // on all indexs
@@ -56,7 +56,7 @@ double g_HIGHQULITY_THRESHOLD = 0.7;
 //
 // For a given block mode this sets up the data needed by the compressor
 //
-// Note that BC7 only uses NO_PBIT, ONE_PBIT and TWO_PBIT encodings 
+// Note that BC7 only uses NO_PBIT, ONE_PBIT and TWO_PBIT encodings
 // for endpoints
 //
 
@@ -122,7 +122,7 @@ void    BC7BlockEncoder::BlockSetup(DWORD blockMode)
 //
 // This function sorts out the bit encoding for the BC7 block and packs everything
 // in the right order for the hardware decoder
-// 
+//
 //
 //
 
@@ -143,7 +143,7 @@ void BC7BlockEncoder::EncodeSingleIndexBlock(DWORD blockMode,
     DWORD   blockIndices[MAX_SUBSET_SIZE];
 
     // Generate Unary header
-    for(i=0; i < (int)blockMode; i++)
+    for(i=0; i < (DWORD)blockMode; i++)
     {
         WriteBit(basePtr, bitPosition++, 0);
     }
@@ -161,7 +161,7 @@ void BC7BlockEncoder::EncodeSingleIndexBlock(DWORD blockMode,
     DWORD   idxCount[3] = {0, 0, 0};
     bool    flipColours[3] = {false, false, false};
 
-    // Sort out the index set and tag whether we need to flip the 
+    // Sort out the index set and tag whether we need to flip the
     // endpoints to get the correct state in the implicit index bits
     // The implicitly encoded MSB of the fixup index must be 0
     DWORD   fixup[3] = {0, 0, 0};
@@ -185,7 +185,7 @@ void BC7BlockEncoder::EncodeSingleIndexBlock(DWORD blockMode,
         DWORD   p = partitionTable[i];
         blockIndices[i] = indices[p][idxCount[p]++];
 
-        for(j=0;j<(int)bti[blockMode].subsetCount;j++)
+        for(j=0;j<(DWORD)bti[blockMode].subsetCount;j++)
         {
             if(i==fixup[j])
             {
@@ -199,7 +199,7 @@ void BC7BlockEncoder::EncodeSingleIndexBlock(DWORD blockMode,
 
     // Now we must flip the endpoints where necessary so that the implicitly encoded
     // index bits have the correct state
-    for(i=0;i<(int)bti[blockMode].subsetCount;i++)
+    for(i=0;i<(DWORD)bti[blockMode].subsetCount;i++)
     {
         if(flipColours[i])
         {
@@ -270,7 +270,7 @@ void BC7BlockEncoder::EncodeSingleIndexBlock(DWORD blockMode,
     for(component=0; component < MAX_DIMENSION_BIG; component++)
     {
         // loop over subsets
-        for(subset=0; subset<(int)bti[blockMode].subsetCount; subset++)
+        for(subset=0; subset<(DWORD)bti[blockMode].subsetCount; subset++)
         {
             // Loop over endpoints and write colour bits
             for(ep=0; ep<2; ep++)
@@ -289,7 +289,7 @@ void BC7BlockEncoder::EncodeSingleIndexBlock(DWORD blockMode,
     // Now write parity bits if present
     if(bti[blockMode].pBitType != NO_PBIT)
     {
-        for(subset=0; subset<(int)bti[blockMode].subsetCount; subset++)
+        for(subset=0; subset<(DWORD)bti[blockMode].subsetCount; subset++)
         {
             if(bti[blockMode].pBitType == ONE_PBIT)
             {
@@ -376,10 +376,10 @@ double BC7BlockEncoder::CompressSingleIndexBlock(double in[MAX_SUBSET_SIZE][MAX_
     DWORD partitionsToTry = numPartitionModes;
 
     // Linearly reduce the number of partitions to try as the quality falls below a threshold
-    if(m_quality < g_qFAST_THRESHOLD) 
+    if(m_quality < g_qFAST_THRESHOLD)
     {
         partitionsToTry = (DWORD)floor((double)(partitionsToTry * m_partitionSearchSize) + 0.5);
-        partitionsToTry = min(numPartitionModes, max(1, partitionsToTry));
+        partitionsToTry = min(numPartitionModes, max(1u, partitionsToTry));
     }
 
     DWORD   blockPartition;
@@ -399,7 +399,7 @@ double BC7BlockEncoder::CompressSingleIndexBlock(double in[MAX_SUBSET_SIZE][MAX_
 #endif
 
 
-    // Loop over the available partitions for the block mode and quantize them 
+    // Loop over the available partitions for the block mode and quantize them
     // to figure out the best candidates for further refinement
     for(blockPartition = 0;
         blockPartition < partitionsToTry;
@@ -450,20 +450,20 @@ double BC7BlockEncoder::CompressSingleIndexBlock(double in[MAX_SUBSET_SIZE][MAX_
                             {
                                 fprintf(fp,"partition[%2d] = %4.2f, %4.2f, %4.2f\n",row,partition[subset][row][0],partition[subset][row][1],partition[subset][row][2]);
                             }
-                    
-                    
+
+
                             fprintf(fp,"\n");
                             for (int row=0; row<16; row++)
                             {
                                 fprintf(fp,"indices[0][%2d] = %4.2f\n",row,indices[0][row]);
                             }
-                    
+
                             fprintf(fp,"\n");
                             for (int row=0; row<16; row++)
                             {
                                 fprintf(fp,"outB[%2d] = %4.2f, %4.2f, %4.2f\n",row,outB[row][0],outB[row][1],outB[row][2]);
                             }
-                    
+
                             fprintf(fp,"\n");
                             fprintf(fp,"entryCount = %d\n",entryCount[subset]);
                             fprintf(fp,"m_clusters[0] = %d\n",m_clusters[0]);
@@ -471,7 +471,7 @@ double BC7BlockEncoder::CompressSingleIndexBlock(double in[MAX_SUBSET_SIZE][MAX_
                             fprintf(fp,"step = %4.2f\n",step);
                             fprintf(fp,"dimension = %4.2f\n",dimension);
                             fprintf(fp,"error = %4.2f\n",error);
-                    }                
+                    }
 #endif
                 }
                 else
@@ -496,20 +496,20 @@ double BC7BlockEncoder::CompressSingleIndexBlock(double in[MAX_SUBSET_SIZE][MAX_
                             {
                                 fprintf(fp,"partition[%2d] = %4.2f, %4.2f, %4.2f\n",row,partition[subset][row][0],partition[subset][row][1],partition[subset][row][2]);
                             }
-                    
-                    
+
+
                             fprintf(fp,"\n");
                             for (int row=0; row<16; row++)
                             {
                                 fprintf(fp,"indices[0][%2d] = %4.2f\n",row,indices[0][row]);
                             }
-                    
+
                             fprintf(fp,"\n");
                             for (int row=0; row<16; row++)
                             {
                                 fprintf(fp,"outB[%2d] = %4.2f, %4.2f, %4.2f\n",row,outB[row][0],outB[row][1],outB[row][2]);
                             }
-                    
+
                             fprintf(fp,"\n");
                             fprintf(fp,"entryCount = %d\n",entryCount[subset]);
                             fprintf(fp,"m_clusters[0] = %d\n",m_clusters[0]);
@@ -519,7 +519,7 @@ double BC7BlockEncoder::CompressSingleIndexBlock(double in[MAX_SUBSET_SIZE][MAX_
                             fprintf(fp,"error = %4.2f\n",error);
                     }
 #endif
-                
+
                 }
 
                 // Store off the indices for later
@@ -586,7 +586,7 @@ double BC7BlockEncoder::CompressSingleIndexBlock(double in[MAX_SUBSET_SIZE][MAX_
     // shakeSize gives the size of the shake cube (for ep_shaker_2_d)
     // ep_shaker always runs on a 1x1x1 cube on both endpoints
     DWORD   shakeSize = 8 - (DWORD)floor(1.5 * bti[blockMode].indexBits[0]);
-    shakeSize = max(2, min((DWORD)floor( shakeSize * m_quality + 0.5), 6));
+    shakeSize = max(2u, min((DWORD)floor( shakeSize * m_quality + 0.5), 6));
 
     // Shake attempts indicates how many partitions to try to shake
     DWORD   numShakeAttempts = max(1, min((DWORD)floor(8 * m_quality + 0.5), partitionsToTry));
@@ -986,14 +986,14 @@ double BC7BlockEncoder::CompressDualIndexBlock(double in[MAX_SUBSET_SIZE][MAX_DI
     fprintf(fp,"m_blockMaxRange =  %4.0f\n",m_blockMaxRange);
     fprintf(fp,"m_quantizerRangeThreshold = %4.0f\n",m_quantizerRangeThreshold);
 #endif
-    
+
     // Go through each possible rotation and selection of indices
-    for(rotation = 0; rotation < maxRotation; rotation++)  
+    for(rotation = 0; rotation < maxRotation; rotation++)
     { // A
 
 
         for(i=0; i<MAX_SUBSET_SIZE; i++)
-        { 
+        {
             cBlock[i][COMP_RED]   = in[i][componentRotations[rotation][1]];
             cBlock[i][COMP_GREEN] = in[i][componentRotations[rotation][2]];
             cBlock[i][COMP_BLUE]  = in[i][componentRotations[rotation][3]];
@@ -1006,14 +1006,14 @@ double BC7BlockEncoder::CompressDualIndexBlock(double in[MAX_SUBSET_SIZE][MAX_DI
 #ifdef    BC7_DEBUG_TO_RESULTS_TXT
         fprintf(fp,"\ncBlock[16][3]\n");
         for(i=0; i<MAX_SUBSET_SIZE; i++)
-        { 
+        {
             fprintf(fp,"%4.0f, %4.0f, %4.0f\n",cBlock[i][COMP_RED],cBlock[i][COMP_GREEN],cBlock[i][COMP_BLUE]);
         }
-        
+
 
         fprintf(fp,"\naBlock[16][3]\n");
         for(i=0; i<MAX_SUBSET_SIZE; i++)
-        { 
+        {
             fprintf(fp,"%4.0f, %4.0f, %4.0f\n",aBlock[i][COMP_RED],aBlock[i][COMP_GREEN],aBlock[i][COMP_BLUE]);
         }
 #endif
@@ -1021,7 +1021,7 @@ double BC7BlockEncoder::CompressDualIndexBlock(double in[MAX_SUBSET_SIZE][MAX_DI
         for(indexSelection = 0; indexSelection < maxIndexSelection; indexSelection++)
         { // B
             quantizerError = 0.;
-            
+
 #ifdef    BC7_DEBUG_TO_RESULTS_TXT
             fprintf(fp,"\n-------------- Quantize the vector block ----------------\n");
 #endif
@@ -1042,26 +1042,26 @@ double BC7BlockEncoder::CompressDualIndexBlock(double in[MAX_SUBSET_SIZE][MAX_DI
                                     direction,
                                     &step,
                                     3);
-                
+
 #ifdef    BC7_DEBUG_TO_RESULTS_TXT
                 fprintf(fp,"\n");
                 for (int row=0; row<16; row++)
                 {
                     fprintf(fp,"indices[0][%2d] = %4.2f\n",row,indices[0][row]);
                 }
-                
+
                 fprintf(fp,"\n");
                 for (int row=0; row<16; row++)
                 {
                     fprintf(fp,"outQ[0][%2d] = %4.2f, %4.2f, %4.2f\n",row,outQ[0][row][0],outQ[0][row][1],outQ[0][row][2]);
                 }
-                
+
                 fprintf(fp,"\n");
                 fprintf(fp,"Direction = %4.2f, %4.2f, %4.2f\n",direction[0],direction[1],direction[2]);
                 fprintf(fp,"step = %4.2f\n",step);
                 fprintf(fp,"quantizerError = %4.2f\n",quantizerError);
 #endif
-            
+
             }
             else
             {
@@ -1086,13 +1086,13 @@ double BC7BlockEncoder::CompressDualIndexBlock(double in[MAX_SUBSET_SIZE][MAX_DI
                 {
                     fprintf(fp,"indices[0][%2d] = %4.2f\n",row,indices[0][row]);
                 }
-                
+
                 fprintf(fp,"\n");
                 for (int row=0; row<16; row++)
                 {
                     fprintf(fp,"outQ[0][%2d] = %4.2f, %4.2f, %4.2f\n",row,outQ[0][row][0],outQ[0][row][1],outQ[0][row][2]);
                 }
-                
+
                 fprintf(fp,"\n");
                 fprintf(fp,"Direction = %4.2f, %4.2f, %4.2f\n",direction[0],direction[1],direction[2]);
                 fprintf(fp,"step = %4.2f\n",step);
@@ -1128,13 +1128,13 @@ double BC7BlockEncoder::CompressDualIndexBlock(double in[MAX_SUBSET_SIZE][MAX_DI
                 {
                     fprintf(fp,"indices[1][%2d] = %4.2f\n",row,indices[1][row]);
                 }
-                
+
                 fprintf(fp,"\n");
                 for (int row=0; row<16; row++)
                 {
                     fprintf(fp,"outQ[1][%2d] = %4.2f, %4.2f, %4.2f\n",row,outQ[1][row][0],outQ[1][row][1],outQ[1][row][2]);
                 }
-                
+
                 fprintf(fp,"\n");
                 fprintf(fp,"Direction = %4.2f, %4.2f, %4.2f\n",direction[0],direction[1],direction[2]);
                 fprintf(fp,"step = %4.2f\n",step);
@@ -1163,13 +1163,13 @@ double BC7BlockEncoder::CompressDualIndexBlock(double in[MAX_SUBSET_SIZE][MAX_DI
                 {
                     fprintf(fp,"indices[1][%2d] = %4.2f\n",row,indices[1][row]);
                 }
-                
+
                 fprintf(fp,"\n");
                 for (int row=0; row<16; row++)
                 {
                     fprintf(fp,"outQ[1][%2d] = %4.2f, %4.2f, %4.2f\n",row,outQ[1][row][0],outQ[1][row][1],outQ[1][row][2]);
                 }
-                
+
                 fprintf(fp,"\n");
                 fprintf(fp,"Direction = %4.2f, %4.2f, %4.2f\n",direction[0],direction[1],direction[2]);
                 fprintf(fp,"step = %4.2f\n",step);
@@ -1378,7 +1378,7 @@ double BC7BlockEncoder::CompressBlock(double in[MAX_SUBSET_SIZE][MAX_DIMENSION_B
     fprintf(fp,"m_blockMin[1] = %4.2f\n",m_blockMin[1]);
     fprintf(fp,"m_blockMin[2] = %4.2f\n",m_blockMin[2]);
     fprintf(fp,"m_blockMin[3] = %4.2f\n\n",m_blockMin[3]);
-    
+
     fprintf(fp,"m_blockMax[0] = %4.2f\n",m_blockMax[0]);
     fprintf(fp,"m_blockMax[1] = %4.2f\n",m_blockMax[1]);
     fprintf(fp,"m_blockMax[2] = %4.2f\n",m_blockMax[2]);
@@ -1400,7 +1400,7 @@ double BC7BlockEncoder::CompressBlock(double in[MAX_SUBSET_SIZE][MAX_DIMENSION_B
     fprintf(fp,"m_blockRange[2] = %4.2f\n",m_blockRange[2]);
     fprintf(fp,"m_blockRange[3] = %4.2f\n",m_blockRange[3]);
     fprintf(fp,"m_blockMaxRange = %4.2f\n\n",m_blockMaxRange);
-    
+
     fprintf(fp,"=========================================\n");
 #endif
 
@@ -1476,10 +1476,10 @@ double BC7BlockEncoder::CompressBlock(double in[MAX_SUBSET_SIZE][MAX_DIMENSION_B
 
         // Setup mode parameters for this block
         BlockSetup(blockMode);
-        
+
         if(bti[blockMode].encodingType != SEPARATE_ALPHA)
         {
-       
+
             #ifdef    BC7_DEBUG_TO_RESULTS_TXT
             fprintf(fp,"=================== CompressSingleIndexBlock ======================\n");
             #endif
@@ -1488,11 +1488,11 @@ double BC7BlockEncoder::CompressBlock(double in[MAX_SUBSET_SIZE][MAX_DIMENSION_B
         }
         else
         {
-            
+
             #ifdef    BC7_DEBUG_TO_RESULTS_TXT
             fprintf(fp,"==================  CompressDualIndexBlock =======================\n");
             #endif
-       
+
             thisError = CompressDualIndexBlock(in, temporaryOutputBlock, blockMode);
         }
 

--- a/Compressonator/Source/Codec/BC7/reconstruct.cpp
+++ b/Compressonator/Source/Codec/BC7/reconstruct.cpp
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -74,7 +74,7 @@ void histoStepCnt (int id, int cnt, double step1) {
             stepHisto[i]=stepHisto1[i]=0;
         histoInit=1;
     }
-    
+
     step1 *= 16;
     step1 = step1 <0 ? 0 : step1;
     step1 = step1 >512.*16 ? 512.*16 : step1;
@@ -89,9 +89,9 @@ void printStepHistoI (void) {
     int i,j,k,l;
 
     for (l=0;l<MAX_SUBSETS;l++) {
-        k=0;         
+        k=0;
         printf("[\n");
-        for (i=0;i<512*16/32;i++) { 
+        for (i=0;i<512*16/32;i++) {
             for (j=0;j<32;j++)
                 printf("%d, ",stepHistoI[l][k++]);
             printf("\n");
@@ -108,7 +108,7 @@ void printStepHisto (void) {
     int i,j,k;
     k=0;
     printf("[\n");
-    for (i=0;i<512*16/32;i++) { 
+    for (i=0;i<512*16/32;i++) {
         for (j=0;j<32;j++)
             printf("%d, ",stepHisto[k++]);
         printf("\n");
@@ -116,9 +116,9 @@ void printStepHisto (void) {
 
     printf("]\n");
 
-    k=0;         
+    k=0;
     printf("[\n");
-    for (i=0;i<512*16/32;i++) { 
+    for (i=0;i<512*16/32;i++) {
         for (j=0;j<32;j++)
             printf("%d, ",stepHisto1[k++]);
         printf("\n");
@@ -160,7 +160,7 @@ void index_collapse  // assymtric of x->n-x, but this does not matter below
 
     mi=Mi=index[0];
 
-    for (k=0;k<numEntries;k++) { 
+    for (k=0;k<numEntries;k++) {
         mi = mi < index[k] ? mi : index[k];
         Mi = Mi > index[k] ? Mi : index[k];
     }
@@ -169,16 +169,16 @@ void index_collapse  // assymtric of x->n-x, but this does not matter below
 
     for (d=2;d<=Mi;d++) {
 
-        for (k=0;k<numEntries;k++)  
+        for (k=0;k<numEntries;k++)
             if ((index[k] -mi) % d !=0)
                 break;
 
-        if (k>=numEntries) 
+        if (k>=numEntries)
             D =d;
     }
 
-    for (k=0;k<numEntries;k++)  
-        index[k] = (index[k]- mi)/D; 
+    for (k=0;k<numEntries;k++)
+        index[k] = (index[k]- mi)/D;
 }
 
 void index_expand  // assymtric of x->n-x, but this does not matter below
@@ -192,18 +192,18 @@ void index_expand  // assymtric of x->n-x, but this does not matter below
 
     int Mi=0,mi=max_clusters-1;
 
-    for (k=0;k<numEntries;k++) { 
+    for (k=0;k<numEntries;k++) {
         mi = mi < index[k] ? mi : index[k];
         Mi = Mi > index[k] ? Mi : index[k];
     }
 
 
-    d = Mi-mi == 0 ? 1 : (max_clusters-1)/(Mi-mi); 
+    d = Mi-mi == 0 ? 1 : (max_clusters-1)/(Mi-mi);
 
-    for (k=0;k<numEntries;k++)  
-        index[k] = (index[k]-mi)*d; 
+    for (k=0;k<numEntries;k++)
+        index[k] = (index[k]-mi)*d;
 }
-    
+
 void sHisto (int index[], int numEntries, double step, double step1)
 {
 #ifdef USE_DBGTRACE
@@ -213,26 +213,32 @@ void sHisto (int index[], int numEntries, double step, double step1)
     int k;
     for (k=0;k<numEntries;k++)
         Mi = Mi > index[k] ? Mi : index[k];
-       
+
 
     if (step!=0.)
+    {
         minStep[Mi]  = minStep[Mi] <  step ? minStep[Mi] : step;
+    }
 
         maxStep[Mi]  = maxStep[Mi] >  step ? maxStep[Mi] : step;
 
 
     if (step1!=0.)
+    {
         minStep1[Mi] = minStep1[Mi] < step1 ? minStep1[Mi] : step1;
+    }
 
     if (step1!=0.)
+    {
         maxStep1[Mi] = maxStep1[Mi] > step1 ? maxStep1[Mi] : step1;
+    }
 }
 
 
 
 
-double reconstruct( 
-    double data[MAX_ENTRIES][DIMENSION], 
+double reconstruct(
+    double data[MAX_ENTRIES][DIMENSION],
     int numEntries, int index_[MAX_ENTRIES],
     double out[MAX_ENTRIES][DIMENSION],int ns,
     double direction [DIMENSION],double *step
@@ -245,8 +251,8 @@ double reconstruct(
     int i,j,k;
     double mean[DIMENSION];
     int index[MAX_ENTRIES];
-    
-    for (k=0;k<numEntries;k++) 
+
+    for (k=0;k<numEntries;k++)
         index[k]=index_[k];
 
 // expand/collapse if needed
@@ -257,24 +263,24 @@ double reconstruct(
         index_expand (index, numEntries, MAX_CLUSTERS);
 
     for (j=0;j<DIMENSION;j++) {
-        for (mean[j]=k=0;k<numEntries;k++) 
+        for (mean[j]=k=0;k<numEntries;k++)
             mean[j]+=data[k][j];
         mean[j]/=(double) numEntries;
     }
 
-    
-    for (k=0;k<numEntries;k++) { 
+
+    for (k=0;k<numEntries;k++) {
         s+= index[k];
         t+= index[k]*index[k];
     }
 
-    double q1 =0; 
+    double q1 =0;
 
     for (j=0;j<DIMENSION;j++) {
         direction[j]=0;
-        for (k=0;k<numEntries;k++) 
+        for (k=0;k<numEntries;k++)
             direction[j]+=(data[k][j]-mean[j])*index[k];
-        
+
         q+= direction[j]* direction[j];
         q1 = fabs(direction[j]) > q1 ? fabs(direction[j]) : q1;
 
@@ -285,11 +291,11 @@ double reconstruct(
     t = t - s * s * (double) numEntries;
 
     t = (t == 0 ? 0. : 1/t);
-    
+
     q=sqrt(q);
 
     *step=t*q;
- 
+
     for (j=0;j<DIMENSION;j++) {
         direction[j]/= (q1 == 0 ? 1:q1) ;
             if (direction[j]>=1.0001)
@@ -299,17 +305,17 @@ double reconstruct(
     if (*step !=0)
         *step*=q1/q;
 
-    for (i=0;i<numEntries;i++) 
-            for (j=0;j<DIMENSION;j++) 
+    for (i=0;i<numEntries;i++)
+            for (j=0;j<DIMENSION;j++)
                 out[i][j]=mean[j]+direction[j]* (*step) *(index[i]-s);
 
     // normalize direction for output
-  
+
     return totalError(data,out,numEntries);
 }
 
-double reconstruct_new( 
-    double data[MAX_ENTRIES][DIMENSION], 
+double reconstruct_new(
+    double data[MAX_ENTRIES][DIMENSION],
     int numEntries, int index[MAX_ENTRIES],
     double out[MAX_ENTRIES][DIMENSION],int ns,
     double direction [DIMENSION],double *step
@@ -329,24 +335,24 @@ double reconstruct_new(
         index_expand (index, numEntries, MAX_CLUSTERS);
 
     for (j=0;j<DIMENSION;j++) {
-        for (mean[j]=k=0;k<numEntries;k++) 
+        for (mean[j]=k=0;k<numEntries;k++)
             mean[j]+=data[k][j];
         mean[j]/=(double) numEntries;
     }
 
-    
-    for (k=0;k<numEntries;k++) { 
+
+    for (k=0;k<numEntries;k++) {
         s+= index[k];
         t+= index[k]*index[k];
     }
 
-    double q1 =0; 
+    double q1 =0;
 
     for (j=0;j<DIMENSION;j++) {
         direction[j]=0;
-        for (k=0;k<numEntries;k++) 
+        for (k=0;k<numEntries;k++)
             direction[j]+=(data[k][j]-mean[j])*index[k];
-        
+
         q+= direction[j]* direction[j];
         q1 = fabs(direction[j]) > q1 ? fabs(direction[j]) : q1;
 
@@ -357,46 +363,46 @@ double reconstruct_new(
     t = t - s * s * (double) numEntries;
 
     t = (t == 0 ? 0. : 1/t);
-    
+
     q=sqrt(q);
 
     *step=t*q;
- 
+
 
     for (j=0;j<DIMENSION;j++) {
         direction[j]/= (q1 == 0 ? 1:q1) ;
             if (direction[j]>=1.0001)
                 printf("error\n");
     }
-    
+
     double step_l2=*step;
 
     if (*step !=0)
         *step*=q1/q;
 
-    double step_li=*step;    
+    double step_li=*step;
 
     sHisto ( index,  numEntries,  step_l2,  step_li);
-    histoStep (step_l2, step_li);    
+    histoStep (step_l2, step_li);
 
-    for (i=0;i<numEntries;i++) 
-            for (j=0;j<DIMENSION;j++) 
+    for (i=0;i<numEntries;i++)
+            for (j=0;j<DIMENSION;j++)
                 out[i][j]=mean[j]+direction[j]* (*step) *(index[i]-s);
 
     return totalError(data,out,numEntries);
 }
 
 void shake(
-    double data[MAX_ENTRIES][DIMENSION], 
+    double data[MAX_ENTRIES][DIMENSION],
     int numEntries, double idx_mean,
-    
+
     double dir_r[4][DIMENSION],
-    double mean_r[8][DIMENSION], 
-    double step_r[2], 
+    double mean_r[8][DIMENSION],
+    double step_r[2],
 
     int index_r[MAX_ENTRIES],
     double out [MAX_ENTRIES][DIMENSION])
- 
+
 {
 #ifdef USE_DBGTRACE
     DbgTrace(());
@@ -417,7 +423,7 @@ void shake(
     for (p=0;p<4;p++)
         for (q=0;q<8;q++)
             for (r=0;r<2;r++) {
-                // generate sequence 
+                // generate sequence
                 for (i=0;i<MAX_CLUSTERS;i++) {
                     t2[i] = 0;
                     for (j=0;j<DIMENSION;j++) {
@@ -429,11 +435,11 @@ void shake(
                 double ea = 0;
 
                 for (i=0; i < numEntries;i++) {
-                    double e = t2[0]+data[i][0]*c[0][0]+data[i][1]*c[0][1]+data[i][2]*c[0][2]; 
+                    double e = t2[0]+data[i][0]*c[0][0]+data[i][1]*c[0][1]+data[i][2]*c[0][2];
                     index_t[i]=0;
 
                     for (k=1;k<MAX_CLUSTERS;k++) {
-                        double t = t2[0]+data[i][0]*c[k][0]+data[i][1]*c[k][1]+data[i][2]*c[k][2]; 
+                        double t = t2[0]+data[i][0]*c[k][0]+data[i][1]*c[k][1]+data[i][2]*c[k][2];
 
                         if (t<e) {
                             index_t[i]=i;
@@ -448,22 +454,22 @@ void shake(
                         index_r[i]=index_t[i];
                 }
             }
-            for (i=0; i <numEntries;i++) 
-                for (j=0;j<DIMENSION;j++) 
+            for (i=0; i <numEntries;i++)
+                for (j=0;j<DIMENSION;j++)
                     out[i][j]=c[index_r[i]][j];
 }
 
 
 void shake_d_s(
-    double data[MAX_ENTRIES][DIMENSION], 
+    double data[MAX_ENTRIES][DIMENSION],
     int numEntries, double idx_mean,
-    
+
     double dir_step_r[2][4][DIMENSION],
-    double mean_r[8][DIMENSION], 
+    double mean_r[8][DIMENSION],
 
     int index_r[MAX_ENTRIES],
     double out [MAX_ENTRIES][DIMENSION])
- 
+
 {
 #ifdef USE_DBGTRACE
     DbgTrace(());
@@ -486,7 +492,7 @@ void shake_d_s(
     for (p=0;p<4;p++)
         for (q=0;q<8;q++)
             for (r=0;r<2;r++) {
-                // generate sequence 
+                // generate sequence
                 for (i=0;i<MAX_CLUSTERS_1_16;i++) {
                     t2[i] = 0;
                     for (j=0;j<DIMENSION;j++) {
@@ -502,11 +508,11 @@ void shake_d_s(
                 ea=0;
 
                 for (i=0; i < numEntries;i++) {
-                    double e = t2[0]-data[i][0]*c[0][0]-data[i][1]*c[0][1]-data[i][2]*c[0][2]; 
+                    double e = t2[0]-data[i][0]*c[0][0]-data[i][1]*c[0][1]-data[i][2]*c[0][2];
                     index_t[i]=0;
 
                     for (k=1;k<MAX_CLUSTERS_1_16;k++) {
-                        double t = t2[k]-data[i][0]*c[k][0]-data[i][1]*c[k][1]-data[i][2]*c[k][2]; 
+                        double t = t2[k]-data[i][0]*c[k][0]-data[i][1]*c[k][1]-data[i][2]*c[k][2];
 
                         if (t<e) {
                             index_t[i]=k;
@@ -521,7 +527,7 @@ void shake_d_s(
 
                     for (i1=0; i1 <numEntries;i1++) {
                         index_r[i1]=index_t[i1];
-                        for (j1=0;j1<DIMENSION;j1++) 
+                        for (j1=0;j1<DIMENSION;j1++)
                             out[i1][j1]=c[index_r[i1]][j1];
                     }
 
@@ -531,15 +537,15 @@ void shake_d_s(
 
 
 void shake_d_s_s(
-    double data[MAX_ENTRIES][DIMENSION], 
+    double data[MAX_ENTRIES][DIMENSION],
     int numEntries, int numClusters, double idx_mean,
-    
+
     double dir_step_r[2][4][DIMENSION],
-    double mean_step_r[2][8][DIMENSION], 
+    double mean_step_r[2][8][DIMENSION],
 
     int index_r[MAX_ENTRIES],
     double out [MAX_ENTRIES][DIMENSION])
- 
+
 {
 #ifdef USE_DBGTRACE
     DbgTrace(());
@@ -560,7 +566,7 @@ void shake_d_s_s(
     for (p=0;p<4;p++)
         for (q=0;q<8;q++)
             for (r=0;r<2;r++) {
-                // generate sequence 
+                // generate sequence
                 for (i=0;i<numClusters;i++) {
                     t2[i] = 0;
                     for (j=0;j<DIMENSION;j++) {
@@ -575,11 +581,11 @@ void shake_d_s_s(
                 ea=0;
 
                 for (i=0; i < numEntries;i++) {
-                    double e = t2[0]-data[i][0]*c[0][0]-data[i][1]*c[0][1]-data[i][2]*c[0][2]; 
+                    double e = t2[0]-data[i][0]*c[0][0]-data[i][1]*c[0][1]-data[i][2]*c[0][2];
                     index_t[i]=0;
 
                     for (k=1;k<numClusters;k++) {
-                        double t = t2[k]-data[i][0]*c[k][0]-data[i][1]*c[k][1]-data[i][2]*c[k][2]; 
+                        double t = t2[k]-data[i][0]*c[k][0]-data[i][1]*c[k][1]-data[i][2]*c[k][2];
 
                         if (t<e) {
                             index_t[i]=k;
@@ -594,7 +600,7 @@ void shake_d_s_s(
 
                     for (i1=0; i1 <numEntries;i1++) {
                         index_r[i1]=index_t[i1];
-                        for (j1=0;j1<DIMENSION;j1++) 
+                        for (j1=0;j1<DIMENSION;j1++)
                             out[i1][j1]=c[index_r[i1]][j1];
                     }
 
@@ -610,25 +616,25 @@ void mds (
 #ifdef USE_DBGTRACE
     DbgTrace(());
 #endif
-    int j,k; 
+    int j,k;
     double t=0,s=0,q1=0;
 
     for (j=0;j<DIMENSION;j++) {
-        for (mean[j]=k=0;k<numEntries;k++) 
+        for (mean[j]=k=0;k<numEntries;k++)
             mean[j]+=data[k][j];
         mean[j]/=(double) numEntries;
     }
-    
-    for (k=0;k<numEntries;k++) { 
+
+    for (k=0;k<numEntries;k++) {
         s+= index[k];
         t+= index[k]*index[k];
     }
 
     for (j=0;j<DIMENSION;j++) {
         direction[j]=0;
-        for (k=0;k<numEntries;k++) 
+        for (k=0;k<numEntries;k++)
             direction[j]+=(data[k][j]-mean[j])*index[k];
-        
+
         q1 = fabs(direction[j]) > q1 ? fabs(direction[j]) : q1;
 
     }
@@ -638,7 +644,7 @@ void mds (
     t = (t == 0 ? 0. : 1/t);
 
     *step=t*q1;
- 
+
     for (j=0;j<DIMENSION;j++) {
         direction[j]/= (q1 == 0 ? 1:q1) ;
             if (direction[j]>=1.0001)
@@ -654,7 +660,7 @@ void mds_d (
 #ifdef USE_DBGTRACE
     DbgTrace(());
 #endif
-    int i,j,k; 
+    int i,j,k;
     double t=0,s=0,q1=0;
     double cc[MAX_CLUSTERS_BIG][DIMENSION];
     int cnt[MAX_CLUSTERS_BIG];
@@ -662,37 +668,37 @@ void mds_d (
 
     for (i=0;i<MAX_CLUSTERS_BIG;i++){
         cnt[i]=0;
-        for (j=0;j<DIMENSION;j++) 
+        for (j=0;j<DIMENSION;j++)
             cc[i][j]=0;
     }
-    
+
     for (k=0;k<numEntries;k++) {
         cnt[index[k]]++;
         s+= index[k];
         t+= index[k]*index[k];
-        for (j=0;j<DIMENSION;j++) 
+        for (j=0;j<DIMENSION;j++)
             cc[index[k]][j]+=data[k][j];
     }
 
-    for (i=0;i<MAX_CLUSTERS_BIG;i++) 
-        if (cnt[i]) 
+    for (i=0;i<MAX_CLUSTERS_BIG;i++)
+        if (cnt[i])
             for (j=0;j<DIMENSION;j++) {
                 cc[i][j]/=(double)cnt[i];
                 cc[i][j]=floor(cc[i][j]+0.5);    // target discrete color
             }
 
     for (j=0;j<DIMENSION;j++) {
-        for (mean[j]=i=0;i<MAX_CLUSTERS_BIG;i++) 
+        for (mean[j]=i=0;i<MAX_CLUSTERS_BIG;i++)
             mean[j]+=cc[i][j]*(double)cnt[i];
         mean[j]/=(double) numEntries;
     }
-    
-    
+
+
     for (j=0;j<DIMENSION;j++) {
         direction[j]=0;
-        for (i=0;i<MAX_CLUSTERS_BIG;i++) 
-            direction[j]+=(cc[i][j]-mean[j])*(double)cnt[i]*(double)i; 
-        
+        for (i=0;i<MAX_CLUSTERS_BIG;i++)
+            direction[j]+=(cc[i][j]-mean[j])*(double)cnt[i]*(double)i;
+
         q1 = fabs(direction[j]) > q1 ? fabs(direction[j]) : q1;
 
     }
@@ -702,21 +708,21 @@ void mds_d (
     t = (t == 0 ? 0. : 1/t);
 
     *step=t*q1;
- 
+
     for (j=0;j<DIMENSION;j++) {
         direction[j]/= (q1 == 0 ? 1:q1) ;
             if (direction[j]>=1.0001)
                 printf("error\n");
     }
 }
-    
+
 //mean rounding setup
-// cube model 
+// cube model
 void setMean(
-      double mean[DIMENSION],  
-      double mr[8][DIMENSION], 
+      double mean[DIMENSION],
+      double mr[8][DIMENSION],
       int div
-      ) 
+      )
 {
 #ifdef USE_DBGTRACE
     DbgTrace(());
@@ -732,7 +738,7 @@ void setMean(
     }
     sdiv = div;
 
-    // bcc*2 and cartesian; starting points for fcc 
+    // bcc*2 and cartesian; starting points for fcc
     mr[4][0]=(mr[0][0]=floor(mean[0]/idiv))+1.;
     if (sdiv==4){ // switch to search in bcc*2
         for (k=0;k<5;k+=4) {
@@ -750,12 +756,12 @@ void setMean(
         mr[4][1]=mr[0][1]=floor(mean[1]/idiv);
         mr[4][2]=mr[0][2]=floor(mean[2]/idiv);
     }
-        
+
     // search in fcc
     for (k=0;k<5;k+=4) {
         if (sdiv==2){
             if ((int) floor(mr[k][0]+mr[k][1]+mr[k][2] +0.5) & 1) {
-                //latice point, leave [0] be, 
+                //latice point, leave [0] be,
                 if (-mr[k][1]+mr[k][2] < -(mean[1]/idiv)+(mean[2]/idiv)){
                     // [-1,1]
                     mr[k][1]--;
@@ -765,13 +771,13 @@ void setMean(
                 if (mr[k][1]+ 1 + mr[k][2] < (mean[1]/idiv)+(mean[2]/idiv))
                     // get to [0,1] and go right
                     mr[k][2]++;
-                else 
+                else
                     // get to [-1,0] and go right
                     mr[k][1]--;
             }
             }
         }
-        
+
 
         if (sdiv==2) {
             mr[1][0] =mr[0][0];
@@ -797,7 +803,7 @@ void setMean(
             mr[7][0] =mr[4][0];
             mr[7][1] =mr[4][1]+1.;
             mr[7][2] =mr[4][2];
-        } 
+        }
         else {
             mr[1][0] =mr[0][0];
             mr[1][1] =mr[0][1]+1.;
@@ -823,13 +829,13 @@ void setMean(
             mr[7][0] =mr[4][0];
             mr[7][1] =mr[4][1]+1.;
             mr[7][2] =mr[4][2]+1.;
-        } 
-    
+        }
+
         if (sdiv==4) // search in bcc*2
             for (k=0;k<8;k++)
-                for (j=1;j<DIMENSION;j++) 
+                for (j=1;j<DIMENSION;j++)
                     mr[k][j]*=2;
-    
+
         for (k=0;k<8;k++)
                 for (j=0;j<DIMENSION;j++) {
                     mr[k][j]*=idiv;
@@ -839,8 +845,8 @@ void setMean(
 
 
 
-double reconstruct_rnd( 
-    double data[MAX_ENTRIES][DIMENSION], 
+double reconstruct_rnd(
+    double data[MAX_ENTRIES][DIMENSION],
     int numEntries, int index_[MAX_ENTRIES],
     double out[MAX_ENTRIES][DIMENSION],int ns,
     double direction [DIMENSION],double *step
@@ -855,7 +861,7 @@ static int code1[NP1][3]=    // step, mean div,diamond
 GOOD
 */
 {
-{7, 1, 2},   {11, 1, 2}, {15, 1, 2}, {19, 1, 4}, 
+{7, 1, 2},   {11, 1, 2}, {15, 1, 2}, {19, 1, 4},
 {24, 1, 4},  {29, 1, 4}, {34, 1, 4}, {40, 1, 4},
 {46, 1, 4}, {53, 1, 4},  {60, 2, 1},
 {67, 2, 1},  {75, 2, 1}, {83, 2, 1}, {92, 2, 2}, {101, 2, 2}, {111, 2, 2}, {122, 2, 2}, {133, 2, 2}, {145, 2, 2}, {158, 2, 2},
@@ -880,7 +886,7 @@ static int code2[NP2][3]=    // step, mean div,diamond
         code = code2;
         dir_limit=dir_limit2;
         np=NP2;
-    } 
+    }
     else {
         code = code1;
         dir_limit=dir_limit1;
@@ -902,20 +908,20 @@ static int code2[NP2][3]=    // step, mean div,diamond
             bd =td;
         }
         printf("Max divider %d \n",bd);
-        for (s=i=0;i<np;i++) 
+        for (s=i=0;i<np;i++)
             s+= bd /(code[i][1]*code[i][1]*code[i][1] * code[i][2]);
         printf("Soft estimate; position capacity (scaled by max divider) %d, direction %d \n",
             s,24*dir_limit*dir_limit+2);
 
-        for (s=i=0;i<np;i++) 
+        for (s=i=0;i<np;i++)
             s+= bd /(code[i][1]*code[i][1]*code[i][1] * code[i][2]) *
             (dir_limit < code[i][0] ? 24*dir_limit*dir_limit+2 : 24*code[i][0]*code[i][0]+2);
 
         printf("Tight estimate, all+divider %d, bits %f;\n sets left total %d, full sets left assuming full directions %d\n",
-            s,log((double)s)/log(2.), 
-            (int) floor(pow(2., ceil(log((double)s)/log(2.)))+0.5)-s,  
-            ((int) floor(pow(2., ceil(log((double)s)/log(2.)))+0.5)-s) /(24*dir_limit*dir_limit+2 )  
-            
+            s,log((double)s)/log(2.),
+            (int) floor(pow(2., ceil(log((double)s)/log(2.)))+0.5)-s,
+            ((int) floor(pow(2., ceil(log((double)s)/log(2.)))+0.5)-s) /(24*dir_limit*dir_limit+2 )
+
             );
         double b =log((double)s)/log(2.)+24;
 
@@ -925,7 +931,7 @@ static int code2[NP2][3]=    // step, mean div,diamond
         }
 
         printf("Tight estimate, TOTAL  %g\n",b);
-        
+
     }
 
 
@@ -962,31 +968,31 @@ static int code2[NP2][3]=    // step, mean div,diamond
     double idx_mean;
     mds_d(data, numEntries, index, mean, &idx_mean, direction , step);
 
-    double step_li=*step;    
+    double step_li=*step;
 
     static double dir_r[4][DIMENSION];
 
     static double dir_step_r[2][4][DIMENSION]; // alternative for dir_r
 
-    static double mean_r[8][DIMENSION]; 
-    static double mean_step_r[2][8][DIMENSION]; 
-    static double step_r[2]; 
+    static double mean_r[8][DIMENSION];
+    static double mean_step_r[2][8][DIMENSION];
+    static double step_r[2];
 
     if (step_li > 200000 ) {// bypass {
         NShakeCnt+=numEntries;
-        for (i=0;i<numEntries;i++) 
-                for (j=0;j<DIMENSION;j++) 
+        for (i=0;i<numEntries;i++)
+                for (j=0;j<DIMENSION;j++)
                     out[i][j]=mean[j]+direction[j]* (*step) *(index[i]-idx_mean);
            return totalError(data,out,numEntries);
     }
 #define STEP_FACTOR 7.
 
-    if (ns==1) { 
+    if (ns==1) {
 
 
 #define STEP_DIV 1.
 #define MEAN_DIV 1.
-        for (j=0;j<DIMENSION;j++) 
+        for (j=0;j<DIMENSION;j++)
             mean_step_r[0][0][j]=mean_step_r[1][0][j]=mean_r[0][j]=floor(mean[j]/MEAN_DIV)*MEAN_DIV;
 
         int ii[3];
@@ -1015,11 +1021,11 @@ static int code2[NP2][3]=    // step, mean div,diamond
             printf("dir mormalizing error");
         }
 
-        for (i=0;i<2;i++) 
+        for (i=0;i<2;i++)
             for (ii[0]=0;ii[0]<2;ii[0]++)
                 for (ii[1]=0;ii[1]<2;ii[1]++)
-                    for (j=0;j<DIMENSION;j++) 
-                        dir_step_r[i][ii[0]+2*ii[1]][j] = 
+                    for (j=0;j<DIMENSION;j++)
+                        dir_step_r[i][ii[0]+2*ii[1]][j] =
                         (j == mc) ? direction[j]*(step_li+i)/STEP_FACTOR : ((floor(direction[j]*(step_li+i))) + (j< mc ? ii[j] : ii[j-1]))/STEP_FACTOR;
                 shake_d_s(data, numEntries, idx_mean,
             dir_step_r, mean_r, index_r, out1 );
@@ -1035,11 +1041,11 @@ static int code2[NP2][3]=    // step, mean div,diamond
         i--;
 
         //"low step"
-        // bcc*2 and cartesian; starting points for fcc 
-        for (j=0;j<2;j++) 
+        // bcc*2 and cartesian; starting points for fcc
+        for (j=0;j<2;j++)
             setMean(mean, mean_step_r[j], code[i+j][1]*code[i+j][1]*code[i+j][1]*code[i+j][2]);
 
-        step_li=code[i][0];    
+        step_li=code[i][0];
 
         double df[2];
 
@@ -1059,11 +1065,11 @@ static int code2[NP2][3]=    // step, mean div,diamond
         }
 
         int ii[3];
-        for (k=0;k<2;k++) 
+        for (k=0;k<2;k++)
             for (ii[0]=0;ii[0]<2;ii[0]++)
                 for (ii[1]=0;ii[1]<2;ii[1]++)
-                    for (j=0;j<DIMENSION;j++) 
-                        dir_step_r[k][ii[0]+2*ii[1]][j] = 
+                    for (j=0;j<DIMENSION;j++)
+                        dir_step_r[k][ii[0]+2*ii[1]][j] =
                         (j == mc) ? direction[j]*(double)code[i+k][0] /STEP_FACTOR:
         (floor(direction[j]*df[k]) + (j< mc ? ii[j] : ii[j-1]) )/df[k]*(double)code[i+k][0]/STEP_FACTOR ;
                 shake_d_s_s(data, numEntries, MAX_CLUSTERS, idx_mean ,
@@ -1084,7 +1090,7 @@ static int code2[NP2][3]=    // step, mean div,diamond
             index[i]=index_r[i];
 
         for (i=0;i<numEntries;i++)
-            for (j=0;j<DIMENSION;j++) 
+            for (j=0;j<DIMENSION;j++)
                 out [i][j]=out1[i][j];
         err=er1;
     }
@@ -1093,8 +1099,8 @@ static int code2[NP2][3]=    // step, mean div,diamond
     return totalError(data,out,numEntries);
 };
 
-double reconstruct_rnd_mean_clip( 
-    double data[MAX_ENTRIES][DIMENSION], 
+double reconstruct_rnd_mean_clip(
+    double data[MAX_ENTRIES][DIMENSION],
     int numEntries, int index_[MAX_ENTRIES],
     double out[MAX_ENTRIES][DIMENSION],int ns,
     double direction [DIMENSION],
@@ -1111,7 +1117,7 @@ static int code1[NP1][3]=    // step, mean div,diamond
 GOOD
 */
 {
-{7, 1, 2},   {11, 1, 2}, {15, 1, 2}, {19, 1, 4}, 
+{7, 1, 2},   {11, 1, 2}, {15, 1, 2}, {19, 1, 4},
 {24, 1, 4},  {29, 1, 4}, {34, 1, 4}, {40, 1, 4},
 {46, 1, 4}, {53, 1, 4},  {60, 2, 1},
 {67, 2, 1},  {75, 2, 1}, {83, 2, 1}, {92, 2, 2}, {101, 2, 2}, {111, 2, 2}, {122, 2, 2}, {133, 2, 2}, {145, 2, 2}, {158, 2, 2},
@@ -1137,7 +1143,7 @@ static int code2[NP2][3]=    // step, mean div,diamond
         code = code2;
         dir_limit=dir_limit2;
         np=NP2;
-    } 
+    }
     else {
         code = code1;
         dir_limit=dir_limit1;
@@ -1159,20 +1165,20 @@ static int code2[NP2][3]=    // step, mean div,diamond
             bd =td;
         }
         printf("Max divider %d \n",bd);
-        for (s=i=0;i<np;i++) 
+        for (s=i=0;i<np;i++)
             s+= bd /(code[i][1]*code[i][1]*code[i][1] * code[i][2]);
         printf("Soft estimate; position capacity (scaled by max divider) %d, direction %d \n",
             s,24*dir_limit*dir_limit+2);
 
-        for (s=i=0;i<np;i++) 
+        for (s=i=0;i<np;i++)
             s+= bd /(code[i][1]*code[i][1]*code[i][1] * code[i][2]) *
             (dir_limit < code[i][0] ? 24*dir_limit*dir_limit+2 : 24*code[i][0]*code[i][0]+2);
 
         printf("Tight estimate, all+divider %d, bits %f;\n sets left total %d, full sets left assuming full directions %d\n",
-            s,log((double)s)/log(2.), 
-            (int) floor(pow(2., ceil(log((double)s)/log(2.)))+0.5)-s,  
-            ((int) floor(pow(2., ceil(log((double)s)/log(2.)))+0.5)-s) /(24*dir_limit*dir_limit+2 )  
-            
+            s,log((double)s)/log(2.),
+            (int) floor(pow(2., ceil(log((double)s)/log(2.)))+0.5)-s,
+            ((int) floor(pow(2., ceil(log((double)s)/log(2.)))+0.5)-s) /(24*dir_limit*dir_limit+2 )
+
             );
         double b =log((double)s)/log(2.)+24;
 
@@ -1182,7 +1188,7 @@ static int code2[NP2][3]=    // step, mean div,diamond
         }
 
         printf("Tight estimate, TOTAL  %g\n",b);
-        
+
     }
 
 
@@ -1220,16 +1226,16 @@ static int code2[NP2][3]=    // step, mean div,diamond
 
     mds(data, numEntries, index, mean, &idx_mean, direction , step);
 
-    double s=0,t=0, q=0, q1 =0; 
+    double s=0,t=0, q=0, q1 =0;
 
     for (j=0;j<DIMENSION;j++) {
-        for (mean[j]=k=0;k<numEntries;k++) 
+        for (mean[j]=k=0;k<numEntries;k++)
             mean[j]+=data[k][j];
         mean[j]/=(double) numEntries;
     }
 
-    
-    for (k=0;k<numEntries;k++) { 
+
+    for (k=0;k<numEntries;k++) {
         s+= index[k];
         t+= index[k]*index[k];
     }
@@ -1237,9 +1243,9 @@ static int code2[NP2][3]=    // step, mean div,diamond
 
     for (j=0;j<DIMENSION;j++) {
         direction[j]=0;
-        for (k=0;k<numEntries;k++) 
+        for (k=0;k<numEntries;k++)
             direction[j]+=(data[k][j]-mean[j])*index[k];
-        
+
         q+= direction[j]* direction[j];
         q1 = fabs(direction[j]) > q1 ? fabs(direction[j]) : q1;
 
@@ -1250,11 +1256,11 @@ static int code2[NP2][3]=    // step, mean div,diamond
     t = t - s * s * (double) numEntries;
 
     t = (t == 0 ? 0. : 1/t);
-    
+
     q=sqrt(q);
 
     *step=t*q;
- 
+
 
     for (j=0;j<DIMENSION;j++) {
         direction[j]/= (q1 == 0 ? 1:q1) ;
@@ -1265,31 +1271,31 @@ static int code2[NP2][3]=    // step, mean div,diamond
     if (*step !=0)
         *step*=q1/q;
 
-    double step_li=*step;    
+    double step_li=*step;
 
     static double dir_r[4][DIMENSION];
 
     static double dir_step_r[2][4][DIMENSION]; // alternative for dir_r
 
-    static double mean_r[8][DIMENSION]; 
-    static double mean_step_r[2][8][DIMENSION]; 
-    static double step_r[2]; 
+    static double mean_r[8][DIMENSION];
+    static double mean_step_r[2][8][DIMENSION];
+    static double step_r[2];
 
     if (step_li > 200000 ) {// bypass {
         NShakeCnt+=numEntries;
-        for (i=0;i<numEntries;i++) 
-                for (j=0;j<DIMENSION;j++) 
+        for (i=0;i<numEntries;i++)
+                for (j=0;j<DIMENSION;j++)
                     out[i][j]=mean[j]+direction[j]* (*step) *(index[i]-idx_mean);
            return totalError(data,out,numEntries);
     }
 #define STEP_FACTOR 7.
 
-    if (ns==1) { 
+    if (ns==1) {
 
 
 #define STEP_DIV 1.
 #define MEAN_DIV 1.
-        for (j=0;j<DIMENSION;j++) 
+        for (j=0;j<DIMENSION;j++)
             mean_step_r[0][0][j]=mean_step_r[1][0][j]=mean_r[0][j]=floor(mean[j]/MEAN_DIV)*MEAN_DIV;
 
         int ii[3];
@@ -1301,7 +1307,7 @@ static int code2[NP2][3]=    // step, mean div,diamond
                     for (j=0;j<DIMENSION;j++)
                     mean_step_r[0][ii[0]+ii[1]*2+ii[2]*4][j]=mean_step_r[1][ii[0]+ii[1]*2+ii[2]*4][j]=
                         mean_r[ii[0]+ii[1]*2+ii[2]*4][j]=mean_r[0][j]+MEAN_DIV*ii[j] >255 ? 255:mean_r[0][j]+MEAN_DIV*ii[j];
-        
+
         step_li = floor((step_li*STEP_FACTOR - STEP_FACTOR)/STEP_DIV)*STEP_DIV+STEP_FACTOR;
 
         step_li = step_li < STEP_FACTOR ? STEP_FACTOR :step_li;
@@ -1320,11 +1326,11 @@ static int code2[NP2][3]=    // step, mean div,diamond
             printf("dir mormalizing error");
         }
 
-        for (i=0;i<2;i++) 
+        for (i=0;i<2;i++)
             for (ii[0]=0;ii[0]<2;ii[0]++)
                 for (ii[1]=0;ii[1]<2;ii[1]++)
-                    for (j=0;j<DIMENSION;j++) 
-                        dir_step_r[i][ii[0]+2*ii[1]][j] = 
+                    for (j=0;j<DIMENSION;j++)
+                        dir_step_r[i][ii[0]+2*ii[1]][j] =
                         (j == mc) ? direction[j]*(step_li+STEP_DIV*i)/STEP_FACTOR : ((floor(direction[j]*(step_li+STEP_DIV*i))) + (j< mc ? ii[j] : ii[j-1]))/STEP_FACTOR;
         shake_d_s_s(data, numEntries,  MAX_CLUSTERS, idx_mean ,
             dir_step_r, mean_step_r, index_r, out1 );
@@ -1342,7 +1348,7 @@ static int code2[NP2][3]=    // step, mean div,diamond
 
         //"low step"
 
-        // bcc*2 and cartesian; starting points for fcc 
+        // bcc*2 and cartesian; starting points for fcc
         for (j=0;j<2;j++) {
             for (j=0;j<DIMENSION;j++)
                 mean[j]-=in_mean[j];
@@ -1354,7 +1360,7 @@ static int code2[NP2][3]=    // step, mean div,diamond
                     mean_step_r[j][k][j]+=in_mean[j];
         }
 
-        step_li=code[i][0];    
+        step_li=code[i][0];
 
         double df[2];
 
@@ -1375,11 +1381,11 @@ static int code2[NP2][3]=    // step, mean div,diamond
         }
 
         int ii[3];
-        for (k=0;k<2;k++) 
+        for (k=0;k<2;k++)
             for (ii[0]=0;ii[0]<2;ii[0]++)
                 for (ii[1]=0;ii[1]<2;ii[1]++)
-                    for (j=0;j<DIMENSION;j++) 
-                        dir_step_r[k][ii[0]+2*ii[1]][j] = 
+                    for (j=0;j<DIMENSION;j++)
+                        dir_step_r[k][ii[0]+2*ii[1]][j] =
                         (j == mc) ? direction[j]*(double)code[i+k][0] /STEP_FACTOR:
         (floor(direction[j]*df[k]) + (j< mc ? ii[j] : ii[j-1]) )/df[k]*(double)code[i+k][0]/STEP_FACTOR ;
 
@@ -1400,7 +1406,7 @@ static int code2[NP2][3]=    // step, mean div,diamond
             index[i]=index_r[i];
 
         for (i=0;i<numEntries;i++)
-            for (j=0;j<DIMENSION;j++) 
+            for (j=0;j<DIMENSION;j++)
                 out [i][j]=out1[i][j];
         err=er1;
     }
@@ -1418,7 +1424,7 @@ inline int getns(int partition[MAX_ENTRIES], int numEntries) {
 #ifdef USE_DBGTRACE
     DbgTrace(());
 #endif
-    int i,c; 
+    int i,c;
     int id[MAX_ENTRIES];
 
     for (i=0;i<MAX_SUBSETS; i++)
@@ -1434,9 +1440,9 @@ inline int getns(int partition[MAX_ENTRIES], int numEntries) {
     return (c);
 }
 
-int block_mean_rnd( 
-    double data_[MAX_ENTRIES][DIMENSION], 
-    int numEntries, 
+int block_mean_rnd(
+    double data_[MAX_ENTRIES][DIMENSION],
+    int numEntries,
     int partition[MAX_ENTRIES],
     int ns,
 
@@ -1446,7 +1452,7 @@ int block_mean_rnd(
     double ni[MAX_SUBSETS]  // norm
 
 
-    ) 
+    )
     {
 #ifdef USE_DBGTRACE
     DbgTrace(());
@@ -1454,8 +1460,8 @@ int block_mean_rnd(
         int i,j,k,l;
 
 
-        double n [MAX_SUBSETS];  // number per set    
-    
+        double n [MAX_SUBSETS];  // number per set
+
         if (ns !=3)
             printf("ns problems\n");
 
@@ -1484,7 +1490,7 @@ int block_mean_rnd(
 
         for (i=0;i<ns;i++) {
             for (j=0;j<DIMENSION;j++)
-                if (n[i]!=0) 
+                if (n[i]!=0)
                     mean[i][j]/=(double) n[i];
         }
 
@@ -1500,7 +1506,7 @@ int block_mean_rnd(
         };
 
 
-        for (l=0;l<ns;l++) 
+        for (l=0;l<ns;l++)
             for (i=l+1;i<ns;i++) {
                 if (ni[i] < ni[l]) {
                     double t = ni[l]; ni[l]=ni[i]; ni[i]=t;
@@ -1519,15 +1525,15 @@ int block_mean_rnd(
         return(ni[1] < 16. );
 }
 
-double ep_shaker( 
+double ep_shaker(
 #define EP_CLUMP
 
-    double data[MAX_ENTRIES][DIMENSION], 
+    double data[MAX_ENTRIES][DIMENSION],
     int numEntries, int index_[MAX_ENTRIES],
     double out[MAX_ENTRIES][DIMENSION],int ns,
     double direction [DIMENSION],double *step,
     int lock
-    ) 
+    )
 
 {
 #ifdef USE_DBGTRACE
@@ -1537,7 +1543,7 @@ double ep_shaker(
     int i,j,k;
     double mean[DIMENSION];
     int index[MAX_ENTRIES];
-    
+
     int maxTry=5;
 
     int Mi=0;
@@ -1549,24 +1555,24 @@ double ep_shaker(
     bits= (ns==1?0 :(ns==2?2:4));
 
 
-    for (k=0;k<numEntries;k++) 
+    for (k=0;k<numEntries;k++)
         index[k]=index_[k];
 
-    for (k=0;k<numEntries;k++) 
+    for (k=0;k<numEntries;k++)
         if (index[k]>=Mi_) {
             printf("index error\n");
-            for (i=0;i<numEntries;i++) 
+            for (i=0;i<numEntries;i++)
                 index[i]=0;
             // work-around for constant block quantizer bug
             break;
         }
 
 
-    // run on actually used exreme points  
+    // run on actually used exreme points
     index_collapse (index, numEntries);
 
     int done;
-    int change;  
+    int change;
     int start=1;
     int better;
 
@@ -1581,19 +1587,19 @@ double ep_shaker(
     do{
 
     for (j=0;j<DIMENSION;j++) {
-        for (mean[j]=k=0;k<numEntries;k++) 
+        for (mean[j]=k=0;k<numEntries;k++)
             mean[j]+=data[k][j];
         mean[j]/=(double) numEntries;
     }
-   
 
-    if (lock) 
+
+    if (lock)
         Mi = Mi_-1;
     else
-        for (k=0;k<numEntries;k++) 
-            Mi = index[k]>Mi ?  index[k] :Mi; 
+        for (k=0;k<numEntries;k++)
+            Mi = index[k]>Mi ?  index[k] :Mi;
 
-    for (k=0;k<numEntries;k++) { 
+    for (k=0;k<numEntries;k++) {
         s+= index[k];
         t+= index[k]*index[k];
     }
@@ -1602,9 +1608,9 @@ double ep_shaker(
 
     for (j=0;j<DIMENSION;j++) {
         direction[j]=0;
-        for (k=0;k<numEntries;k++) 
+        for (k=0;k<numEntries;k++)
             direction[j]+=(data[k][j]-mean[j])*index[k];
-   
+
     }
 
     s /= (double) numEntries;
@@ -1625,13 +1631,13 @@ double ep_shaker(
     }
 
     int glue =1;
-    for (j=0;j<DIMENSION;j++) 
+    for (j=0;j<DIMENSION;j++)
         glue = glue && (m[j]==M[j]);
 
     if (glue) {
         if (start ){
-        for (i=0;i<numEntries;i++) 
-            for (j=0;j<DIMENSION;j++) 
+        for (i=0;i<numEntries;i++)
+            for (j=0;j<DIMENSION;j++)
                 out[i][j]=m[j];
         return  totalError(data,out,numEntries);
         }
@@ -1642,17 +1648,17 @@ double ep_shaker(
     double pp[64][DIMENSION];
     double c[MAX_ENTRIES][64][DIMENSION];
 
-    for (i=0;i<=Mi;i++) 
+    for (i=0;i<=Mi;i++)
         for (j=0;j<DIMENSION;j++) {
             pp[i][j] = floor(m[j]+(M[j]-m[j])* (i/ (double) Mi) + 0.5);
             pp[i][j]= pp[i][j] > 0 ? pp[i][j] : 0 ;
             pp[i][j]= pp[i][j] < 255. ? pp[i][j] : 255. ;
         }
 
-    
 
-    for (k=0;k<numEntries;k++) 
-        for (i=0;i<=Mi;i++) 
+
+    for (k=0;k<numEntries;k++)
+        for (i=0;i<=Mi;i++)
             for (j=0;j<DIMENSION;j++) {
                 double t1=(data[k][j]-pp[i][j]);
                 c[k][i][j]=t1*t1;
@@ -1678,8 +1684,8 @@ double ep_shaker(
         ma+=t1;
     }
     mag=ma;
-    for (k=0;k<numEntries;k++) { 
-        for (j=0;j<DIMENSION;j++) 
+    for (k=0;k<numEntries;k++) {
+        for (j=0;j<DIMENSION;j++)
             outg[k][j]=pp[idg[k]][j];
     }
 
@@ -1688,16 +1694,16 @@ double ep_shaker(
     int p,q,r;
 
     for (p=1;p<64;p++) {
-        // Gray code increment bit 
+        // Gray code increment bit
         q=p^(p>>1) ^ (p-1)^((p-1)>>1);
         r=p & (-p);
         if (q != r)
             printf("Gray code problem");
 
-        
+
         int di;
 
-        di =  (ss & q) ? -(1<< bits) : (1<<bits); 
+        di =  (ss & q) ? -(1<< bits) : (1<<bits);
         ss = ss ^ q;
         int i0=0,j0=0;
         if (q >=8) {
@@ -1719,7 +1725,7 @@ double ep_shaker(
 #ifdef EP_CLUMP
             M[j0]= M[j0] > 0 ? M[j0] : 0 ;
             M[j0]= M[j0] < 255. ? M[j0] : 255. ;
-#endif        
+#endif
         }
 
         for (i=0;i<=Mi;i++) {
@@ -1730,7 +1736,7 @@ double ep_shaker(
 
 
 
-        for (k=0;k<numEntries;k++) 
+        for (k=0;k<numEntries;k++)
             for (i=0;i<=Mi;i++) {
                     double t1=(data[k][j0]-pp[i][j0]);
                     c[k][i][j0]=t1*t1;
@@ -1753,14 +1759,14 @@ double ep_shaker(
         }
         if (ma < mag) {
             mag=ma;
-            for (k=0;k<numEntries;k++) { 
+            for (k=0;k<numEntries;k++) {
                 idg[k]=id[k];
                 for (j=0;j<DIMENSION;j++) {
                     outg[k][j]=pp[idg[k]][j];
                     mb[j]=m[j];
                     Mb[j]=M[j];
 
-    
+
                 }
             }
         }
@@ -1768,7 +1774,7 @@ double ep_shaker(
     double nf = totalError(data,outg,numEntries);
 
     change =0;
-    for (k=0;k<numEntries;k++) { 
+    for (k=0;k<numEntries;k++) {
         change = change || (index[k]!=idg[k]);
     }
     if (! start) {
@@ -1778,9 +1784,9 @@ double ep_shaker(
         better =1;
 
     if (better) {
-        for (k=0;k<numEntries;k++) { 
+        for (k=0;k<numEntries;k++) {
             index_[k]=index[k]=idg[k];
-            for (j=0;j<DIMENSION;j++) 
+            for (j=0;j<DIMENSION;j++)
                 out[k][j]=outg[k][j];
         }
             of=nf;
@@ -1797,11 +1803,11 @@ int expand (int bits, int v) {
 #ifdef USE_DBGTRACE
     DbgTrace(());
 #endif
-    return (  v << (8-bits) | v >> (2* bits - 8)); 
+    return (  v << (8-bits) | v >> (2* bits - 8));
 }
 
 
-void getRndRamp(int bits, double v, int size, double out[], int *parity, int range[2], int ep[] ){ 
+void getRndRamp(int bits, double v, int size, double out[], int *parity, int range[2], int ep[] ){
 #ifdef USE_DBGTRACE
     DbgTrace(());
 #endif
@@ -1826,7 +1832,7 @@ void getRndRamp(int bits, double v, int size, double out[], int *parity, int ran
     for (i=0;i< size;i++){
         if (m >=0){
             if (m < (1<<bits)) {
-                out[i] = m; // no expansion here, as single point bcc handling is outside 
+                out[i] = m; // no expansion here, as single point bcc handling is outside
                 ep[i]=m;
             }
             else if (range[1] > i){
@@ -1840,7 +1846,7 @@ void getRndRamp(int bits, double v, int size, double out[], int *parity, int ran
     }
 }
 
-void getRndRampN(int bits[DIMENSION], double v[DIMENSION], int size, double out[ MAX_SHAKE_SIZE][DIMENSION], int parity[DIMENSION], int range[2][DIMENSION], int ep[ MAX_SHAKE_SIZE][DIMENSION],int bcc)  
+void getRndRampN(int bits[DIMENSION], double v[DIMENSION], int size, double out[ MAX_SHAKE_SIZE][DIMENSION], int parity[DIMENSION], int range[2][DIMENSION], int ep[ MAX_SHAKE_SIZE][DIMENSION],int bcc)
 {
 #ifdef USE_DBGTRACE
     DbgTrace(());
@@ -1864,7 +1870,7 @@ void getRndRampN(int bits[DIMENSION], double v[DIMENSION], int size, double out[
                 for (i=0;i<size;i++)
                     ep[i][j]=ep_[j][i];
         }
-    }        
+    }
     else if (size ==1) {// m in range
         for (j=0;j<DIMENSION;j++) {
             range[0][j]=0;
@@ -1875,7 +1881,7 @@ void getRndRampN(int bits[DIMENSION], double v[DIMENSION], int size, double out[
             int ok0=1,ok1=1;
             int p = 0;
 
-                for (j=0;j<DIMENSION;j++) 
+                for (j=0;j<DIMENSION;j++)
                     out_[j][1]=out_[j][0]+1;
                 for (j=0;j<DIMENSION;j++) {
                     // partity 0
@@ -1888,10 +1894,10 @@ void getRndRampN(int bits[DIMENSION], double v[DIMENSION], int size, double out[
 
                         ok1 = ok1 && out_[j][(parity[j] ^ 1) & 1 ]<  ((1<<(bits[j]+bcc)));
                 }
-                if (ok0 && ok1 ) 
-                    if (t0<t1) 
+                if (ok0 && ok1 )
+                    if (t0<t1)
                         p=0;
-                    else 
+                    else
                         p=1;
                 else if (ok0)
                     p=0;
@@ -1910,8 +1916,8 @@ void getRndRampN(int bits[DIMENSION], double v[DIMENSION], int size, double out[
         }
         else {
             for (j=0;j<DIMENSION;j++) {
-                if ( out_[j][0] +1 <  ((1<<(bits[j]))) &&  // bcc == 0 
-                    (abs(expand(bits[j]+bcc, (int)(out_[j][0]+1 -v[j]))) < 
+                if ( out_[j][0] +1 <  ((1<<(bits[j]))) &&  // bcc == 0
+                    (abs(expand(bits[j]+bcc, (int)(out_[j][0]+1 -v[j]))) <
                      abs(expand(bits[j]+bcc, (int)(out_[j][0]   -v[j])))))
                 {
                         out[0][j]=expand(bits[j]+bcc, (int)(out_[j][0]+1));
@@ -1930,9 +1936,9 @@ void getRndRampN(int bits[DIMENSION], double v[DIMENSION], int size, double out[
 }
 
 
-double ep_shaker_2( 
+double ep_shaker_2(
 
-    double data[MAX_ENTRIES][DIMENSION], 
+    double data[MAX_ENTRIES][DIMENSION],
     int numEntries, int index_[MAX_ENTRIES],
     double out[MAX_ENTRIES][DIMENSION],
     int epo_code[2][DIMENSION],
@@ -1940,7 +1946,7 @@ double ep_shaker_2(
     int bcc,
     int nClusters,
     int size
-    ) 
+    )
 {
 #ifdef USE_DBGTRACE
     DbgTrace(());
@@ -1949,33 +1955,33 @@ double ep_shaker_2(
     int i,j,k;
     double mean[DIMENSION];
     int index[MAX_ENTRIES];
-    
+
     int maxTry=8;
 
     int Mi=0;
 
     int Mi_= nClusters-1; // this is last cluster, not max number 0f clusters
 
-    for (k=0;k<numEntries;k++) 
+    for (k=0;k<numEntries;k++)
         index[k]=index_[k];
 
-    for (k=0;k<numEntries;k++) 
+    for (k=0;k<numEntries;k++)
         if (index[k]> Mi_) {
             printf("index error\n");
-            for (i=0;i<numEntries;i++) 
+            for (i=0;i<numEntries;i++)
                 index[i]=0;
             // work-around for constant block quantizer bug
             break;
         }
-    
+
 
     index_collapse (index, numEntries);
 
     int done;
-    int change;  
+    int change;
     int start=1;
     int better;
-    
+
     double of = 0.0;
     double epo[2][DIMENSION];
     int ep[2][ MAX_SHAKE_SIZE][DIMENSION];
@@ -1987,14 +1993,14 @@ double ep_shaker_2(
     do{
 
         for (j=0;j<DIMENSION;j++) {
-            for (mean[j]=k=0;k<numEntries;k++) 
+            for (mean[j]=k=0;k<numEntries;k++)
                 mean[j]+=data[k][j];
             mean[j]/=(double) numEntries;
         }
-       
 
-        for (k=0;k<numEntries;k++) 
-            Mi = index[k]>Mi ?  index[k] :Mi; 
+
+        for (k=0;k<numEntries;k++)
+            Mi = index[k]>Mi ?  index[k] :Mi;
 
         // shift/scale
 
@@ -2006,7 +2012,7 @@ double ep_shaker_2(
 
 
         if (Mi==0){
-            getRndRampN(bits, mean, 1/* size*/, epo+0, parity[0], range[0], ep[0],bcc) ; 
+            getRndRampN(bits, mean, 1/* size*/, epo+0, parity[0], range[0], ep[0],bcc) ;
             getRndRampN(bits, mean, 1/* size*/, epo+1, parity[1], range[1], ep[1],bcc)  ;
             for (j=0;j<DIMENSION;j++) {
                 epo_code[0][j]=ep[0][0][j];
@@ -2017,11 +2023,11 @@ double ep_shaker_2(
 
         for (q=1;Mi!=0 && q*Mi <= Mi_;q++)
             for (p=q*Mi;p<=Mi_;p++)  {
-                //index * q + p-Mi*q 
-            
+                //index * q + p-Mi*q
+
             int cidx[MAX_ENTRIES];
-            
-            for (k=0;k<numEntries;k++) 
+
+            for (k=0;k<numEntries;k++)
                 cidx[k]=index[k] * q + p-Mi*q;
 
             double im [2][2] = {{0,0},{0,0}};    // matrix /inverse matrix
@@ -2040,15 +2046,15 @@ double ep_shaker_2(
 
             for (k=0;k<numEntries;k++) {
                 cnt[cidx[k]]+=1;
-                for (j=0;j<DIMENSION;j++) 
+                for (j=0;j<DIMENSION;j++)
                     cc[cidx[k]][j]+=data[k][j];
             }
 
             for (i=0;i<=Mi_;i++)
-                for (j=0;j<DIMENSION;j++) 
+                for (j=0;j<DIMENSION;j++)
                     if (cnt[i]!=0)
                         cc[i][j]=floor(cc[i][j]/cnt[i]+0.5); // more or less ideal location
-                    else 
+                    else
                         cc[i][j]=0;
 
                                                          // for cluster centers
@@ -2076,8 +2082,8 @@ double ep_shaker_2(
 
 
                 if (dd==0) {
- //############## degenerate, usually the same index                    
-                    for (i=0;i<=Mi_;i++) 
+ //############## degenerate, usually the same index
+                    for (i=0;i<=Mi_;i++)
                         if (cnt[i]!=0)
                             break;
                 // Make it into ramp
@@ -2101,14 +2107,14 @@ double ep_shaker_2(
                         epa[0][j]=(im[1][0]*rp[0][j]+im[1][1]*rp[1][j])*Mi_;
                         epa[1][j]=(im[0][0]*rp[0][j]+im[0][1]*rp[1][j])*Mi_;
                     }
-                    getRndRampN(bits, epa[0], size, epd[0], parity[0], range[0], ep[0],bcc);  
-                    getRndRampN(bits, epa[1], size, epd[1], parity[1], range[1], ep[1],bcc) ; 
+                    getRndRampN(bits, epa[0], size, epd[0], parity[0], range[0], ep[0],bcc);
+                    getRndRampN(bits, epa[1], size, epd[1], parity[1], range[1], ep[1],bcc) ;
 
                 }
             int best_ep [2][2][2][DIMENSION];// point, parity0,parity1, coordinate
             double e[2][2][DIMENSION]; //  parity0, parity1, coordinate
             int l0,l1;
-    
+
             for (j=0;j<DIMENSION;j++) {
 
                 e[0][0][j] = e[0][1][j] = e[1][0][j] = e[1][1][j] = MAX_ENTRIES*256*256*4.;
@@ -2117,7 +2123,7 @@ double ep_shaker_2(
                     for (l1=range[1][0][j];l1<range[1][1][j];l1++) {
 // ran on points or clusters ??
                         double cv [MAX_CLUSTERS_BIG];
-                        double t=0;                        
+                        double t=0;
                         int i1;
                         for (i1=0;i1<=Mi_;i1++) {
                             cv[i1]=floor( (epd[1][l1][j]*i1+ epd[0][l0][j]*(Mi_-i1))/((double)Mi_)+0.5);
@@ -2127,15 +2133,15 @@ double ep_shaker_2(
                         for (i1=0;i1< numEntries;i1++)
                             t+=(cv[cidx[i1]]-data[i1][j])*(cv[cidx[i1]]-data[i1][j]);
                         if (bcc) {
-                            if (t < e[(parity[0][j] ^ l0)& 1] [(parity[1][j] ^ l1)& 1][j] )        
+                            if (t < e[(parity[0][j] ^ l0)& 1] [(parity[1][j] ^ l1)& 1][j] )
                             {
                                 e[(parity[0][j] ^ l0)& 1] [(parity[1][j] ^ l1)& 1][j] =t;
                                 best_ep[0][(parity[0][j] ^ l0)& 1] [(parity[1][j] ^ l1)& 1][j]=l0;
                                 best_ep[1][(parity[0][j] ^ l0)& 1] [(parity[1][j] ^ l1)& 1][j]=l1;
                             }
-                        } 
+                        }
                         else {
-                            if (t < e[0][0][j])        
+                            if (t < e[0][0][j])
                             {
                                 e[0][0][j] =t;
                                 best_ep[0][0][0][j]=l0;
@@ -2144,13 +2150,13 @@ double ep_shaker_2(
                         }
                     }
             }
-            if (bcc) { 
+            if (bcc) {
                 double t[2][2]={0,0,0,0};
                 double tt;
                 int a,b,a0,b0;
                 for (a=0;a<2;a++)
                     for (b=0;b<2;b++)
-                        for (j=0;j<DIMENSION;j++) 
+                        for (j=0;j<DIMENSION;j++)
                             t[a][b]+=e[a][b][j];
                 a0=b0=0;
                 tt = t[0][0];
@@ -2176,9 +2182,9 @@ double ep_shaker_2(
                     }
                 }
             }
-            else { 
+            else {
                 double t=0;
-                for (j=0;j<DIMENSION;j++) 
+                for (j=0;j<DIMENSION;j++)
                     t+=e[0][0][j];
                 if (t< ee) {
                     ee = t;
@@ -2201,15 +2207,15 @@ double ep_shaker_2(
         double pp[64][DIMENSION];
         double c[MAX_ENTRIES][64][DIMENSION];
 
-        for (i=0;i<=Mi_;i++) 
+        for (i=0;i<=Mi_;i++)
             for (j=0;j<DIMENSION;j++) {
                 pp[i][j] = floor(epo[0][j]+(epo[1][j]-epo[0][j])* (i/ (double) Mi_) + 0.5);
                 pp[i][j]= pp[i][j] > 0 ? pp[i][j] : 0 ;
                 pp[i][j]= pp[i][j] < 255. ? pp[i][j] : 255. ;
         }
 
-        for (k=0;k<numEntries;k++) 
-            for (i=0;i<=Mi_;i++) 
+        for (k=0;k<numEntries;k++)
+            for (i=0;i<=Mi_;i++)
                 for (j=0;j<DIMENSION;j++) {
                     double t=(data[k][j]-pp[i][j]);
                 c[k][i][j]=t*t;
@@ -2234,8 +2240,8 @@ double ep_shaker_2(
             ma+=t;
         }
         mag=ma;
-        for (k=0;k<numEntries;k++) { 
-            for (j=0;j<DIMENSION;j++) 
+        for (k=0;k<numEntries;k++) {
+            for (j=0;j<DIMENSION;j++)
                 outg[k][j]=pp[idg[k]][j];
         }
 
@@ -2244,7 +2250,7 @@ double ep_shaker_2(
         double nf = totalError(data,outg,numEntries);
 
         change =0;
-        for (k=0;k<numEntries;k++) { 
+        for (k=0;k<numEntries;k++) {
             change = change || (index[k] * q0 + p0-Mi*q0!=idg[k]);
         }
         if (! start) {
@@ -2254,9 +2260,9 @@ double ep_shaker_2(
             better =1;
 
         if (better) {
-            for (k=0;k<numEntries;k++) { 
+            for (k=0;k<numEntries;k++) {
                 index_[k]=index[k]=idg[k];
-                for (j=0;j<DIMENSION;j++) 
+                for (j=0;j<DIMENSION;j++)
                     out[k][j]=outg[k][j];
             }
         of=nf;
@@ -2280,11 +2286,11 @@ if (bcc)
 };
 
 
-double ep_shaker_2__( 
-    double data[MAX_ENTRIES][DIMENSION], 
+double ep_shaker_2__(
+    double data[MAX_ENTRIES][DIMENSION],
     int numEntries, int index_[MAX_ENTRIES],
     double out[MAX_ENTRIES][DIMENSION],int ns
-    ) 
+    )
 {
 #ifdef USE_DBGTRACE
     DbgTrace(());
@@ -2293,7 +2299,7 @@ double ep_shaker_2__(
     int i,j,k;
     double mean[DIMENSION];
     int index[MAX_ENTRIES];
-    
+
     int maxTry=8;
 
     int Mi=0;
@@ -2302,24 +2308,24 @@ double ep_shaker_2__(
     int bits;
 
     bits= (ns==1?0 :(ns==2?2:4));
-    
-    for (k=0;k<numEntries;k++) 
+
+    for (k=0;k<numEntries;k++)
         index[k]=index_[k];
 
-    for (k=0;k<numEntries;k++) 
+    for (k=0;k<numEntries;k++)
         if (index[k]> Mi_) {
             printf("index error\n");
-            for (i=0;i<numEntries;i++) 
+            for (i=0;i<numEntries;i++)
                 index[i]=0;
             // work-around for constant block quantizer bug
             break;
         }
-    
+
 
     index_collapse (index, numEntries);
 
     int done;
-    int change;  
+    int change;
     int start=1;
     int better;
 
@@ -2329,14 +2335,14 @@ double ep_shaker_2__(
     do{
 
         for (j=0;j<DIMENSION;j++) {
-            for (mean[j]=k=0;k<numEntries;k++) 
+            for (mean[j]=k=0;k<numEntries;k++)
                 mean[j]+=data[k][j];
             mean[j]/=(double) numEntries;
         }
-       
 
-        for (k=0;k<numEntries;k++) 
-            Mi = index[k]>Mi ?  index[k] :Mi; 
+
+        for (k=0;k<numEntries;k++)
+            Mi = index[k]>Mi ?  index[k] :Mi;
 
         // shift/scale
 
@@ -2361,11 +2367,11 @@ double ep_shaker_2__(
 
         for (q=1;Mi!=0 && q*Mi <= Mi_;q++)
             for (p=q*Mi;p<=Mi_;p++)  {
-                //index * q + p-Mi*q 
-            
+                //index * q + p-Mi*q
+
             int cidx[MAX_ENTRIES];
-            
-            for (k=0;k<numEntries;k++) 
+
+            for (k=0;k<numEntries;k++)
                 cidx[k]=index[k] * q + p-Mi*q;
 
             double im [2][2] = {{0,0},{0,0}};    // matrix /inverse matrix
@@ -2384,15 +2390,15 @@ double ep_shaker_2__(
 
             for (k=0;k<numEntries;k++) {
                 cnt[cidx[k]]+=1;
-                for (j=0;j<DIMENSION;j++) 
+                for (j=0;j<DIMENSION;j++)
                     cc[cidx[k]][j]+=data[k][j];
             }
 
             for (i=0;i<=Mi_;i++)
-                for (j=0;j<DIMENSION;j++) 
+                for (j=0;j<DIMENSION;j++)
                     if (cnt[i]!=0)
                         cc[i][j]=floor(cc[i][j]/cnt[i]+0.5); // more or less ideal location
-                    else 
+                    else
                         cc[i][j]=0;
 
                                                          // for cluster centers
@@ -2423,8 +2429,8 @@ double ep_shaker_2__(
 
 
                 if (dd==0) {
- //############## degenerate, usually the same index                    
-                    for (i=0;i<=Mi_;i++) 
+ //############## degenerate, usually the same index
+                    for (i=0;i<=Mi_;i++)
                         if (cnt[i]!=0)
                             break;
                 // Make it into ramp
@@ -2458,9 +2464,9 @@ double ep_shaker_2__(
                         }
                     }
 #if 1
-                    for (k=0;k<numEntries;k++) { 
+                    for (k=0;k<numEntries;k++) {
                         index_[k]=index[k]=0;
-                        for (j=0;j<DIMENSION;j++) 
+                        for (j=0;j<DIMENSION;j++)
                             out[k][j]=floor(mean[j] /((double)(1<<bits)))*(1<<bits) + (i-1)*(1<<bits);
                     }
 #endif
@@ -2508,14 +2514,14 @@ double ep_shaker_2__(
             int best_ep [2][DIMENSION];
             double e[DIMENSION];
             int l0,l1;
-    
+
             for (j=0;j<DIMENSION;j++) {
                 e[j] = MAX_ENTRIES*256*256*4.;
                 for (l0=range[0][0][j];l0<range[0][1][j];l0++)
                     for (l1=range[1][0][j];l1<range[1][1][j];l1++) {
 // ran on points or clusters ??
                         double cv [MAX_CLUSTERS_BIG];
-                        double t=0;                        
+                        double t=0;
                         int i1;
                         for (i1=0;i1<=Mi_;i1++) {
                             cv[i1]=floor( (epd[1][l1][j]*i1+ epd[0][l0][j]*(Mi_-i1))/((double)Mi_)+0.5);
@@ -2531,9 +2537,9 @@ double ep_shaker_2__(
                         }
                     }
             }
-            { 
+            {
                 double t=0;
-                for (j=0;j<DIMENSION;j++) 
+                for (j=0;j<DIMENSION;j++)
                     t+=e[j];
                 if (t< ee) {
                     ee = t;
@@ -2555,15 +2561,15 @@ double ep_shaker_2__(
         double pp[64][DIMENSION];
         double c[MAX_ENTRIES][64][DIMENSION];
 
-        for (i=0;i<=Mi_;i++) 
+        for (i=0;i<=Mi_;i++)
             for (j=0;j<DIMENSION;j++) {
                 pp[i][j] = floor(epo[0][j]+(epo[1][j]-epo[0][j])* (i/ (double) Mi_) + 0.5);
                 pp[i][j]= pp[i][j] > 0 ? pp[i][j] : 0 ;
                 pp[i][j]= pp[i][j] < 255. ? pp[i][j] : 255. ;
         }
 
-        for (k=0;k<numEntries;k++) 
-            for (i=0;i<=Mi_;i++) 
+        for (k=0;k<numEntries;k++)
+            for (i=0;i<=Mi_;i++)
                 for (j=0;j<DIMENSION;j++) {
                     double t=(data[k][j]-pp[i][j]);
                 c[k][i][j]=t*t;
@@ -2588,16 +2594,16 @@ double ep_shaker_2__(
             ma+=t;
         }
         mag=ma;
-        for (k=0;k<numEntries;k++) { 
-            for (j=0;j<DIMENSION;j++) 
+        for (k=0;k<numEntries;k++) {
+            for (j=0;j<DIMENSION;j++)
                 outg[k][j]=pp[idg[k]][j];
         }
 
         double nf = totalError(data,outg,numEntries);
 
         change =0;
-        for (k=0;k<numEntries;k++) { 
-            change = change || (index[k] * q0 + p0-Mi*q0!=idg[k]);    
+        for (k=0;k<numEntries;k++) {
+            change = change || (index[k] * q0 + p0-Mi*q0!=idg[k]);
         }
         if (! start) {
             better = nf < of;
@@ -2606,9 +2612,9 @@ double ep_shaker_2__(
             better =1;
 
         if (better) {
-            for (k=0;k<numEntries;k++) { 
+            for (k=0;k<numEntries;k++) {
                 index_[k]=index[k]=idg[k];
-                for (j=0;j<DIMENSION;j++) 
+                for (j=0;j<DIMENSION;j++)
                     out[k][j]=outg[k][j];
             }
         of=nf;
@@ -2618,10 +2624,10 @@ double ep_shaker_2__(
     return totalError(data,out,numEntries);
 }
 
-        
+
 //################################
-double reconstruct_rnd__( 
-    double data[MAX_ENTRIES][DIMENSION], 
+double reconstruct_rnd__(
+    double data[MAX_ENTRIES][DIMENSION],
     int numEntries, int index_[MAX_ENTRIES],
     double out[MAX_ENTRIES][DIMENSION],int ns,
     double direction [DIMENSION],double *step
@@ -2636,7 +2642,7 @@ static int code1[NP1][3]=    // step, mean div,diamond
 GOOD
 */
 {
-{7, 1, 2},   {11, 1, 2}, {15, 1, 2}, {19, 1, 4}, 
+{7, 1, 2},   {11, 1, 2}, {15, 1, 2}, {19, 1, 4},
 {24, 1, 4},  {29, 1, 4}, {34, 1, 4}, {40, 1, 4},
 {46, 1, 4}, {53, 1, 4},  {60, 2, 1},
 {67, 2, 1},  {75, 2, 1}, {83, 2, 1}, {92, 2, 2}, {101, 2, 2}, {111, 2, 2}, {122, 2, 2}, {133, 2, 2}, {145, 2, 2}, {158, 2, 2},
@@ -2664,7 +2670,7 @@ static int code2[NP2][3]=    // step, mean div,diamond
         code = code2;
         dir_limit=dir_limit2;
         np=NP2;
-    } 
+    }
     else {
         code = code1;
         dir_limit=dir_limit1;
@@ -2686,20 +2692,20 @@ static int code2[NP2][3]=    // step, mean div,diamond
             bd =td;
         }
         printf("Max divider %d \n",bd);
-        for (s=i=0;i<np;i++) 
+        for (s=i=0;i<np;i++)
             s+= bd /(code[i][1]*code[i][1]*code[i][1] * code[i][2]);
         printf("Soft estimate; position capacity (scaled by max divider) %d, direction %d \n",
             s,24*dir_limit*dir_limit+2);
 
-        for (s=i=0;i<np;i++) 
+        for (s=i=0;i<np;i++)
             s+= bd /(code[i][1]*code[i][1]*code[i][1] * code[i][2]) *
             (dir_limit < code[i][0] ? 24*dir_limit*dir_limit+2 : 24*code[i][0]*code[i][0]+2);
 
         printf("Tight estimate, all+divider %d, bits %f;\n sets left total %d, full sets left assuming full directions %d\n",
-            s,log((double)s)/log(2.), 
-            (int) floor(pow(2., ceil(log((double)s)/log(2.)))+0.5)-s,  
-            ((int) floor(pow(2., ceil(log((double)s)/log(2.)))+0.5)-s) /(24*dir_limit*dir_limit+2 )  
-            
+            s,log((double)s)/log(2.),
+            (int) floor(pow(2., ceil(log((double)s)/log(2.)))+0.5)-s,
+            ((int) floor(pow(2., ceil(log((double)s)/log(2.)))+0.5)-s) /(24*dir_limit*dir_limit+2 )
+
             );
         double b =log((double)s)/log(2.)+24;
 
@@ -2709,7 +2715,7 @@ static int code2[NP2][3]=    // step, mean div,diamond
         }
 
         printf("Tight estimate, TOTAL  %g\n",b);
-        
+
     }
 
 
@@ -2747,16 +2753,16 @@ static int code2[NP2][3]=    // step, mean div,diamond
 
     mds(data, numEntries, index, mean, &idx_mean, direction , step);
 
-    double s=0,t=0, q=0, q1 =0; 
+    double s=0,t=0, q=0, q1 =0;
 
     for (j=0;j<DIMENSION;j++) {
-        for (mean[j]=k=0;k<numEntries;k++) 
+        for (mean[j]=k=0;k<numEntries;k++)
             mean[j]+=data[k][j];
         mean[j]/=(double) numEntries;
     }
 
-    
-    for (k=0;k<numEntries;k++) { 
+
+    for (k=0;k<numEntries;k++) {
         s+= index[k];
         t+= index[k]*index[k];
     }
@@ -2764,9 +2770,9 @@ static int code2[NP2][3]=    // step, mean div,diamond
 
     for (j=0;j<DIMENSION;j++) {
         direction[j]=0;
-        for (k=0;k<numEntries;k++) 
+        for (k=0;k<numEntries;k++)
             direction[j]+=(data[k][j]-mean[j])*index[k];
-        
+
         q+= direction[j]* direction[j];
         q1 = fabs(direction[j]) > q1 ? fabs(direction[j]) : q1;
 
@@ -2777,11 +2783,11 @@ static int code2[NP2][3]=    // step, mean div,diamond
     t = t - s * s * (double) numEntries;
 
     t = (t == 0 ? 0. : 1/t);
-    
+
     q=sqrt(q);
 
     *step=t*q;
- 
+
 
     for (j=0;j<DIMENSION;j++) {
         direction[j]/= (q1 == 0 ? 1:q1) ;
@@ -2792,31 +2798,31 @@ static int code2[NP2][3]=    // step, mean div,diamond
     if (*step !=0)
         *step*=q1/q;
 
-    double step_li=*step;    
+    double step_li=*step;
 
     static double dir_r[4][DIMENSION];
 
     static double dir_step_r[2][4][DIMENSION]; // alternative for dir_r
 
-    static double mean_r[8][DIMENSION]; 
-    static double mean_step_r[2][8][DIMENSION]; 
-    static double step_r[2]; 
+    static double mean_r[8][DIMENSION];
+    static double mean_step_r[2][8][DIMENSION];
+    static double step_r[2];
 
     if (step_li > 200000 ) {// bypass {
         NShakeCnt+=numEntries;
-        for (i=0;i<numEntries;i++) 
-                for (j=0;j<DIMENSION;j++) 
+        for (i=0;i<numEntries;i++)
+                for (j=0;j<DIMENSION;j++)
                     out[i][j]=mean[j]+direction[j]* (*step) *(index[i]-idx_mean);
            return totalError(data,out,numEntries);
     }
 #define STEP_FACTOR 7.
 
-    if (ns==1) { 
+    if (ns==1) {
 
 
 #define STEP_DIV 1.
 #define MEAN_DIV 1.
-        for (j=0;j<DIMENSION;j++) 
+        for (j=0;j<DIMENSION;j++)
             mean_step_r[0][0][j]=mean_step_r[1][0][j]=mean_r[0][j]=floor(mean[j]/MEAN_DIV)*MEAN_DIV;
 
         int ii[3];
@@ -2845,11 +2851,11 @@ static int code2[NP2][3]=    // step, mean div,diamond
             printf("dir mormalizing error");
         }
 
-        for (i=0;i<2;i++) 
+        for (i=0;i<2;i++)
             for (ii[0]=0;ii[0]<2;ii[0]++)
                 for (ii[1]=0;ii[1]<2;ii[1]++)
-                    for (j=0;j<DIMENSION;j++) 
-                        dir_step_r[i][ii[0]+2*ii[1]][j] = 
+                    for (j=0;j<DIMENSION;j++)
+                        dir_step_r[i][ii[0]+2*ii[1]][j] =
                         (j == mc) ? direction[j]*(step_li+i)/STEP_FACTOR : ((floor(direction[j]*(step_li+i))) + (j< mc ? ii[j] : ii[j-1]))/STEP_FACTOR;
                 shake_d_s(data, numEntries, idx_mean,
             dir_step_r, mean_r, index_r, out1 );
@@ -2867,11 +2873,11 @@ static int code2[NP2][3]=    // step, mean div,diamond
 
         //"low step"
 
-        // bcc*2 and cartesian; starting points for fcc 
-        for (j=0;j<2;j++) 
+        // bcc*2 and cartesian; starting points for fcc
+        for (j=0;j<2;j++)
             setMean(mean, mean_step_r[j], code[i+j][1]*code[i+j][1]*code[i+j][1]*code[i+j][2]);
 
-        step_li=code[i][0];    
+        step_li=code[i][0];
 
         double df[2];
 
@@ -2892,11 +2898,11 @@ static int code2[NP2][3]=    // step, mean div,diamond
         }
 
         int ii[3];
-        for (k=0;k<2;k++) 
+        for (k=0;k<2;k++)
             for (ii[0]=0;ii[0]<2;ii[0]++)
                 for (ii[1]=0;ii[1]<2;ii[1]++)
-                    for (j=0;j<DIMENSION;j++) 
-                        dir_step_r[k][ii[0]+2*ii[1]][j] = 
+                    for (j=0;j<DIMENSION;j++)
+                        dir_step_r[k][ii[0]+2*ii[1]][j] =
                         (j == mc) ? direction[j]*(double)code[i+k][0] /STEP_FACTOR:
         (floor(direction[j]*df[k]) + (j< mc ? ii[j] : ii[j-1]) )/df[k]*(double)code[i+k][0]/STEP_FACTOR ;
                 shake_d_s_s(data, numEntries, MAX_CLUSTERS, idx_mean ,
@@ -2917,7 +2923,7 @@ static int code2[NP2][3]=    // step, mean div,diamond
             index[i]=index_r[i];
 
         for (i=0;i<numEntries;i++)
-            for (j=0;j<DIMENSION;j++) 
+            for (j=0;j<DIMENSION;j++)
                 out [i][j]=out1[i][j];
         err=er1;
     }

--- a/Compressonator/Source/Codec/DXT/Codec_DXT1.cpp
+++ b/Compressonator/Source/Codec/DXT/Codec_DXT1.cpp
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -26,7 +26,9 @@
 //  Description: implementation of the CCodec_DXT1 class
 //
 //////////////////////////////////////////////////////////////////////////////
+#ifdef _MSC_VER
 #pragma warning(disable:4100)
+#endif //_MSC_VER
 
 #include "Common.h"
 #include "Codec_DXT1.h"
@@ -53,7 +55,7 @@ bool CCodec_DXT1::SetParameter(const CMP_CHAR* pszParamName, CMP_CHAR* sValue)
         m_bDXT1UseAlpha = (std::stoi(sValue) > 0) ? true : false;
     else if(strcmp(pszParamName, "AlphaThreshold") == 0)
         m_nAlphaThreshold = (CMP_BYTE) (std::stoi(sValue) & 0xFF);
-    else 
+    else
         return CCodec_DXTC::SetParameter(pszParamName, sValue);
     return true;
 }

--- a/Compressonator/Source/Codec/DXT/Codec_DXT3.cpp
+++ b/Compressonator/Source/Codec/DXT/Codec_DXT3.cpp
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -26,7 +26,9 @@
 //  Description: implementation of the CCodec_DXT3 class
 //
 //////////////////////////////////////////////////////////////////////////////
+#ifdef _MSC_VER
 #pragma warning(disable:4100)
+#endif //_MSC_VER
 
 #include "Common.h"
 #include "Codec_DXT3.h"

--- a/Compressonator/Source/Codec/DXT/Codec_DXT5.cpp
+++ b/Compressonator/Source/Codec/DXT/Codec_DXT5.cpp
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -26,7 +26,9 @@
 //  Description: implementation of the CCodec_DXT5 class
 //
 //////////////////////////////////////////////////////////////////////////////
+#ifdef _MSC_VER
 #pragma warning(disable:4100)
+#endif //_MSC_VER
 
 #include "Common.h"
 #include "Codec_DXT5.h"
@@ -74,18 +76,18 @@ CodecError CCodec_DXT5::Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut
         DbgTrace(("-------> Remote Server Connected"));
     }
     #endif
-    
+
     const CMP_DWORD dwBlocksX = ((bufferIn.GetWidth() + 3) >> 2);
     const CMP_DWORD dwBlocksY = ((bufferIn.GetHeight() + 3) >> 2);
 
 
-    #ifdef DXT5_COMPDEBUGGER
+#ifdef DXT5_COMPDEBUGGER
     DbgTrace(("IN : BufferType %d ChannelCount %d ChannelDepth %d",bufferIn.GetBufferType(),bufferIn.GetChannelCount(),bufferIn.GetChannelDepth()));
     DbgTrace(("   : Height %d Width %d Pitch %d isFloat %d",bufferIn.GetHeight(),bufferIn.GetWidth(),bufferIn.GetWidth(),bufferIn.IsFloat()));
 
     DbgTrace(("OUT: BufferType %d ChannelCount %d ChannelDepth %d",bufferOut.GetBufferType(),bufferOut.GetChannelCount(),bufferOut.GetChannelDepth()));
     DbgTrace(("   : Height %d Width %d Pitch %d isFloat %d",bufferOut.GetHeight(),bufferOut.GetWidth(),bufferOut.GetWidth(),bufferOut.IsFloat()));
-    #endif;
+#endif
 
 
     bool bUseFixed = (!bufferIn.IsFloat() && bufferIn.GetChannelDepth() == 8 && !m_bUseFloat);
@@ -116,8 +118,8 @@ CodecError CCodec_DXT5::Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut
             }
 
             bufferOut.WriteBlock(i*4, j*4, compressedBlock, 4);
-    
-            #ifdef DXT5_COMPDEBUGGER 
+
+            #ifdef DXT5_COMPDEBUGGER
                 //g_CompClient.SendData(2,sizeof(compressedBlock),(byte *)&compressedBlock[0]);
             #endif
 

--- a/Compressonator/Source/Codec/DXT/Codec_DXT5_RBxG.cpp
+++ b/Compressonator/Source/Codec/DXT/Codec_DXT5_RBxG.cpp
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -46,8 +46,10 @@ CCodec_DXT5_RBxG::~CCodec_DXT5_RBxG()
 }
 
 // Disable erroneous C4715 warning
+#ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable:4715) 
+#pragma warning(disable:4715)
+#endif //_MSC_VER
 
 
 bool CCodec_DXT5_RBxG::SetParameter(const CMP_CHAR* pszParamName, CMP_CHAR* sValue)
@@ -93,7 +95,9 @@ bool CCodec_DXT5_RBxG::GetParameter(const CMP_CHAR* pszParamName, CODECFLOAT& fV
 }
 
 // Re-enable erroneous C4715 warning
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif //_MSC_VER
 
 void CCodec_DXT5_RBxG::ReadBlock(CCodecBuffer& buffer, CMP_DWORD x, CMP_DWORD y, CMP_BYTE block[BLOCK_SIZE_4X4X4])
 {

--- a/Compressonator/Source/Codec/DXT/Codec_DXT5_Swizzled.cpp
+++ b/Compressonator/Source/Codec/DXT/Codec_DXT5_Swizzled.cpp
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -26,7 +26,9 @@
 //  Description: implementation of the CCodec_DXT5_Swizzled class
 //
 //////////////////////////////////////////////////////////////////////////////
+#ifdef _MSC_VER
 #pragma warning(disable:4100)
+#endif //_MSC_VER
 
 #include "Common.h"
 #include "Codec_DXT5_Swizzled.h"
@@ -183,7 +185,7 @@ CodecError CCodec_DXT5_Swizzled::Decompress(CCodecBuffer& bufferIn, CCodecBuffer
             {
                 CMP_BYTE destBlock[BLOCK_SIZE_4X4X4];
                 DecompressRGBABlock(destBlock, compressedBlock);
-                WriteBlock(bufferOut, i*4, j*4, destBlock);    
+                WriteBlock(bufferOut, i*4, j*4, destBlock);
             }
             else
             {

--- a/Compressonator/Source/Codec/DXT/Codec_DXT5_xRBG.cpp
+++ b/Compressonator/Source/Codec/DXT/Codec_DXT5_xRBG.cpp
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -46,8 +46,10 @@ CCodec_DXT5_xRBG::~CCodec_DXT5_xRBG()
 }
 
 // Disable erroneous C4715 warning
+#ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable:4715) 
+#pragma warning(disable:4715)
+#endif //_MSC_VER
 
 bool CCodec_DXT5_xRBG::SetParameter(const CMP_CHAR* pszParamName, CMP_CHAR* sValue)
 {
@@ -91,7 +93,9 @@ bool CCodec_DXT5_xRBG::GetParameter(const CMP_CHAR* pszParamName, CODECFLOAT& fV
 }
 
 // Re-enable erroneous C4715 warning
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif //_MSC_VER
 
 void CCodec_DXT5_xRBG::ReadBlock(CCodecBuffer& buffer, CMP_DWORD x, CMP_DWORD y, CMP_BYTE block[BLOCK_SIZE_4X4X4])
 {

--- a/Compressonator/Source/Codec/DXTC/Codec_DXTC_RGBA.cpp
+++ b/Compressonator/Source/Codec/DXTC/Codec_DXTC_RGBA.cpp
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -41,17 +41,17 @@ CodecError CCodec_DXTC::CompressRGBABlock(CMP_BYTE rgbaBlock[BLOCK_SIZE_4X4X4], 
     CodecError err = CompressAlphaBlock(alphaBlock, &compressedBlock[DXTC_OFFSET_ALPHA]);
     if(err != CE_OK)
         return err;
-    
+
     return CompressRGBBlock(rgbaBlock, &compressedBlock[DXTC_OFFSET_RGB], pfChannelWeights, false);
 }
 
 void CCodec_DXTC::DecompressRGBABlock(CMP_BYTE rgbaBlock[BLOCK_SIZE_4X4X4], CMP_DWORD compressedBlock[4])
 {
     CMP_BYTE alphaBlock[BLOCK_SIZE_4X4];
-    
+
     DecompressAlphaBlock(alphaBlock, &compressedBlock[DXTC_OFFSET_ALPHA]);
     DecompressRGBBlock(rgbaBlock, &compressedBlock[DXTC_OFFSET_RGB], false);
-    
+
     for(CMP_DWORD i = 0; i < 16; i++)
         ((DWORD*)rgbaBlock)[i] = (alphaBlock[i] << RGBA8888_OFFSET_A) | (((DWORD*)rgbaBlock)[i] & ~(BYTE_MASK << RGBA8888_OFFSET_A));
 }
@@ -65,24 +65,24 @@ CodecError CCodec_DXTC::CompressRGBABlock_ExplicitAlpha(CMP_BYTE rgbaBlock[BLOCK
     CodecError err = CompressExplicitAlphaBlock(alphaBlock, &compressedBlock[DXTC_OFFSET_ALPHA]);
     if(err != CE_OK)
         return err;
-    
+
     return CompressRGBBlock(rgbaBlock, &compressedBlock[DXTC_OFFSET_RGB], pfChannelWeights, false);
 }
 
 void CCodec_DXTC::DecompressRGBABlock_ExplicitAlpha(CMP_BYTE rgbaBlock[BLOCK_SIZE_4X4X4], CMP_DWORD compressedBlock[4])
 {
     CMP_BYTE alphaBlock[BLOCK_SIZE_4X4];
-    
+
     DecompressExplicitAlphaBlock(alphaBlock, &compressedBlock[DXTC_OFFSET_ALPHA]);
     DecompressRGBBlock(rgbaBlock, &compressedBlock[DXTC_OFFSET_RGB], false);
-    
+
     for(CMP_DWORD i = 0; i < 16; i++)
         ((DWORD*)rgbaBlock)[i] = (alphaBlock[i] << RGBA8888_OFFSET_A) | (((DWORD*)rgbaBlock)[i] & ~(BYTE_MASK << RGBA8888_OFFSET_A));
 }
 
 #define ConstructColour(r, g, b)  (((r) << 11) | ((g) << 5) | (b))
 
-/* 
+/*
 Channel Bits
 */
 #define RG 5
@@ -109,11 +109,11 @@ CodecError CCodec_DXTC::CompressRGBBlock(CMP_BYTE rgbBlock[BLOCK_SIZE_4X4X4], CM
 
         double fError3 = CompRGBBlock((DWORD*)rgbBlock, BLOCK_SIZE_4X4, RG, GG, BG, nEndpoints[0], nIndices[0], 3, m_bUseSSE2, m_b3DRefinement, m_nRefinementSteps, pfChannelWeights, bDXT1UseAlpha, nDXT1AlphaThreshold);
         double fError4 = (fError3 == 0.0) ? FLT_MAX : CompRGBBlock((DWORD*)rgbBlock, BLOCK_SIZE_4X4, RG, GG, BG, nEndpoints[1], nIndices[1], 4, m_bUseSSE2, m_b3DRefinement, m_nRefinementSteps, pfChannelWeights, bDXT1UseAlpha, nDXT1AlphaThreshold);
-        
+
         unsigned int nMethod = (fError3 <= fError4) ? 0 : 1;
         unsigned int c0 = ConstructColour((nEndpoints[nMethod][RC][0] >> (8-RG)), (nEndpoints[nMethod][GC][0] >> (8-GG)), (nEndpoints[nMethod][BC][0] >> (8-BG)));
         unsigned int c1 = ConstructColour((nEndpoints[nMethod][RC][1] >> (8-RG)), (nEndpoints[nMethod][GC][1] >> (8-GG)), (nEndpoints[nMethod][BC][1] >> (8-BG)));
-        if(nMethod == 1 && c0 <= c1 || nMethod == 0 && c0 > c1)
+        if(( nMethod == 1 && c0 <= c1 ) || ( nMethod == 0 && c0 > c1 ))
             compressedBlock[0] = c1 | (c0<<16);
         else
             compressedBlock[0] = c0 | (c1<<16);
@@ -140,7 +140,7 @@ CodecError CCodec_DXTC::CompressRGBBlock(CMP_BYTE rgbBlock[BLOCK_SIZE_4X4X4], CM
         for(int i=0; i<16; i++)
             compressedBlock[1] |= (nIndices[i] << (2*i));
     }
-    
+
     return CE_OK;
 }
 
@@ -162,7 +162,7 @@ CodecError CCodec_DXTC::CompressRGBBlock_SuperFast(CMP_BYTE rgbBlock[BLOCK_SIZE_
 {
     #if defined(USE_SSE2)
 #ifdef _WIN64
-    // todo: fix sse2 asm function 
+    // todo: fix sse2 asm function
     DXTCV11CompressBlockSSE2((DWORD*)rgbBlock, compressedBlock);
 #else
     DXTCV11CompressBlockSSEMinimal((DWORD*)rgbBlock, compressedBlock);
@@ -237,7 +237,7 @@ CodecError CCodec_DXTC::CompressRGBABlock(CODECFLOAT rgbaBlock[BLOCK_SIZE_4X4X4]
     CodecError err = CompressAlphaBlock(alphaBlock, &compressedBlock[DXTC_OFFSET_ALPHA]);
     if(err != CE_OK)
         return err;
-    
+
     return CompressRGBBlock(rgbaBlock, &compressedBlock[DXTC_OFFSET_RGB], pfChannelWeights, false);
 }
 
@@ -278,7 +278,7 @@ CodecError CCodec_DXTC::CompressRGBBlock(CODECFLOAT rgbBlock[BLOCK_SIZE_4X4X4], 
         unsigned int nMethod = (fError3 <= fError4) ? 0 : 1;
         unsigned int c0 = ConstructColour((nEndpoints[nMethod][RC][0] >> (8-RG)), (nEndpoints[nMethod][GC][0] >> (8-GG)), (nEndpoints[nMethod][BC][0] >> (8-BG)));
         unsigned int c1 = ConstructColour((nEndpoints[nMethod][RC][1] >> (8-RG)), (nEndpoints[nMethod][GC][1] >> (8-GG)), (nEndpoints[nMethod][BC][1] >> (8-BG)));
-        if(nMethod == 1 && c0 <= c1 || nMethod == 0 && c0 > c1)
+        if(( nMethod == 1 && c0 <= c1 ) || ( nMethod == 0 && c0 > c1 ))
             compressedBlock[0] = c1 | (c0<<16);
         else
             compressedBlock[0] = c0 | (c1<<16);
@@ -311,10 +311,10 @@ CodecError CCodec_DXTC::CompressRGBBlock(CODECFLOAT rgbBlock[BLOCK_SIZE_4X4X4], 
 void CCodec_DXTC::DecompressRGBABlock(CODECFLOAT rgbaBlock[BLOCK_SIZE_4X4X4], CMP_DWORD compressedBlock[4])
 {
     CODECFLOAT alphaBlock[BLOCK_SIZE_4X4];
-    
+
     DecompressAlphaBlock(alphaBlock, &compressedBlock[DXTC_OFFSET_ALPHA]);
     DecompressRGBBlock(rgbaBlock, &compressedBlock[DXTC_OFFSET_RGB], false);
-    
+
     for(CMP_DWORD i = 0; i < 16; i++)
         rgbaBlock[(i * 4) + RGBA32F_OFFSET_A] = alphaBlock[i];
 }
@@ -322,10 +322,10 @@ void CCodec_DXTC::DecompressRGBABlock(CODECFLOAT rgbaBlock[BLOCK_SIZE_4X4X4], CM
 void CCodec_DXTC::DecompressRGBABlock_ExplicitAlpha(CODECFLOAT rgbaBlock[BLOCK_SIZE_4X4X4], CMP_DWORD compressedBlock[4])
 {
     CODECFLOAT alphaBlock[BLOCK_SIZE_4X4];
-    
+
     DecompressExplicitAlphaBlock(alphaBlock, &compressedBlock[DXTC_OFFSET_ALPHA]);
     DecompressRGBBlock(rgbaBlock, &compressedBlock[DXTC_OFFSET_RGB], false);
-    
+
     for(CMP_DWORD i = 0; i < 16; i++)
         rgbaBlock[(i * 4) + RGBA32F_OFFSET_A] = alphaBlock[i];
 }
@@ -363,7 +363,7 @@ void CCodec_DXTC::DecompressRGBBlock(CMP_BYTE rgbBlock[BLOCK_SIZE_4X4X4], CMP_DW
         g1 = ((n1 & 0x07e0) >> 3);
         b1 = ((n1 & 0x001f) << 3);
     }
-    
+
     // Apply the lower bit replication to give full dynamic range
     r0 += (r0>>5); r1 += (r1>>5);
     g0 += (g0>>6); g1 += (g1>>6);
@@ -604,7 +604,7 @@ CODECFLOAT* CCodec_DXTC::CalculateColourWeightings(CODECFLOAT block[BLOCK_SIZE_4
 
         for(CMP_DWORD k=0; k<BLOCK_SIZE_4X4; k++)
         {
-            *block++;
+            block++;
             medianB += *block++;
             medianG += *block++;
             medianR += *block++;

--- a/Compressonator/Source/Codec/ETC/Codec_ETC2_RGB.cpp
+++ b/Compressonator/Source/Codec/ETC/Codec_ETC2_RGB.cpp
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -26,7 +26,9 @@
 //  Description: implementation of the CCodec_ETC class
 //
 //////////////////////////////////////////////////////////////////////////////
+#ifdef _MSC_VER
 #pragma warning(disable:4100)
+#endif //_MSC_VER
 
 #include "Common.h"
 #include "Codec_ETC2_RGB.h"

--- a/Compressonator/Source/Codec/ETC/Codec_ETC_RGB.cpp
+++ b/Compressonator/Source/Codec/ETC/Codec_ETC_RGB.cpp
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -26,7 +26,9 @@
 //  Description: implementation of the CCodec_ETC class
 //
 //////////////////////////////////////////////////////////////////////////////
+#ifdef _MSC_VER
 #pragma warning(disable:4100)
+#endif //_MSC_VER
 
 #include "Common.h"
 #include "Codec_ETC_RGB.h"

--- a/Compressonator/Source/Codec/ETC/etc.cpp
+++ b/Compressonator/Source/Codec/ETC/etc.cpp
@@ -10,10 +10,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -24,18 +24,20 @@
 //
 
 
+#ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable:4100)
 #pragma warning(disable:4189)
 #pragma warning(disable:4244)
 #pragma warning(disable:4514)
+#endif //_MSC_VER
 
 #if 1
     // Set SPEED to FAST or MEDIUM
     #define MEDIUM      2
     #define FAST        3
     #define SPEED       FAST
-    
+
     #if SPEED != FAST && SPEED != MEDIUM
         #error SPEED must be set to FAST or MEDIUM!
     #endif
@@ -56,7 +58,7 @@ void atiEncodeRGBBlockETC(
     unsigned int compressed1, compressed2;    // Used to interface C's (unsigned int*) to C++'s &(unsigned int)
 #if SPEED == FAST
     unsigned char tmp[4*4*3];                // Required just by "fast" ETC function
-    
+
     compressBlockDiffFlipFastPerceptual( (uint8 *)pPixels, (uint8 *)tmp, 4, 4, 0, 0, compressed1, compressed2 );
 #elif SPEED == MEDIUM
     compressBlockDiffFlipMediumPerceptual( (uint8 *)pPixels, 4, 4, 0, 0, compressed1, compressed2 );
@@ -81,4 +83,6 @@ void atiDecodeRGBBlockETC(
     decompressBlockDiffFlip( compressed1, compressed2, (uint8*)pPixels, 4, 4, 0, 0);
 }
 
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif //_MSC_VER

--- a/Compressonator/Source/Codec/ETC/etcpack/etcimage.cxx
+++ b/Compressonator/Source/Codec/ETC/etcpack/etcimage.cxx
@@ -1,7 +1,7 @@
 //// etcpack v2.74
-//// 
-//// NO WARRANTY 
-//// 
+////
+//// NO WARRANTY
+////
 //// BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE THE PROGRAM IS PROVIDED
 //// "AS IS". ERICSSON MAKES NO REPRESENTATIONS OF ANY KIND, EXTENDS NO
 //// WARRANTIES OR CONDITIONS OF ANY KIND; EITHER EXPRESS, IMPLIED OR
@@ -18,7 +18,7 @@
 //// TO YOUR SOLE RESPONSIBILITY TO MAKE SUCH DETERMINATION AND ACQUIRE
 //// SUCH LICENSES AS MAY BE NECESSARY WITH RESPECT TO PATENTS, COPYRIGHT
 //// AND OTHER INTELLECTUAL PROPERTY OF THIRD PARTIES.
-//// 
+////
 //// FOR THE AVOIDANCE OF DOUBT THE PROGRAM (I) IS NOT LICENSED FOR; (II)
 //// IS NOT DESIGNED FOR OR INTENDED FOR; AND (III) MAY NOT BE USED FOR;
 //// ANY MISSION CRITICAL APPLICATIONS SUCH AS, BUT NOT LIMITED TO
@@ -30,7 +30,7 @@
 //// DAMAGE. YOUR RIGHTS UNDER THIS LICENSE WILL TERMINATE AUTOMATICALLY
 //// AND IMMEDIATELY WITHOUT NOTICE IF YOU FAIL TO COMPLY WITH THIS
 //// PARAGRAPH.
-//// 
+////
 //// IN NO EVENT WILL ERICSSON, BE LIABLE FOR ANY DAMAGES WHATSOEVER,
 //// INCLUDING BUT NOT LIMITED TO PERSONAL INJURY, ANY GENERAL, SPECIAL,
 //// INDIRECT, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF OR IN
@@ -41,19 +41,21 @@
 //// THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS) REGARDLESS OF THE
 //// THEORY OF LIABILITY (CONTRACT, TORT OR OTHERWISE), EVEN IF SUCH HOLDER
 //// OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-//// 
+////
 //// (C) Ericsson AB 2005-2013. All Rights Reserved.
-//// 
+////
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include "etcimage.h"
 
+#ifdef _MSC_VER
 // Remove warnings for unsafe functions such as strcpy
 #pragma warning(disable : 4996)
 // Remove warnings for conversions between different time variables
 #pragma warning(disable : 4244)
+#endif //_MSC_VER
 
 // Removes comments in a .ppm file
 // (i.e., lines starting with #)
@@ -91,14 +93,14 @@ void removeSpaces(FILE *f1)
 // and returns the image in pixels.
 //
 // The header must look like this:
-// 
+//
 // P6
 // # Comments (not necessary)
 // width height
 // 255
 //
 // after that follows RGBRGBRGB...
-// 
+//
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 bool fReadPPM(char *filename, int &width, int &height, unsigned char *&pixels, int targetbitrate)
 {
@@ -126,7 +128,7 @@ bool fReadPPM(char *filename, int &width, int &height, unsigned char *&pixels, i
         removeSpaces(f1);
         removeComments(f1);
         removeSpaces(f1);
-        
+
         fscanf(f1, "%d %d", &width, &height);
         if( width<=0 || height <=0)
         {
@@ -156,7 +158,7 @@ bool fReadPPM(char *filename, int &width, int &height, unsigned char *&pixels, i
         char c = 0;
         while(c != '\n')
             fscanf(f1, "%c", &c);
-        
+
         unsigned char* readbuffer = (unsigned char*) malloc(3*width*height*bitrate/8);
         if(!readbuffer)
         {
@@ -178,33 +180,33 @@ bool fReadPPM(char *filename, int &width, int &height, unsigned char *&pixels, i
         //now, convert it to the target bitrate
         if(targetbitrate==bitrate)
             pixels=readbuffer;
-        else 
+        else
         {
             pixels = (unsigned char*) malloc(3*width*height*targetbitrate/8);
-            if(targetbitrate<bitrate) 
+            if(targetbitrate<bitrate)
             {
                 //cut least significant bits to go from 16 -> 8 bits..
                 printf("converting 16 bit input to 8 bits\n");
-                for(int x=0; x<width; x++) 
+                for(int x=0; x<width; x++)
                 {
-                    for(int y=0; y<height; y++) 
+                    for(int y=0; y<height; y++)
                     {
-                        for(int c1=0; c1<3; c1++) 
+                        for(int c1=0; c1<3; c1++)
                         {
                             pixels[3*(x+y*width)+c1]=readbuffer[6*(x+y*width)+2*c1];
                         }
                     }
                 }
             }
-            else 
+            else
             {
                 //replicate 8 bits to go from 8 -> 16 bits...
                 printf("converting 8 bit input to 16 bits\n");
-                for(int x=0; x<width; x++) 
+                for(int x=0; x<width; x++)
                 {
-                    for(int y=0; y<height; y++) 
+                    for(int y=0; y<height; y++)
                     {
-                        for(int c1=0; c1<3; c1++) 
+                        for(int c1=0; c1<3; c1++)
                         {
                             pixels[6*(x+y*width)+2*c1]=readbuffer[3*(x+y*width)+c1];
                             pixels[6*(x+y*width)+2*c1+1]=readbuffer[3*(x+y*width)+c1];
@@ -224,9 +226,9 @@ bool fReadPPM(char *filename, int &width, int &height, unsigned char *&pixels, i
     }
 }
 
-// Write PPM 
+// Write PPM
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-bool fWritePPM(char *filename, int width, int height, unsigned char *pixels, int bitrate, bool reverse_y)
+bool fWritePPM(const char *filename, int width, int height, unsigned char *pixels, int bitrate, bool reverse_y)
 {
     FILE *fsave;
     fsave = fopen(filename, "wb");
@@ -239,7 +241,7 @@ bool fWritePPM(char *filename, int width, int height, unsigned char *pixels, int
         for(q = 0; q< height; q++)
         {
             unsigned char *adr;
-            if(reverse_y) 
+            if(reverse_y)
                 adr = pixels+3*width*(height-1-q)*fac;
             else
                 adr = pixels+3*width*q*fac;
@@ -270,7 +272,7 @@ bool fWritePGM(char *filename, int width, int height, unsigned char *pixels,bool
           width*=2; //ugly way of doubling the number of bytes to write, since we write one line at a time..
       for(q=0;q<height;q++)
       {
-         unsigned char *adr;     
+         unsigned char *adr;
          if(reverse_y) adr=pixels+width*(height-1-q);
          else adr=pixels+width*q;
          fwrite(adr,width,1,f);
@@ -348,9 +350,9 @@ int fReadPGM(char *filename, int &width, int &height, unsigned char *&pixels, in
         {
             printf("Error: could not allocate memory for the pixels of the texture. File: %s\n",filename);
             fclose(f);
-            return 0;     
+            return 0;
         }
-      
+
         if(fread(pixels,width*height*bitdepth/8,1,f)!=1)
         {
             printf("Error: could not read %d bytes of pixel info. File: %s\n",width*height*bitdepth/8,filename);
@@ -360,21 +362,21 @@ int fReadPGM(char *filename, int &width, int &height, unsigned char *&pixels, in
         }
         fclose(f);
         printf("read %d-bit alpha channel",bitdepth);
-        if(bitdepth!=wantedBitDepth) 
+        if(bitdepth!=wantedBitDepth)
         {
             printf(", converting to %d-bit!",wantedBitDepth);
             unsigned char* newpixels = (unsigned char*)malloc(width*height*wantedBitDepth/8);
-            for(int x=0; x<width; x++) 
+            for(int x=0; x<width; x++)
             {
-                for(int y=0; y<height; y++) 
+                for(int y=0; y<height; y++)
                 {
-                    if(bitdepth<wantedBitDepth) 
+                    if(bitdepth<wantedBitDepth)
                     {
                         //do bit-replication to get 2-bytes per pixel
                         newpixels[2*(x+y*width)]=pixels[x+y*width];
                         newpixels[2*(x+y*width)+1]=pixels[x+y*width];
                     }
-                    else 
+                    else
                     {
                         //simply truncate the extra data..
                         newpixels[(x+y*width)]=pixels[2*(x+y*width)];
@@ -391,7 +393,7 @@ int fReadPGM(char *filename, int &width, int &height, unsigned char *&pixels, in
     {
         printf("Error: could not open %s.\n",filename);
         return 0;
-    }   
+    }
 }
 /* writes a .tga file from two arrays --- one RGB array and one alpha-array */
 /* */
@@ -411,7 +413,7 @@ bool fWriteTGAfromRGBandA(char *filename, int width, int height, unsigned char *
     myByteVal = 0;
     fwrite(&myByteVal, 1, 1, f1); // ID field (0)
     fwrite(&myByteVal, 1, 1, f1); // Palette? (no=0)
-    myByteVal = 2; 
+    myByteVal = 2;
     fwrite(&myByteVal, 1, 1, f1); // Image type (rgb=2)
     myShortVal = 0;
     fwrite(&myShortVal, 2, 1, f1); // Palette stuff... 0
@@ -430,7 +432,7 @@ bool fWriteTGAfromRGBandA(char *filename, int width, int height, unsigned char *
     fwrite(&myByteVal, 1, 1, f1); // Bits per pixel = 32
     myByteVal = 8;
     fwrite(&myByteVal, 1, 1, f1); // flip bits = 8
-   
+
     // Write pixels in BGRA format
     if(reverse_y)
     {

--- a/Compressonator/Source/Codec/ETC/etcpack/etcimage.cxx
+++ b/Compressonator/Source/Codec/ETC/etcpack/etcimage.cxx
@@ -102,7 +102,7 @@ void removeSpaces(FILE *f1)
 // after that follows RGBRGBRGB...
 //
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-bool fReadPPM(char *filename, int &width, int &height, unsigned char *&pixels, int targetbitrate)
+bool fReadPPM(const char *filename, int &width, int &height, unsigned char *&pixels, int targetbitrate)
 {
     FILE *f1;
     int maximum;
@@ -259,7 +259,7 @@ bool fWritePPM(const char *filename, int width, int height, unsigned char *pixel
 
 // WritePGM
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-bool fWritePGM(char *filename, int width, int height, unsigned char *pixels,bool reverse_y, int bitdepth)
+bool fWritePGM(const char *filename, int width, int height, unsigned char *pixels,bool reverse_y, int bitdepth)
 {
    FILE *f;
    f=fopen(filename,"wb");
@@ -298,7 +298,7 @@ bool fWritePGM(char *filename, int width, int height, unsigned char *pixels,bool
  * then follows RGBRGBRGBRGBRGB...
  */
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-int fReadPGM(char *filename, int &width, int &height, unsigned char *&pixels, int wantedBitDepth)
+int fReadPGM(const char *filename, int &width, int &height, unsigned char *&pixels, int wantedBitDepth)
 {
     FILE *f;
     int colres;
@@ -398,7 +398,7 @@ int fReadPGM(char *filename, int &width, int &height, unsigned char *&pixels, in
 /* writes a .tga file from two arrays --- one RGB array and one alpha-array */
 /* */
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2012. All Rights Reserved.
-bool fWriteTGAfromRGBandA(char *filename, int width, int height, unsigned char *pixelsRGB, unsigned char *pixelsA, bool reverse_y)
+bool fWriteTGAfromRGBandA(const char *filename, int width, int height, unsigned char *pixelsRGB, unsigned char *pixelsA, bool reverse_y)
 {
     FILE *f1;
 

--- a/Compressonator/Source/Codec/ETC/etcpack/etcpack.cxx
+++ b/Compressonator/Source/Codec/ETC/etcpack/etcpack.cxx
@@ -1,7 +1,7 @@
 //// etcpack v2.74
-//// 
-//// NO WARRANTY 
-//// 
+////
+//// NO WARRANTY
+////
 //// BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE THE PROGRAM IS PROVIDED
 //// "AS IS". ERICSSON MAKES NO REPRESENTATIONS OF ANY KIND, EXTENDS NO
 //// WARRANTIES OR CONDITIONS OF ANY KIND; EITHER EXPRESS, IMPLIED OR
@@ -18,7 +18,7 @@
 //// TO YOUR SOLE RESPONSIBILITY TO MAKE SUCH DETERMINATION AND ACQUIRE
 //// SUCH LICENSES AS MAY BE NECESSARY WITH RESPECT TO PATENTS, COPYRIGHT
 //// AND OTHER INTELLECTUAL PROPERTY OF THIRD PARTIES.
-//// 
+////
 //// FOR THE AVOIDANCE OF DOUBT THE PROGRAM (I) IS NOT LICENSED FOR; (II)
 //// IS NOT DESIGNED FOR OR INTENDED FOR; AND (III) MAY NOT BE USED FOR;
 //// ANY MISSION CRITICAL APPLICATIONS SUCH AS, BUT NOT LIMITED TO
@@ -30,7 +30,7 @@
 //// DAMAGE. YOUR RIGHTS UNDER THIS LICENSE WILL TERMINATE AUTOMATICALLY
 //// AND IMMEDIATELY WITHOUT NOTICE IF YOU FAIL TO COMPLY WITH THIS
 //// PARAGRAPH.
-//// 
+////
 //// IN NO EVENT WILL ERICSSON, BE LIABLE FOR ANY DAMAGES WHATSOEVER,
 //// INCLUDING BUT NOT LIMITED TO PERSONAL INJURY, ANY GENERAL, SPECIAL,
 //// INDIRECT, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF OR IN
@@ -41,14 +41,14 @@
 //// THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS) REGARDLESS OF THE
 //// THEORY OF LIABILITY (CONTRACT, TORT OR OTHERWISE), EVEN IF SUCH HOLDER
 //// OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-//// 
+////
 //// (C) Ericsson AB 2005-2013. All Rights Reserved.
-//// 
+////
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <math.h> 
+#include <math.h>
 #include <time.h>
 #include <sys/timeb.h>
 #include "etcimage.h"
@@ -82,7 +82,7 @@ uint8 getbit(uint8 input, int frompos, int topos);
 int clamp(int val);
 void decompressBlockAlpha(uint8* data,uint8* img,int width,int height,int ix,int iy);
 uint16 get16bits11bits(int base, int table, int mul, int index);
-void decompressBlockAlpha16bit(uint8* data,uint8* img,int width,int height,int ix,int iy); 
+void decompressBlockAlpha16bit(uint8* data,uint8* img,int width,int height,int ix,int iy);
 int16 get16bits11signed(int base, int table, int mul, int index);
 void setupAlphaTable();
 
@@ -94,18 +94,20 @@ void setupAlphaTable();
 // can then be removed.
 #define EXHAUSTIVE_CODE_ACTIVE 1
 
+#ifdef _MSC_VER
 // Remove warnings for unsafe functions such as strcpy
 #pragma warning(disable : 4996)
 // Remove warnings for conversions between different time variables
 #pragma warning(disable : 4244)
 // Remove warnings for negative or too big shifts
 //#pragma warning(disable : 4293)
- 
+#endif //_MSC_VER
+
 #define CLAMP(ll,x,ul) (((x)<(ll)) ? (ll) : (((x)>(ul)) ? (ul) : (x)))
 // The below code works as CLAMP(0, x, 255) if x < 255
 #define CLAMP_LEFT_ZERO(x) ((~(((int)(x))>>31))&(x))
 // The below code works as CLAMP(0, x, 255) if x is in [0,511]
-#define CLAMP_RIGHT_255(x) (((( ((((int)(x))<<23)>>31)  ))|(x))&0x000000ff)   
+#define CLAMP_RIGHT_255(x) (((( ((((int)(x))<<23)>>31)  ))|(x))&0x000000ff)
 
 #define SQUARE(x) ((x)*(x))
 #define JAS_ROUND(x) (((x) < 0.0 ) ? ((int)((x)-0.5)) : ((int)((x)+0.5)))
@@ -161,7 +163,7 @@ static uint8 table58H[8] = {3,6,11,16,23,32,41,64};  // 3-bit table for the 58 b
 uint8 weight[3] = {1,1,1};            // Color weight
 
 // Enums
-static enum{PATTERN_H = 0, 
+static enum{PATTERN_H = 0,
             PATTERN_T = 1} E_PATTERNS;
 
 static enum { MODE_ETC1, MODE_THUMB_T, MODE_THUMB_H, MODE_PLANAR } E_MODEs;
@@ -179,14 +181,14 @@ static enum { MODE_ETC1, MODE_THUMB_T, MODE_THUMB_H, MODE_PLANAR } E_MODEs;
 // GL_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2     0x9277
 // GL_COMPRESSED_RGBA8_ETC2_EAC                     0x9278
 // GL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC              0x9279
-// 
-// The older codec ETC1 is not included in the package 
+//
+// The older codec ETC1 is not included in the package
 // GL_ETC1_RGB8_OES                                 0x8d64
 // but since ETC2 is backwards compatible an ETC1 texture can
 // be decoded using the RGB8_ETC2 enum (0x9274)
-// 
+//
 // In a PKM-file, the codecs are stored using the following identifiers
-// 
+//
 // identifier                         value               codec
 // --------------------------------------------------------------------
 // ETC1_RGB_NO_MIPMAPS                  0                 GL_ETC1_RGB8_OES
@@ -201,9 +203,9 @@ static enum { MODE_ETC1, MODE_THUMB_T, MODE_THUMB_H, MODE_PLANAR } E_MODEs;
 //
 // In the code, the identifiers are not always used strictly. For instance, the
 // identifier ETC2PACKAGE_R_NO_MIPMAPS is sometimes used for both the unsigned
-// (GL_COMPRESSED_R11_EAC) and signed (GL_COMPRESSED_SIGNED_R11_EAC) version of 
+// (GL_COMPRESSED_R11_EAC) and signed (GL_COMPRESSED_SIGNED_R11_EAC) version of
 // the codec.
-// 
+//
 static enum{ETC1_RGB_NO_MIPMAPS,ETC2PACKAGE_RGB_NO_MIPMAPS,ETC2PACKAGE_RGBA_NO_MIPMAPS_OLD,ETC2PACKAGE_RGBA_NO_MIPMAPS,ETC2PACKAGE_RGBA1_NO_MIPMAPS,ETC2PACKAGE_R_NO_MIPMAPS,ETC2PACKAGE_RG_NO_MIPMAPS,ETC2PACKAGE_R_SIGNED_NO_MIPMAPS,ETC2PACKAGE_RG_SIGNED_NO_MIPMAPS,ETC2PACKAGE_sRGB_NO_MIPMAPS,ETC2PACKAGE_sRGBA_NO_MIPMAPS,ETC2PACKAGE_sRGBA1_NO_MIPMAPS} E_ETCn;
 static enum {MODE_COMPRESS, MODE_UNCOMPRESS, MODE_PSNR} E_1;
 static enum {SPEED_SLOW, SPEED_FAST, SPEED_MEDIUM} E_2;
@@ -239,7 +241,7 @@ typedef struct KTX_header_t
     unsigned int numberOfFaces;
     unsigned int numberOfMipmapLevels;
     unsigned int bytesOfKeyValueData;
-} 
+}
 KTX_header;
 #define KTX_IDENTIFIER_REF  { 0xAB, 0x4B, 0x54, 0x58, 0x20, 0x31, 0x31, 0xBB, 0x0D, 0x0A, 0x1A, 0x0A }
 
@@ -266,18 +268,18 @@ static enum {GL_R=0x1903,GL_RG=0x8227,GL_RGB=0x1907,GL_RGBA=0x1908} E_5;
 int ktx_identifier[] = KTX_IDENTIFIER_REF;
 
 
-//converts indices from  |a0|a1|e0|e1|i0|i1|m0|m1|b0|b1|f0|f1|j0|j1|n0|n1|c0|c1|g0|g1|k0|k1|o0|o1|d0|d1|h0|h1|l0|l1|p0|p1| previously used by T- and H-modes 
+//converts indices from  |a0|a1|e0|e1|i0|i1|m0|m1|b0|b1|f0|f1|j0|j1|n0|n1|c0|c1|g0|g1|k0|k1|o0|o1|d0|d1|h0|h1|l0|l1|p0|p1| previously used by T- and H-modes
 //                         into  |p0|o0|n0|m0|l0|k0|j0|i0|h0|g0|f0|e0|d0|c0|b0|a0|p1|o1|n1|m1|l1|k1|j1|i1|h1|g1|f1|e1|d1|c1|b1|a1| which should be used for all modes.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-int indexConversion(int pixelIndices) 
+int indexConversion(int pixelIndices)
 {
     int correctIndices = 0;
     int LSB[4][4];
     int MSB[4][4];
     int shift=0;
-    for(int y=3; y>=0; y--) 
+    for(int y=3; y>=0; y--)
     {
-        for(int x=3; x>=0; x--) 
+        for(int x=3; x>=0; x--)
         {
             LSB[x][y] = (pixelIndices>>shift)&1;
             shift++;
@@ -286,9 +288,9 @@ int indexConversion(int pixelIndices)
         }
     }
     shift=0;
-    for(int x=0; x<4; x++) 
+    for(int x=0; x<4; x++)
     {
-        for(int y=0; y<4; y++) 
+        for(int y=0; y<4; y++)
         {
             correctIndices|=(LSB[x][y]<<shift);
             correctIndices|=(MSB[x][y]<<(16+shift));
@@ -300,7 +302,7 @@ int indexConversion(int pixelIndices)
 
 // Tests if a file exists.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-bool fileExist(char *filename)
+bool fileExist(const char *filename)
 {
     FILE *f=NULL;
     if((f=fopen(filename,"rb"))!=NULL)
@@ -337,7 +339,7 @@ bool expandToWidthDivByFour(uint8 *&img, int width, int height, int &expandedwid
             for(xx = 0; xx < width; xx++)
             {
                 //we have 3*bitrate/8 bytes for each pixel..
-                for(int i=0; i<3*bitrate/8; i++) 
+                for(int i=0; i<3*bitrate/8; i++)
                 {
                     newimg[(yy * expandedwidth+ xx)*3*bitrate/8 + i] = img[(yy * width+xx)*3*bitrate/8 + i];
 
@@ -351,7 +353,7 @@ bool expandToWidthDivByFour(uint8 *&img, int width, int height, int &expandedwid
         {
             for(xx = width; xx < expandedwidth; xx++)
             {
-                for(int i=0; i<3*bitrate/8; i++) 
+                for(int i=0; i<3*bitrate/8; i++)
                 {
                     newimg[(yy * expandedwidth+xx)*3*bitrate/8 + i] = img[(yy * width+(width-1))*3*bitrate/8 + i];
                 }
@@ -397,7 +399,7 @@ bool expandToHeightDivByFour(uint8 *&img, int width, int height, int &expandedwi
             printf("Could not allocate memory to expand height\n");
             return false;
         }
-        
+
         // First copy image. No need to reformat data.
 
         for(xx = 0; xx<3*width*height*bitrate/8; xx++)
@@ -409,7 +411,7 @@ bool expandToHeightDivByFour(uint8 *&img, int width, int height, int &expandedwi
         {
             for(xx = 0; xx<width; xx++)
             {
-                for(int i=0; i<3*bitrate/8; i++) 
+                for(int i=0; i<3*bitrate/8; i++)
                 {
                     newimg[(yy*width+xx)*3*bitrate/8 + i] = img[((height-1)*width+xx)*3*bitrate/8 + i];
                 }
@@ -444,7 +446,7 @@ int find_pos_of_extension(char *src)
         if(src[q]=='.') break;
         q--;
     }
-    if(q<0) 
+    if(q<0)
         return -1;
     else
         return q;
@@ -468,20 +470,20 @@ bool readSrcFile(char *filename,uint8 *&img,int &width,int &height, int &expande
     }
 
     int q = find_pos_of_extension(filename);
-    if(!strcmp(&filename[q],".ppm")) 
+    if(!strcmp(&filename[q],".ppm"))
     {
-        // Already a .ppm file. Just copy. 
+        // Already a .ppm file. Just copy.
         sprintf(str,"copy %s tmp.ppm \n", filename);
         printf("Copying source %s file to tmp.ppm\n", filename);
     }
     else
     {
-        // Converting from other format to .ppm 
-        // 
+        // Converting from other format to .ppm
+        //
         // Use your favorite command line image converter program,
         // for instance Image Magick. Just make sure the syntax can
         // be written as below:
-        // 
+        //
         // C:\imconv source.jpg dest.ppm
         //
         sprintf(str,"imconv %s tmp.ppm\n", filename);
@@ -543,7 +545,7 @@ bool readSrcFile(char *filename,uint8 *&img,int &width,int &height, int &expande
     //else
     //{
         printf("Could not read tmp.ppm file\n");
-        exit(1);    
+        exit(1);
     //}
    // return false;
 
@@ -567,20 +569,20 @@ bool readSrcFileNoExpand(char *filename,uint8 *&img,int &width,int &height)
 
 
     int q = find_pos_of_extension(filename);
-    if(!strcmp(&filename[q],".ppm")) 
+    if(!strcmp(&filename[q],".ppm"))
     {
-        // Already a .ppm file. Just copy. 
+        // Already a .ppm file. Just copy.
         sprintf(str,"copy %s tmp.ppm \n", filename);
         printf("Copying source %s file to tmp.ppm\n", filename);
     }
     else
     {
-        // Converting from other format to .ppm 
-        // 
+        // Converting from other format to .ppm
+        //
         // Use your favorite command line image converter program,
         // for instance Image Magick. Just make sure the syntax can
         // be written as below:
-        // 
+        //
         // C:\imconv source.jpg dest.ppm
         //
         sprintf(str,"imconv %s tmp.ppm\n", filename);
@@ -608,88 +610,88 @@ void readArguments(int argc,char *argv[],char* src,char *dst)
 
     //new code!! do this in a more nicer way!
     bool srcfound=false,dstfound=false;
-    for(int i=1; i<argc; i++) 
+    for(int i=1; i<argc; i++)
     {
         //loop through the arguments!
         //first check for flags..
-        if(argv[i][0]=='-') 
+        if(argv[i][0]=='-')
         {
-            if(i==argc-1) 
+            if(i==argc-1)
             {
                 printf("flag missing argument: !\n");
                 exit(1);
             }
             //handle speed flag
-            if(!strcmp(argv[i],"-s"))  
+            if(!strcmp(argv[i],"-s"))
             {
                 // We have argument -s. Now check for slow, medium or fast.
-                if(!strcmp(argv[i+1],"slow")) 
+                if(!strcmp(argv[i+1],"slow"))
                     speed = SPEED_SLOW;
-                else if(!strcmp(argv[i+1],"medium")) 
+                else if(!strcmp(argv[i+1],"medium"))
                     speed = SPEED_MEDIUM;
-                else if(!strcmp(argv[i+1],"fast")) 
+                else if(!strcmp(argv[i+1],"fast"))
                     speed = SPEED_FAST;
-                else 
+                else
                 {
                     printf("Error: %s not part of flag %s\n",argv[i+1], argv[i]);
                     exit(1);
                 }
             }
             //handle verbose flag
-            else if(!strcmp(argv[i],"-v"))  
+            else if(!strcmp(argv[i],"-v"))
             {
                 // We have argument -s. Now check for slow, medium or fast.
-                if(!strcmp(argv[i+1],"off")) 
+                if(!strcmp(argv[i+1],"off"))
                     verbose = false;
-                else if(!strcmp(argv[i+1],"on")) 
+                else if(!strcmp(argv[i+1],"on"))
                     verbose = true;
-                else 
+                else
                 {
                     printf("Error: %s not part of flag %s\n",argv[i+1], argv[i]);
                     exit(1);
                 }
             }
             //error metric flag
-            else if(!strcmp(argv[i],"-e"))     
+            else if(!strcmp(argv[i],"-e"))
             {
                 // We have argument -e. Now check for perceptual or nonperceptual
-                if(!strcmp(argv[i+1],"perceptual")) 
+                if(!strcmp(argv[i+1],"perceptual"))
                     metric = METRIC_PERCEPTUAL;
-                else if(!strcmp(argv[i+1],"nonperceptual")) 
+                else if(!strcmp(argv[i+1],"nonperceptual"))
                     metric = METRIC_NONPERCEPTUAL;
-                else 
+                else
                 {
                     printf("Error: %s not part of flag %s\n",argv[i+1], argv[i]);
                     exit(1);
                 }
             }
             //codec flag
-            else if(!strcmp(argv[i],"-c")) 
+            else if(!strcmp(argv[i],"-c"))
             {
                 // We have argument -c. Now check for perceptual or nonperceptual
                 if(!strcmp(argv[i+1],"etc") || !strcmp(argv[i+1],"etc1"))
                     codec = CODEC_ETC;
-                else if(!strcmp(argv[i+1],"etc2")) 
+                else if(!strcmp(argv[i+1],"etc2"))
                     codec = CODEC_ETC2;
-                else 
+                else
                 {
                     printf("Error: %s not part of flag %s\n",argv[i+1], argv[i]);
                     exit(1);
                 }
             }
             //format flag
-            else if(!strcmp(argv[i],"-f")) 
+            else if(!strcmp(argv[i],"-f"))
             {
                 if(!strcmp(argv[i+1],"R"))
                     format=ETC2PACKAGE_R_NO_MIPMAPS;
                 else if(!strcmp(argv[i+1],"RG"))
                     format=ETC2PACKAGE_RG_NO_MIPMAPS;
-                else if(!strcmp(argv[i+1],"R_signed")) 
+                else if(!strcmp(argv[i+1],"R_signed"))
                 {
                     format=ETC2PACKAGE_R_NO_MIPMAPS;
                     formatSigned=1;
                 }
-                else if(!strcmp(argv[i+1],"RG_signed")) 
+                else if(!strcmp(argv[i+1],"RG_signed"))
                 {
                     format=ETC2PACKAGE_RG_NO_MIPMAPS;
                     formatSigned=1;
@@ -706,18 +708,18 @@ void readArguments(int argc,char *argv[],char* src,char *dst)
                     format=ETC2PACKAGE_RGBA1_NO_MIPMAPS;
                 else if(!strcmp(argv[i+1],"sRGBA1"))
                     format=ETC2PACKAGE_sRGBA1_NO_MIPMAPS;
-                else 
+                else
                 {
                     printf("Error: %s not part of flag %s\n",argv[i+1], argv[i]);
                     exit(1);
                 }
             }
-            else if(!strcmp(argv[i],"-p")) 
+            else if(!strcmp(argv[i],"-p"))
             {
                 mode=MODE_PSNR;
                 i--; //ugly way of negating the increment of i done later because -p doesn't have an argument.
             }
-            else 
+            else
             {
                 printf("Error: cannot interpret flag %s %s\n",argv[i], argv[i+1]);
                 exit(1);
@@ -726,26 +728,26 @@ void readArguments(int argc,char *argv[],char* src,char *dst)
             i++;
         }
         //this isn't a flag, so must be src or dst
-        else 
+        else
         {
-            if(srcfound&&dstfound) 
+            if(srcfound&&dstfound)
             {
                 printf("too many arguments! expecting src, dst; found %s, %s, %s\n",src,dst,argv[i]);
                 exit(1);
             }
-            else if(srcfound) 
+            else if(srcfound)
             {
                 strcpy(dst,argv[i]);
                 dstfound=true;
             }
-            else 
+            else
             {
                 strcpy(src,argv[i]);
                 srcfound=true;
             }
         }
     }
-    if(!srcfound&&dstfound) 
+    if(!srcfound&&dstfound)
     {
         printf("too few arguments! expecting src, dst\n");
         exit(1);
@@ -754,7 +756,7 @@ void readArguments(int argc,char *argv[],char* src,char *dst)
         return;
     //check source/destination.. is this compression or decompression?
     q = find_pos_of_extension(src);
-    if(q<0) 
+    if(q<0)
     {
         printf("invalid source file: %s\n",src);
         exit(1);
@@ -762,14 +764,14 @@ void readArguments(int argc,char *argv[],char* src,char *dst)
 
     // If we have etcpack img.pkm img.any
 
-    if(!strncmp(&src[q],".pkm",4)) 
+    if(!strncmp(&src[q],".pkm",4))
     {
-        // First argument is .pkm. Decompress. 
+        // First argument is .pkm. Decompress.
         mode = MODE_UNCOMPRESS;            // uncompress from binary file format .pkm
     }
-    else if(!strncmp(&src[q],".ktx",4)) 
+    else if(!strncmp(&src[q],".ktx",4))
     {
-        // First argument is .ktx. Decompress. 
+        // First argument is .ktx. Decompress.
         mode = MODE_UNCOMPRESS;            // uncompress from binary file format .pkm
         ktxFile=true;
         printf("decompressing ktx\n");
@@ -778,31 +780,31 @@ void readArguments(int argc,char *argv[],char* src,char *dst)
     {
         // The first argument was not .pkm. The second argument must then be .pkm.
         q = find_pos_of_extension(dst);
-        if(q<0) 
+        if(q<0)
         {
             printf("invalid destination file: %s\n",src);
             exit(1);
         }
-        if(!strncmp(&dst[q],".pkm",4)) 
+        if(!strncmp(&dst[q],".pkm",4))
         {
-            // Second argument is .pkm. Compress. 
+            // Second argument is .pkm. Compress.
             mode = MODE_COMPRESS;            // compress to binary file format .pkm
         }
-        else if(!strncmp(&dst[q],".ktx",4)) 
+        else if(!strncmp(&dst[q],".ktx",4))
         {
-            // Second argument is .ktx. Compress. 
+            // Second argument is .ktx. Compress.
             ktxFile=true;
             mode = MODE_COMPRESS;            // compress to binary file format .pkm
             printf("compressing to ktx\n");
         }
-        else 
+        else
         {
             printf("source or destination must be a .pkm or .ktx file\n");
             exit(1);
         }
     }
     //do some sanity check stuff..
-    if(codec==CODEC_ETC&&format!=ETC2PACKAGE_RGB_NO_MIPMAPS) 
+    if(codec==CODEC_ETC&&format!=ETC2PACKAGE_RGB_NO_MIPMAPS)
     {
         printf("ETC1 codec only supports RGB format\n");
         exit(1);
@@ -839,7 +841,7 @@ bool readCompressParams(void)
     compressParams[13][0] =-106; compressParams[13][1] = -33; compressParams[13][2] = 33; compressParams[13][3] = 106;
     compressParams[14][0] =-183; compressParams[14][1] = -47; compressParams[14][2] = 47; compressParams[14][3] = 183;
     compressParams[15][0] =-183; compressParams[15][1] = -47; compressParams[15][2] = 47; compressParams[15][3] = 183;
-    
+
     return true;
 }
 
@@ -922,7 +924,7 @@ int compressBlockWithTable2x4(uint8 *img,int width,int height,int startx,int sta
                 approx[2]=CLAMP(0, avg_color[2]+compressParams[table][q],255);
 
                 // Here we just use equal weights to R, G and B. Although this will
-                // give visually worse results, it will give a better PSNR score. 
+                // give visually worse results, it will give a better PSNR score.
                 err=SQUARE(approx[0]-orig[0]) + SQUARE(approx[1]-orig[1]) + SQUARE(approx[2]-orig[2]);
                 if(err<min_error)
                 {
@@ -939,8 +941,8 @@ int compressBlockWithTable2x4(uint8 *img,int width,int height,int startx,int sta
             i++;
 
             // In order to simplify hardware, the table {-12, -4, 4, 12} is indexed {11, 10, 00, 01}
-            // so that first bit is sign bit and the other bit is size bit (4 or 12). 
-            // This means that we have to scramble the bits before storing them. 
+            // so that first bit is sign bit and the other bit is size bit (4 or 12).
+            // This means that we have to scramble the bits before storing them.
             sum_error+=min_error;
         }
     }
@@ -984,9 +986,9 @@ unsigned int compressBlockWithTable2x4percep1000(uint8 *img,int width,int height
                 approx[2]=CLAMP(0, avg_color[2]+compressParams[table][q],255);
 
                 // Here we just use equal weights to R, G and B. Although this will
-                // give visually worse results, it will give a better PSNR score. 
-                  err = (PERCEPTUAL_WEIGHT_R_SQUARED_TIMES1000*SQUARE((approx[0]-orig[0])) 
-                     + PERCEPTUAL_WEIGHT_G_SQUARED_TIMES1000*SQUARE((approx[1]-orig[1])) 
+                // give visually worse results, it will give a better PSNR score.
+                  err = (PERCEPTUAL_WEIGHT_R_SQUARED_TIMES1000*SQUARE((approx[0]-orig[0]))
+                     + PERCEPTUAL_WEIGHT_G_SQUARED_TIMES1000*SQUARE((approx[1]-orig[1]))
                      + PERCEPTUAL_WEIGHT_B_SQUARED_TIMES1000*SQUARE((approx[2]-orig[2])));
                 if(err<min_error)
                 {
@@ -1004,10 +1006,10 @@ unsigned int compressBlockWithTable2x4percep1000(uint8 *img,int width,int height
             i++;
 
             // In order to simplify hardware, the table {-12, -4, 4, 12} is indexed {11, 10, 00, 01}
-            // so that first bit is sign bit and the other bit is size bit (4 or 12). 
-            // This means that we have to scramble the bits before storing them. 
+            // so that first bit is sign bit and the other bit is size bit (4 or 12).
+            // This means that we have to scramble the bits before storing them.
 
-            
+
             sum_error+=min_error;
         }
 
@@ -1054,7 +1056,7 @@ float compressBlockWithTable2x4percep(uint8 *img,int width,int height,int startx
                 approx[2]=CLAMP(0, avg_color[2]+compressParams[table][q],255);
 
                 // Here we just use equal weights to R, G and B. Although this will
-                // give visually worse results, it will give a better PSNR score. 
+                // give visually worse results, it will give a better PSNR score.
                   err=(float)(wR2*SQUARE((approx[0]-orig[0])) + (float)wG2*SQUARE((approx[1]-orig[1])) + (float)wB2*SQUARE((approx[2]-orig[2])));
                 if(err<min_error)
                 {
@@ -1071,9 +1073,9 @@ float compressBlockWithTable2x4percep(uint8 *img,int width,int height,int startx
             i++;
 
             // In order to simplify hardware, the table {-12, -4, 4, 12} is indexed {11, 10, 00, 01}
-            // so that first bit is sign bit and the other bit is size bit (4 or 12). 
-            // This means that we have to scramble the bits before storing them. 
-        
+            // so that first bit is sign bit and the other bit is size bit (4 or 12).
+            // This means that we have to scramble the bits before storing them.
+
             sum_error+=min_error;
         }
     }
@@ -1116,7 +1118,7 @@ int compressBlockWithTable4x2(uint8 *img,int width,int height,int startx,int sta
                 approx[2]=CLAMP(0, avg_color[2]+compressParams[table][q],255);
 
                 // Here we just use equal weights to R, G and B. Although this will
-                // give visually worse results, it will give a better PSNR score. 
+                // give visually worse results, it will give a better PSNR score.
                 err=SQUARE(approx[0]-orig[0]) + SQUARE(approx[1]-orig[1]) + SQUARE(approx[2]-orig[2]);
                 if(err<min_error)
                 {
@@ -1131,8 +1133,8 @@ int compressBlockWithTable4x2(uint8 *img,int width,int height,int startx,int sta
             i++;
 
             // In order to simplify hardware, the table {-12, -4, 4, 12} is indexed {11, 10, 00, 01}
-            // so that first bit is sign bit and the other bit is size bit (4 or 12). 
-            // This means that we have to scramble the bits before storing them. 
+            // so that first bit is sign bit and the other bit is size bit (4 or 12).
+            // This means that we have to scramble the bits before storing them.
 
             sum_error+=min_error;
         }
@@ -1178,9 +1180,9 @@ unsigned int compressBlockWithTable4x2percep1000(uint8 *img,int width,int height
                 approx[2]=CLAMP(0, avg_color[2]+compressParams[table][q],255);
 
                 // Here we just use equal weights to R, G and B. Although this will
-                // give visually worse results, it will give a better PSNR score. 
-                err = PERCEPTUAL_WEIGHT_R_SQUARED_TIMES1000*SQUARE(approx[0]-orig[0]) 
-                    + PERCEPTUAL_WEIGHT_G_SQUARED_TIMES1000*SQUARE(approx[1]-orig[1]) 
+                // give visually worse results, it will give a better PSNR score.
+                err = PERCEPTUAL_WEIGHT_R_SQUARED_TIMES1000*SQUARE(approx[0]-orig[0])
+                    + PERCEPTUAL_WEIGHT_G_SQUARED_TIMES1000*SQUARE(approx[1]-orig[1])
                     + PERCEPTUAL_WEIGHT_B_SQUARED_TIMES1000*SQUARE(approx[2]-orig[2]);
                 if(err<min_error)
                 {
@@ -1195,8 +1197,8 @@ unsigned int compressBlockWithTable4x2percep1000(uint8 *img,int width,int height
             i++;
 
             // In order to simplify hardware, the table {-12, -4, 4, 12} is indexed {11, 10, 00, 01}
-            // so that first bit is sign bit and the other bit is size bit (4 or 12). 
-            // This means that we have to scramble the bits before storing them. 
+            // so that first bit is sign bit and the other bit is size bit (4 or 12).
+            // This means that we have to scramble the bits before storing them.
 
             sum_error+=min_error;
         }
@@ -1245,7 +1247,7 @@ float compressBlockWithTable4x2percep(uint8 *img,int width,int height,int startx
                 approx[2]=CLAMP(0, avg_color[2]+compressParams[table][q],255);
 
                 // Here we just use equal weights to R, G and B. Although this will
-                // give visually worse results, it will give a better PSNR score. 
+                // give visually worse results, it will give a better PSNR score.
                 err=(float) wR2*SQUARE(approx[0]-orig[0]) + (float)wG2*SQUARE(approx[1]-orig[1]) + (float)wB2*SQUARE(approx[2]-orig[2]);
                 if(err<min_error)
                 {
@@ -1260,8 +1262,8 @@ float compressBlockWithTable4x2percep(uint8 *img,int width,int height,int startx
             i++;
 
             // In order to simplify hardware, the table {-12, -4, 4, 12} is indexed {11, 10, 00, 01}
-            // so that first bit is sign bit and the other bit is size bit (4 or 12). 
-            // This means that we have to scramble the bits before storing them. 
+            // so that first bit is sign bit and the other bit is size bit (4 or 12).
+            // This means that we have to scramble the bits before storing them.
 
             sum_error+=min_error;
         }
@@ -1275,50 +1277,50 @@ float compressBlockWithTable4x2percep(uint8 *img,int width,int height,int startx
 }
 
 // Table for fast implementation of clamping to the interval [0,255] followed by addition of 255.
-const int clamp_table_plus_255[768] = {0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 
-                        0+255, 1+255, 2+255, 3+255, 4+255, 5+255, 6+255, 7+255, 8+255, 9+255, 10+255, 11+255, 12+255, 13+255, 14+255, 15+255, 16+255, 17+255, 18+255, 19+255, 20+255, 21+255, 22+255, 23+255, 24+255, 25+255, 26+255, 27+255, 28+255, 29+255, 30+255, 31+255, 32+255, 33+255, 34+255, 35+255, 36+255, 37+255, 38+255, 39+255, 40+255, 41+255, 42+255, 43+255, 44+255, 45+255, 46+255, 47+255, 48+255, 49+255, 50+255, 51+255, 52+255, 53+255, 54+255, 55+255, 56+255, 57+255, 58+255, 59+255, 60+255, 61+255, 62+255, 63+255, 64+255, 65+255, 66+255, 67+255, 68+255, 69+255, 70+255, 71+255, 72+255, 73+255, 74+255, 75+255, 76+255, 77+255, 78+255, 79+255, 80+255, 81+255, 82+255, 83+255, 84+255, 85+255, 86+255, 87+255, 88+255, 89+255, 90+255, 91+255, 92+255, 93+255, 94+255, 95+255, 96+255, 97+255, 98+255, 99+255, 100+255, 101+255, 102+255, 103+255, 104+255, 105+255, 106+255, 107+255, 108+255, 109+255, 110+255, 111+255, 112+255, 113+255, 114+255, 115+255, 116+255, 117+255, 118+255, 119+255, 120+255, 121+255, 122+255, 123+255, 124+255, 125+255, 126+255, 127+255, 128+255, 129+255, 130+255, 131+255, 132+255, 133+255, 134+255, 135+255, 136+255, 137+255, 138+255, 139+255, 140+255, 141+255, 142+255, 143+255, 144+255, 145+255, 146+255, 147+255, 148+255, 149+255, 150+255, 151+255, 152+255, 153+255, 154+255, 155+255, 156+255, 157+255, 158+255, 159+255, 160+255, 161+255, 162+255, 163+255, 164+255, 165+255, 166+255, 167+255, 168+255, 169+255, 170+255, 171+255, 172+255, 173+255, 174+255, 175+255, 176+255, 177+255, 178+255, 179+255, 180+255, 181+255, 182+255, 183+255, 184+255, 185+255, 186+255, 187+255, 188+255, 189+255, 190+255, 191+255, 192+255, 193+255, 194+255, 195+255, 196+255, 197+255, 198+255, 199+255, 200+255, 201+255, 202+255, 203+255, 204+255, 205+255, 206+255, 207+255, 208+255, 209+255, 210+255, 211+255, 
+const int clamp_table_plus_255[768] = {0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255, 0+255,
+                        0+255, 1+255, 2+255, 3+255, 4+255, 5+255, 6+255, 7+255, 8+255, 9+255, 10+255, 11+255, 12+255, 13+255, 14+255, 15+255, 16+255, 17+255, 18+255, 19+255, 20+255, 21+255, 22+255, 23+255, 24+255, 25+255, 26+255, 27+255, 28+255, 29+255, 30+255, 31+255, 32+255, 33+255, 34+255, 35+255, 36+255, 37+255, 38+255, 39+255, 40+255, 41+255, 42+255, 43+255, 44+255, 45+255, 46+255, 47+255, 48+255, 49+255, 50+255, 51+255, 52+255, 53+255, 54+255, 55+255, 56+255, 57+255, 58+255, 59+255, 60+255, 61+255, 62+255, 63+255, 64+255, 65+255, 66+255, 67+255, 68+255, 69+255, 70+255, 71+255, 72+255, 73+255, 74+255, 75+255, 76+255, 77+255, 78+255, 79+255, 80+255, 81+255, 82+255, 83+255, 84+255, 85+255, 86+255, 87+255, 88+255, 89+255, 90+255, 91+255, 92+255, 93+255, 94+255, 95+255, 96+255, 97+255, 98+255, 99+255, 100+255, 101+255, 102+255, 103+255, 104+255, 105+255, 106+255, 107+255, 108+255, 109+255, 110+255, 111+255, 112+255, 113+255, 114+255, 115+255, 116+255, 117+255, 118+255, 119+255, 120+255, 121+255, 122+255, 123+255, 124+255, 125+255, 126+255, 127+255, 128+255, 129+255, 130+255, 131+255, 132+255, 133+255, 134+255, 135+255, 136+255, 137+255, 138+255, 139+255, 140+255, 141+255, 142+255, 143+255, 144+255, 145+255, 146+255, 147+255, 148+255, 149+255, 150+255, 151+255, 152+255, 153+255, 154+255, 155+255, 156+255, 157+255, 158+255, 159+255, 160+255, 161+255, 162+255, 163+255, 164+255, 165+255, 166+255, 167+255, 168+255, 169+255, 170+255, 171+255, 172+255, 173+255, 174+255, 175+255, 176+255, 177+255, 178+255, 179+255, 180+255, 181+255, 182+255, 183+255, 184+255, 185+255, 186+255, 187+255, 188+255, 189+255, 190+255, 191+255, 192+255, 193+255, 194+255, 195+255, 196+255, 197+255, 198+255, 199+255, 200+255, 201+255, 202+255, 203+255, 204+255, 205+255, 206+255, 207+255, 208+255, 209+255, 210+255, 211+255,
                         212+255, 213+255, 214+255, 215+255, 216+255, 217+255, 218+255, 219+255, 220+255, 221+255, 222+255, 223+255, 224+255, 225+255, 226+255, 227+255, 228+255, 229+255, 230+255, 231+255, 232+255, 233+255, 234+255, 235+255, 236+255, 237+255, 238+255, 239+255, 240+255, 241+255, 242+255, 243+255, 244+255, 245+255, 246+255, 247+255, 248+255, 249+255, 250+255, 251+255, 252+255, 253+255, 254+255, 255+255,
-                        255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 
+                        255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255,
                         255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255, 255+255};
 
 // Table for fast implementationi of clamping to the interval [0,255]
-const int clamp_table[768] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+const int clamp_table[768] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255,
                         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255};
 
 // Table for fast implementation of squaring for numbers in the interval [-255, 255]
-const unsigned int square_table[511] = {65025, 64516, 64009, 63504, 63001, 62500, 62001, 61504, 61009, 60516, 60025, 59536, 59049, 58564, 58081, 57600, 
-                         57121, 56644, 56169, 55696, 55225, 54756, 54289, 53824, 53361, 52900, 52441, 51984, 51529, 51076, 50625, 50176, 
-                         49729, 49284, 48841, 48400, 47961, 47524, 47089, 46656, 46225, 45796, 45369, 44944, 44521, 44100, 43681, 43264, 
-                         42849, 42436, 42025, 41616, 41209, 40804, 40401, 40000, 39601, 39204, 38809, 38416, 38025, 37636, 37249, 36864, 
-                         36481, 36100, 35721, 35344, 34969, 34596, 34225, 33856, 33489, 33124, 32761, 32400, 32041, 31684, 31329, 30976, 
-                         30625, 30276, 29929, 29584, 29241, 28900, 28561, 28224, 27889, 27556, 27225, 26896, 26569, 26244, 25921, 25600, 
-                         25281, 24964, 24649, 24336, 24025, 23716, 23409, 23104, 22801, 22500, 22201, 21904, 21609, 21316, 21025, 20736, 
-                         20449, 20164, 19881, 19600, 19321, 19044, 18769, 18496, 18225, 17956, 17689, 17424, 17161, 16900, 16641, 16384, 
-                         16129, 15876, 15625, 15376, 15129, 14884, 14641, 14400, 14161, 13924, 13689, 13456, 13225, 12996, 12769, 12544, 
-                         12321, 12100, 11881, 11664, 11449, 11236, 11025, 10816, 10609, 10404, 10201, 10000, 9801, 9604, 9409, 9216, 
-                         9025, 8836, 8649, 8464, 8281, 8100, 7921, 7744, 7569, 7396, 7225, 7056, 6889, 6724, 6561, 6400, 
-                         6241, 6084, 5929, 5776, 5625, 5476, 5329, 5184, 5041, 4900, 4761, 4624, 4489, 4356, 4225, 4096, 
-                         3969, 3844, 3721, 3600, 3481, 3364, 3249, 3136, 3025, 2916, 2809, 2704, 2601, 2500, 2401, 2304, 
-                         2209, 2116, 2025, 1936, 1849, 1764, 1681, 1600, 1521, 1444, 1369, 1296, 1225, 1156, 1089, 1024, 
+const unsigned int square_table[511] = {65025, 64516, 64009, 63504, 63001, 62500, 62001, 61504, 61009, 60516, 60025, 59536, 59049, 58564, 58081, 57600,
+                         57121, 56644, 56169, 55696, 55225, 54756, 54289, 53824, 53361, 52900, 52441, 51984, 51529, 51076, 50625, 50176,
+                         49729, 49284, 48841, 48400, 47961, 47524, 47089, 46656, 46225, 45796, 45369, 44944, 44521, 44100, 43681, 43264,
+                         42849, 42436, 42025, 41616, 41209, 40804, 40401, 40000, 39601, 39204, 38809, 38416, 38025, 37636, 37249, 36864,
+                         36481, 36100, 35721, 35344, 34969, 34596, 34225, 33856, 33489, 33124, 32761, 32400, 32041, 31684, 31329, 30976,
+                         30625, 30276, 29929, 29584, 29241, 28900, 28561, 28224, 27889, 27556, 27225, 26896, 26569, 26244, 25921, 25600,
+                         25281, 24964, 24649, 24336, 24025, 23716, 23409, 23104, 22801, 22500, 22201, 21904, 21609, 21316, 21025, 20736,
+                         20449, 20164, 19881, 19600, 19321, 19044, 18769, 18496, 18225, 17956, 17689, 17424, 17161, 16900, 16641, 16384,
+                         16129, 15876, 15625, 15376, 15129, 14884, 14641, 14400, 14161, 13924, 13689, 13456, 13225, 12996, 12769, 12544,
+                         12321, 12100, 11881, 11664, 11449, 11236, 11025, 10816, 10609, 10404, 10201, 10000, 9801, 9604, 9409, 9216,
+                         9025, 8836, 8649, 8464, 8281, 8100, 7921, 7744, 7569, 7396, 7225, 7056, 6889, 6724, 6561, 6400,
+                         6241, 6084, 5929, 5776, 5625, 5476, 5329, 5184, 5041, 4900, 4761, 4624, 4489, 4356, 4225, 4096,
+                         3969, 3844, 3721, 3600, 3481, 3364, 3249, 3136, 3025, 2916, 2809, 2704, 2601, 2500, 2401, 2304,
+                         2209, 2116, 2025, 1936, 1849, 1764, 1681, 1600, 1521, 1444, 1369, 1296, 1225, 1156, 1089, 1024,
                          961, 900, 841, 784, 729, 676, 625, 576, 529, 484, 441, 400, 361, 324, 289, 256,
-                         225, 196, 169, 144, 121, 100, 81, 64, 49, 36, 25, 16, 9, 4, 1, 
-                         0, 1, 4, 9, 16, 25, 36, 49, 64, 81, 100, 121, 144, 169, 196, 225, 
-                         256, 289, 324, 361, 400, 441, 484, 529, 576, 625, 676, 729, 784, 841, 900, 961, 
-                         1024, 1089, 1156, 1225, 1296, 1369, 1444, 1521, 1600, 1681, 1764, 1849, 1936, 2025, 2116, 2209, 
-                         2304, 2401, 2500, 2601, 2704, 2809, 2916, 3025, 3136, 3249, 3364, 3481, 3600, 3721, 3844, 3969, 
-                         4096, 4225, 4356, 4489, 4624, 4761, 4900, 5041, 5184, 5329, 5476, 5625, 5776, 5929, 6084, 6241, 
-                         6400, 6561, 6724, 6889, 7056, 7225, 7396, 7569, 7744, 7921, 8100, 8281, 8464, 8649, 8836, 9025, 
+                         225, 196, 169, 144, 121, 100, 81, 64, 49, 36, 25, 16, 9, 4, 1,
+                         0, 1, 4, 9, 16, 25, 36, 49, 64, 81, 100, 121, 144, 169, 196, 225,
+                         256, 289, 324, 361, 400, 441, 484, 529, 576, 625, 676, 729, 784, 841, 900, 961,
+                         1024, 1089, 1156, 1225, 1296, 1369, 1444, 1521, 1600, 1681, 1764, 1849, 1936, 2025, 2116, 2209,
+                         2304, 2401, 2500, 2601, 2704, 2809, 2916, 3025, 3136, 3249, 3364, 3481, 3600, 3721, 3844, 3969,
+                         4096, 4225, 4356, 4489, 4624, 4761, 4900, 5041, 5184, 5329, 5476, 5625, 5776, 5929, 6084, 6241,
+                         6400, 6561, 6724, 6889, 7056, 7225, 7396, 7569, 7744, 7921, 8100, 8281, 8464, 8649, 8836, 9025,
                          9216, 9409, 9604, 9801, 10000, 10201, 10404, 10609, 10816, 11025, 11236, 11449, 11664, 11881, 12100, 12321,
                          12544, 12769, 12996, 13225, 13456, 13689, 13924, 14161, 14400, 14641, 14884, 15129, 15376, 15625, 15876, 16129,
-                         16384, 16641, 16900, 17161, 17424, 17689, 17956, 18225, 18496, 18769, 19044, 19321, 19600, 19881, 20164, 20449, 
-                         20736, 21025, 21316, 21609, 21904, 22201, 22500, 22801, 23104, 23409, 23716, 24025, 24336, 24649, 24964, 25281, 
-                         25600, 25921, 26244, 26569, 26896, 27225, 27556, 27889, 28224, 28561, 28900, 29241, 29584, 29929, 30276, 30625, 
-                         30976, 31329, 31684, 32041, 32400, 32761, 33124, 33489, 33856, 34225, 34596, 34969, 35344, 35721, 36100, 36481, 
-                         36864, 37249, 37636, 38025, 38416, 38809, 39204, 39601, 40000, 40401, 40804, 41209, 41616, 42025, 42436, 42849, 
-                         43264, 43681, 44100, 44521, 44944, 45369, 45796, 46225, 46656, 47089, 47524, 47961, 48400, 48841, 49284, 49729, 
-                         50176, 50625, 51076, 51529, 51984, 52441, 52900, 53361, 53824, 54289, 54756, 55225, 55696, 56169, 56644, 57121, 
-                         57600, 58081, 58564, 59049, 59536, 60025, 60516, 61009, 61504, 62001, 62500, 63001, 63504, 64009, 64516, 65025}; 
+                         16384, 16641, 16900, 17161, 17424, 17689, 17956, 18225, 18496, 18769, 19044, 19321, 19600, 19881, 20164, 20449,
+                         20736, 21025, 21316, 21609, 21904, 22201, 22500, 22801, 23104, 23409, 23716, 24025, 24336, 24649, 24964, 25281,
+                         25600, 25921, 26244, 26569, 26896, 27225, 27556, 27889, 28224, 28561, 28900, 29241, 29584, 29929, 30276, 30625,
+                         30976, 31329, 31684, 32041, 32400, 32761, 33124, 33489, 33856, 34225, 34596, 34969, 35344, 35721, 36100, 36481,
+                         36864, 37249, 37636, 38025, 38416, 38809, 39204, 39601, 40000, 40401, 40804, 41209, 41616, 42025, 42436, 42849,
+                         43264, 43681, 44100, 44521, 44944, 45369, 45796, 46225, 46656, 47089, 47524, 47961, 48400, 48841, 49284, 49729,
+                         50176, 50625, 51076, 51529, 51984, 52441, 52900, 53361, 53824, 54289, 54756, 55225, 55696, 56169, 56644, 57121,
+                         57600, 58081, 58564, 59049, 59536, 60025, 60516, 61009, 61504, 62001, 62500, 63001, 63504, 64009, 64516, 65025};
 
 // Abbreviated variable names to make below tables smaller in source code size
 #define KR PERCEPTUAL_WEIGHT_R_SQUARED_TIMES1000
@@ -1327,108 +1329,108 @@ const unsigned int square_table[511] = {65025, 64516, 64009, 63504, 63001, 62500
 
 // Table for fast implementation of squaring for numbers in the interval [-255, 255] multiplied by the perceptual weight for red.
 const unsigned int square_table_percep_red[511] = {
-                         65025*KR, 64516*KR, 64009*KR, 63504*KR, 63001*KR, 62500*KR, 62001*KR, 61504*KR, 61009*KR, 60516*KR, 60025*KR, 59536*KR, 59049*KR, 58564*KR, 58081*KR, 57600*KR, 
-                         57121*KR, 56644*KR, 56169*KR, 55696*KR, 55225*KR, 54756*KR, 54289*KR, 53824*KR, 53361*KR, 52900*KR, 52441*KR, 51984*KR, 51529*KR, 51076*KR, 50625*KR, 50176*KR, 
-                         49729*KR, 49284*KR, 48841*KR, 48400*KR, 47961*KR, 47524*KR, 47089*KR, 46656*KR, 46225*KR, 45796*KR, 45369*KR, 44944*KR, 44521*KR, 44100*KR, 43681*KR, 43264*KR, 
-                         42849*KR, 42436*KR, 42025*KR, 41616*KR, 41209*KR, 40804*KR, 40401*KR, 40000*KR, 39601*KR, 39204*KR, 38809*KR, 38416*KR, 38025*KR, 37636*KR, 37249*KR, 36864*KR, 
-                         36481*KR, 36100*KR, 35721*KR, 35344*KR, 34969*KR, 34596*KR, 34225*KR, 33856*KR, 33489*KR, 33124*KR, 32761*KR, 32400*KR, 32041*KR, 31684*KR, 31329*KR, 30976*KR, 
-                         30625*KR, 30276*KR, 29929*KR, 29584*KR, 29241*KR, 28900*KR, 28561*KR, 28224*KR, 27889*KR, 27556*KR, 27225*KR, 26896*KR, 26569*KR, 26244*KR, 25921*KR, 25600*KR, 
-                         25281*KR, 24964*KR, 24649*KR, 24336*KR, 24025*KR, 23716*KR, 23409*KR, 23104*KR, 22801*KR, 22500*KR, 22201*KR, 21904*KR, 21609*KR, 21316*KR, 21025*KR, 20736*KR, 
-                         20449*KR, 20164*KR, 19881*KR, 19600*KR, 19321*KR, 19044*KR, 18769*KR, 18496*KR, 18225*KR, 17956*KR, 17689*KR, 17424*KR, 17161*KR, 16900*KR, 16641*KR, 16384*KR, 
-                         16129*KR, 15876*KR, 15625*KR, 15376*KR, 15129*KR, 14884*KR, 14641*KR, 14400*KR, 14161*KR, 13924*KR, 13689*KR, 13456*KR, 13225*KR, 12996*KR, 12769*KR, 12544*KR, 
-                         12321*KR, 12100*KR, 11881*KR, 11664*KR, 11449*KR, 11236*KR, 11025*KR, 10816*KR, 10609*KR, 10404*KR, 10201*KR, 10000*KR, 9801*KR, 9604*KR, 9409*KR, 9216*KR, 
-                         9025*KR, 8836*KR, 8649*KR, 8464*KR, 8281*KR, 8100*KR, 7921*KR, 7744*KR, 7569*KR, 7396*KR, 7225*KR, 7056*KR, 6889*KR, 6724*KR, 6561*KR, 6400*KR, 
-                         6241*KR, 6084*KR, 5929*KR, 5776*KR, 5625*KR, 5476*KR, 5329*KR, 5184*KR, 5041*KR, 4900*KR, 4761*KR, 4624*KR, 4489*KR, 4356*KR, 4225*KR, 4096*KR, 
-                         3969*KR, 3844*KR, 3721*KR, 3600*KR, 3481*KR, 3364*KR, 3249*KR, 3136*KR, 3025*KR, 2916*KR, 2809*KR, 2704*KR, 2601*KR, 2500*KR, 2401*KR, 2304*KR, 
-                         2209*KR, 2116*KR, 2025*KR, 1936*KR, 1849*KR, 1764*KR, 1681*KR, 1600*KR, 1521*KR, 1444*KR, 1369*KR, 1296*KR, 1225*KR, 1156*KR, 1089*KR, 1024*KR, 
+                         65025*KR, 64516*KR, 64009*KR, 63504*KR, 63001*KR, 62500*KR, 62001*KR, 61504*KR, 61009*KR, 60516*KR, 60025*KR, 59536*KR, 59049*KR, 58564*KR, 58081*KR, 57600*KR,
+                         57121*KR, 56644*KR, 56169*KR, 55696*KR, 55225*KR, 54756*KR, 54289*KR, 53824*KR, 53361*KR, 52900*KR, 52441*KR, 51984*KR, 51529*KR, 51076*KR, 50625*KR, 50176*KR,
+                         49729*KR, 49284*KR, 48841*KR, 48400*KR, 47961*KR, 47524*KR, 47089*KR, 46656*KR, 46225*KR, 45796*KR, 45369*KR, 44944*KR, 44521*KR, 44100*KR, 43681*KR, 43264*KR,
+                         42849*KR, 42436*KR, 42025*KR, 41616*KR, 41209*KR, 40804*KR, 40401*KR, 40000*KR, 39601*KR, 39204*KR, 38809*KR, 38416*KR, 38025*KR, 37636*KR, 37249*KR, 36864*KR,
+                         36481*KR, 36100*KR, 35721*KR, 35344*KR, 34969*KR, 34596*KR, 34225*KR, 33856*KR, 33489*KR, 33124*KR, 32761*KR, 32400*KR, 32041*KR, 31684*KR, 31329*KR, 30976*KR,
+                         30625*KR, 30276*KR, 29929*KR, 29584*KR, 29241*KR, 28900*KR, 28561*KR, 28224*KR, 27889*KR, 27556*KR, 27225*KR, 26896*KR, 26569*KR, 26244*KR, 25921*KR, 25600*KR,
+                         25281*KR, 24964*KR, 24649*KR, 24336*KR, 24025*KR, 23716*KR, 23409*KR, 23104*KR, 22801*KR, 22500*KR, 22201*KR, 21904*KR, 21609*KR, 21316*KR, 21025*KR, 20736*KR,
+                         20449*KR, 20164*KR, 19881*KR, 19600*KR, 19321*KR, 19044*KR, 18769*KR, 18496*KR, 18225*KR, 17956*KR, 17689*KR, 17424*KR, 17161*KR, 16900*KR, 16641*KR, 16384*KR,
+                         16129*KR, 15876*KR, 15625*KR, 15376*KR, 15129*KR, 14884*KR, 14641*KR, 14400*KR, 14161*KR, 13924*KR, 13689*KR, 13456*KR, 13225*KR, 12996*KR, 12769*KR, 12544*KR,
+                         12321*KR, 12100*KR, 11881*KR, 11664*KR, 11449*KR, 11236*KR, 11025*KR, 10816*KR, 10609*KR, 10404*KR, 10201*KR, 10000*KR, 9801*KR, 9604*KR, 9409*KR, 9216*KR,
+                         9025*KR, 8836*KR, 8649*KR, 8464*KR, 8281*KR, 8100*KR, 7921*KR, 7744*KR, 7569*KR, 7396*KR, 7225*KR, 7056*KR, 6889*KR, 6724*KR, 6561*KR, 6400*KR,
+                         6241*KR, 6084*KR, 5929*KR, 5776*KR, 5625*KR, 5476*KR, 5329*KR, 5184*KR, 5041*KR, 4900*KR, 4761*KR, 4624*KR, 4489*KR, 4356*KR, 4225*KR, 4096*KR,
+                         3969*KR, 3844*KR, 3721*KR, 3600*KR, 3481*KR, 3364*KR, 3249*KR, 3136*KR, 3025*KR, 2916*KR, 2809*KR, 2704*KR, 2601*KR, 2500*KR, 2401*KR, 2304*KR,
+                         2209*KR, 2116*KR, 2025*KR, 1936*KR, 1849*KR, 1764*KR, 1681*KR, 1600*KR, 1521*KR, 1444*KR, 1369*KR, 1296*KR, 1225*KR, 1156*KR, 1089*KR, 1024*KR,
                          961*KR, 900*KR, 841*KR, 784*KR, 729*KR, 676*KR, 625*KR, 576*KR, 529*KR, 484*KR, 441*KR, 400*KR, 361*KR, 324*KR, 289*KR, 256*KR,
-                         225*KR, 196*KR, 169*KR, 144*KR, 121*KR, 100*KR, 81*KR, 64*KR, 49*KR, 36*KR, 25*KR, 16*KR, 9*KR, 4*KR, 1*KR, 
-                         0*KR, 1*KR, 4*KR, 9*KR, 16*KR, 25*KR, 36*KR, 49*KR, 64*KR, 81*KR, 100*KR, 121*KR, 144*KR, 169*KR, 196*KR, 225*KR, 
-                         256*KR, 289*KR, 324*KR, 361*KR, 400*KR, 441*KR, 484*KR, 529*KR, 576*KR, 625*KR, 676*KR, 729*KR, 784*KR, 841*KR, 900*KR, 961*KR, 
-                         1024*KR, 1089*KR, 1156*KR, 1225*KR, 1296*KR, 1369*KR, 1444*KR, 1521*KR, 1600*KR, 1681*KR, 1764*KR, 1849*KR, 1936*KR, 2025*KR, 2116*KR, 2209*KR, 
-                         2304*KR, 2401*KR, 2500*KR, 2601*KR, 2704*KR, 2809*KR, 2916*KR, 3025*KR, 3136*KR, 3249*KR, 3364*KR, 3481*KR, 3600*KR, 3721*KR, 3844*KR, 3969*KR, 
-                         4096*KR, 4225*KR, 4356*KR, 4489*KR, 4624*KR, 4761*KR, 4900*KR, 5041*KR, 5184*KR, 5329*KR, 5476*KR, 5625*KR, 5776*KR, 5929*KR, 6084*KR, 6241*KR, 
-                         6400*KR, 6561*KR, 6724*KR, 6889*KR, 7056*KR, 7225*KR, 7396*KR, 7569*KR, 7744*KR, 7921*KR, 8100*KR, 8281*KR, 8464*KR, 8649*KR, 8836*KR, 9025*KR, 
+                         225*KR, 196*KR, 169*KR, 144*KR, 121*KR, 100*KR, 81*KR, 64*KR, 49*KR, 36*KR, 25*KR, 16*KR, 9*KR, 4*KR, 1*KR,
+                         0*KR, 1*KR, 4*KR, 9*KR, 16*KR, 25*KR, 36*KR, 49*KR, 64*KR, 81*KR, 100*KR, 121*KR, 144*KR, 169*KR, 196*KR, 225*KR,
+                         256*KR, 289*KR, 324*KR, 361*KR, 400*KR, 441*KR, 484*KR, 529*KR, 576*KR, 625*KR, 676*KR, 729*KR, 784*KR, 841*KR, 900*KR, 961*KR,
+                         1024*KR, 1089*KR, 1156*KR, 1225*KR, 1296*KR, 1369*KR, 1444*KR, 1521*KR, 1600*KR, 1681*KR, 1764*KR, 1849*KR, 1936*KR, 2025*KR, 2116*KR, 2209*KR,
+                         2304*KR, 2401*KR, 2500*KR, 2601*KR, 2704*KR, 2809*KR, 2916*KR, 3025*KR, 3136*KR, 3249*KR, 3364*KR, 3481*KR, 3600*KR, 3721*KR, 3844*KR, 3969*KR,
+                         4096*KR, 4225*KR, 4356*KR, 4489*KR, 4624*KR, 4761*KR, 4900*KR, 5041*KR, 5184*KR, 5329*KR, 5476*KR, 5625*KR, 5776*KR, 5929*KR, 6084*KR, 6241*KR,
+                         6400*KR, 6561*KR, 6724*KR, 6889*KR, 7056*KR, 7225*KR, 7396*KR, 7569*KR, 7744*KR, 7921*KR, 8100*KR, 8281*KR, 8464*KR, 8649*KR, 8836*KR, 9025*KR,
                          9216*KR, 9409*KR, 9604*KR, 9801*KR, 10000*KR, 10201*KR, 10404*KR, 10609*KR, 10816*KR, 11025*KR, 11236*KR, 11449*KR, 11664*KR, 11881*KR, 12100*KR, 12321*KR,
                          12544*KR, 12769*KR, 12996*KR, 13225*KR, 13456*KR, 13689*KR, 13924*KR, 14161*KR, 14400*KR, 14641*KR, 14884*KR, 15129*KR, 15376*KR, 15625*KR, 15876*KR, 16129*KR,
-                         16384*KR, 16641*KR, 16900*KR, 17161*KR, 17424*KR, 17689*KR, 17956*KR, 18225*KR, 18496*KR, 18769*KR, 19044*KR, 19321*KR, 19600*KR, 19881*KR, 20164*KR, 20449*KR, 
-                         20736*KR, 21025*KR, 21316*KR, 21609*KR, 21904*KR, 22201*KR, 22500*KR, 22801*KR, 23104*KR, 23409*KR, 23716*KR, 24025*KR, 24336*KR, 24649*KR, 24964*KR, 25281*KR, 
-                         25600*KR, 25921*KR, 26244*KR, 26569*KR, 26896*KR, 27225*KR, 27556*KR, 27889*KR, 28224*KR, 28561*KR, 28900*KR, 29241*KR, 29584*KR, 29929*KR, 30276*KR, 30625*KR, 
-                         30976*KR, 31329*KR, 31684*KR, 32041*KR, 32400*KR, 32761*KR, 33124*KR, 33489*KR, 33856*KR, 34225*KR, 34596*KR, 34969*KR, 35344*KR, 35721*KR, 36100*KR, 36481*KR, 
-                         36864*KR, 37249*KR, 37636*KR, 38025*KR, 38416*KR, 38809*KR, 39204*KR, 39601*KR, 40000*KR, 40401*KR, 40804*KR, 41209*KR, 41616*KR, 42025*KR, 42436*KR, 42849*KR, 
-                         43264*KR, 43681*KR, 44100*KR, 44521*KR, 44944*KR, 45369*KR, 45796*KR, 46225*KR, 46656*KR, 47089*KR, 47524*KR, 47961*KR, 48400*KR, 48841*KR, 49284*KR, 49729*KR, 
-                         50176*KR, 50625*KR, 51076*KR, 51529*KR, 51984*KR, 52441*KR, 52900*KR, 53361*KR, 53824*KR, 54289*KR, 54756*KR, 55225*KR, 55696*KR, 56169*KR, 56644*KR, 57121*KR, 
-                         57600*KR, 58081*KR, 58564*KR, 59049*KR, 59536*KR, 60025*KR, 60516*KR, 61009*KR, 61504*KR, 62001*KR, 62500*KR, 63001*KR, 63504*KR, 64009*KR, 64516*KR, 65025*KR}; 
+                         16384*KR, 16641*KR, 16900*KR, 17161*KR, 17424*KR, 17689*KR, 17956*KR, 18225*KR, 18496*KR, 18769*KR, 19044*KR, 19321*KR, 19600*KR, 19881*KR, 20164*KR, 20449*KR,
+                         20736*KR, 21025*KR, 21316*KR, 21609*KR, 21904*KR, 22201*KR, 22500*KR, 22801*KR, 23104*KR, 23409*KR, 23716*KR, 24025*KR, 24336*KR, 24649*KR, 24964*KR, 25281*KR,
+                         25600*KR, 25921*KR, 26244*KR, 26569*KR, 26896*KR, 27225*KR, 27556*KR, 27889*KR, 28224*KR, 28561*KR, 28900*KR, 29241*KR, 29584*KR, 29929*KR, 30276*KR, 30625*KR,
+                         30976*KR, 31329*KR, 31684*KR, 32041*KR, 32400*KR, 32761*KR, 33124*KR, 33489*KR, 33856*KR, 34225*KR, 34596*KR, 34969*KR, 35344*KR, 35721*KR, 36100*KR, 36481*KR,
+                         36864*KR, 37249*KR, 37636*KR, 38025*KR, 38416*KR, 38809*KR, 39204*KR, 39601*KR, 40000*KR, 40401*KR, 40804*KR, 41209*KR, 41616*KR, 42025*KR, 42436*KR, 42849*KR,
+                         43264*KR, 43681*KR, 44100*KR, 44521*KR, 44944*KR, 45369*KR, 45796*KR, 46225*KR, 46656*KR, 47089*KR, 47524*KR, 47961*KR, 48400*KR, 48841*KR, 49284*KR, 49729*KR,
+                         50176*KR, 50625*KR, 51076*KR, 51529*KR, 51984*KR, 52441*KR, 52900*KR, 53361*KR, 53824*KR, 54289*KR, 54756*KR, 55225*KR, 55696*KR, 56169*KR, 56644*KR, 57121*KR,
+                         57600*KR, 58081*KR, 58564*KR, 59049*KR, 59536*KR, 60025*KR, 60516*KR, 61009*KR, 61504*KR, 62001*KR, 62500*KR, 63001*KR, 63504*KR, 64009*KR, 64516*KR, 65025*KR};
 
 // Table for fast implementation of squaring for numbers in the interval [-255, 255] multiplied by the perceptual weight for green.
 const unsigned int square_table_percep_green[511] = {
-                         65025*KG, 64516*KG, 64009*KG, 63504*KG, 63001*KG, 62500*KG, 62001*KG, 61504*KG, 61009*KG, 60516*KG, 60025*KG, 59536*KG, 59049*KG, 58564*KG, 58081*KG, 57600*KG, 
-                         57121*KG, 56644*KG, 56169*KG, 55696*KG, 55225*KG, 54756*KG, 54289*KG, 53824*KG, 53361*KG, 52900*KG, 52441*KG, 51984*KG, 51529*KG, 51076*KG, 50625*KG, 50176*KG, 
-                         49729*KG, 49284*KG, 48841*KG, 48400*KG, 47961*KG, 47524*KG, 47089*KG, 46656*KG, 46225*KG, 45796*KG, 45369*KG, 44944*KG, 44521*KG, 44100*KG, 43681*KG, 43264*KG, 
-                         42849*KG, 42436*KG, 42025*KG, 41616*KG, 41209*KG, 40804*KG, 40401*KG, 40000*KG, 39601*KG, 39204*KG, 38809*KG, 38416*KG, 38025*KG, 37636*KG, 37249*KG, 36864*KG, 
-                         36481*KG, 36100*KG, 35721*KG, 35344*KG, 34969*KG, 34596*KG, 34225*KG, 33856*KG, 33489*KG, 33124*KG, 32761*KG, 32400*KG, 32041*KG, 31684*KG, 31329*KG, 30976*KG, 
-                         30625*KG, 30276*KG, 29929*KG, 29584*KG, 29241*KG, 28900*KG, 28561*KG, 28224*KG, 27889*KG, 27556*KG, 27225*KG, 26896*KG, 26569*KG, 26244*KG, 25921*KG, 25600*KG, 
-                         25281*KG, 24964*KG, 24649*KG, 24336*KG, 24025*KG, 23716*KG, 23409*KG, 23104*KG, 22801*KG, 22500*KG, 22201*KG, 21904*KG, 21609*KG, 21316*KG, 21025*KG, 20736*KG, 
-                         20449*KG, 20164*KG, 19881*KG, 19600*KG, 19321*KG, 19044*KG, 18769*KG, 18496*KG, 18225*KG, 17956*KG, 17689*KG, 17424*KG, 17161*KG, 16900*KG, 16641*KG, 16384*KG, 
-                         16129*KG, 15876*KG, 15625*KG, 15376*KG, 15129*KG, 14884*KG, 14641*KG, 14400*KG, 14161*KG, 13924*KG, 13689*KG, 13456*KG, 13225*KG, 12996*KG, 12769*KG, 12544*KG, 
-                         12321*KG, 12100*KG, 11881*KG, 11664*KG, 11449*KG, 11236*KG, 11025*KG, 10816*KG, 10609*KG, 10404*KG, 10201*KG, 10000*KG, 9801*KG, 9604*KG, 9409*KG, 9216*KG, 
-                         9025*KG, 8836*KG, 8649*KG, 8464*KG, 8281*KG, 8100*KG, 7921*KG, 7744*KG, 7569*KG, 7396*KG, 7225*KG, 7056*KG, 6889*KG, 6724*KG, 6561*KG, 6400*KG, 
-                         6241*KG, 6084*KG, 5929*KG, 5776*KG, 5625*KG, 5476*KG, 5329*KG, 5184*KG, 5041*KG, 4900*KG, 4761*KG, 4624*KG, 4489*KG, 4356*KG, 4225*KG, 4096*KG, 
-                         3969*KG, 3844*KG, 3721*KG, 3600*KG, 3481*KG, 3364*KG, 3249*KG, 3136*KG, 3025*KG, 2916*KG, 2809*KG, 2704*KG, 2601*KG, 2500*KG, 2401*KG, 2304*KG, 
-                         2209*KG, 2116*KG, 2025*KG, 1936*KG, 1849*KG, 1764*KG, 1681*KG, 1600*KG, 1521*KG, 1444*KG, 1369*KG, 1296*KG, 1225*KG, 1156*KG, 1089*KG, 1024*KG, 
+                         65025*KG, 64516*KG, 64009*KG, 63504*KG, 63001*KG, 62500*KG, 62001*KG, 61504*KG, 61009*KG, 60516*KG, 60025*KG, 59536*KG, 59049*KG, 58564*KG, 58081*KG, 57600*KG,
+                         57121*KG, 56644*KG, 56169*KG, 55696*KG, 55225*KG, 54756*KG, 54289*KG, 53824*KG, 53361*KG, 52900*KG, 52441*KG, 51984*KG, 51529*KG, 51076*KG, 50625*KG, 50176*KG,
+                         49729*KG, 49284*KG, 48841*KG, 48400*KG, 47961*KG, 47524*KG, 47089*KG, 46656*KG, 46225*KG, 45796*KG, 45369*KG, 44944*KG, 44521*KG, 44100*KG, 43681*KG, 43264*KG,
+                         42849*KG, 42436*KG, 42025*KG, 41616*KG, 41209*KG, 40804*KG, 40401*KG, 40000*KG, 39601*KG, 39204*KG, 38809*KG, 38416*KG, 38025*KG, 37636*KG, 37249*KG, 36864*KG,
+                         36481*KG, 36100*KG, 35721*KG, 35344*KG, 34969*KG, 34596*KG, 34225*KG, 33856*KG, 33489*KG, 33124*KG, 32761*KG, 32400*KG, 32041*KG, 31684*KG, 31329*KG, 30976*KG,
+                         30625*KG, 30276*KG, 29929*KG, 29584*KG, 29241*KG, 28900*KG, 28561*KG, 28224*KG, 27889*KG, 27556*KG, 27225*KG, 26896*KG, 26569*KG, 26244*KG, 25921*KG, 25600*KG,
+                         25281*KG, 24964*KG, 24649*KG, 24336*KG, 24025*KG, 23716*KG, 23409*KG, 23104*KG, 22801*KG, 22500*KG, 22201*KG, 21904*KG, 21609*KG, 21316*KG, 21025*KG, 20736*KG,
+                         20449*KG, 20164*KG, 19881*KG, 19600*KG, 19321*KG, 19044*KG, 18769*KG, 18496*KG, 18225*KG, 17956*KG, 17689*KG, 17424*KG, 17161*KG, 16900*KG, 16641*KG, 16384*KG,
+                         16129*KG, 15876*KG, 15625*KG, 15376*KG, 15129*KG, 14884*KG, 14641*KG, 14400*KG, 14161*KG, 13924*KG, 13689*KG, 13456*KG, 13225*KG, 12996*KG, 12769*KG, 12544*KG,
+                         12321*KG, 12100*KG, 11881*KG, 11664*KG, 11449*KG, 11236*KG, 11025*KG, 10816*KG, 10609*KG, 10404*KG, 10201*KG, 10000*KG, 9801*KG, 9604*KG, 9409*KG, 9216*KG,
+                         9025*KG, 8836*KG, 8649*KG, 8464*KG, 8281*KG, 8100*KG, 7921*KG, 7744*KG, 7569*KG, 7396*KG, 7225*KG, 7056*KG, 6889*KG, 6724*KG, 6561*KG, 6400*KG,
+                         6241*KG, 6084*KG, 5929*KG, 5776*KG, 5625*KG, 5476*KG, 5329*KG, 5184*KG, 5041*KG, 4900*KG, 4761*KG, 4624*KG, 4489*KG, 4356*KG, 4225*KG, 4096*KG,
+                         3969*KG, 3844*KG, 3721*KG, 3600*KG, 3481*KG, 3364*KG, 3249*KG, 3136*KG, 3025*KG, 2916*KG, 2809*KG, 2704*KG, 2601*KG, 2500*KG, 2401*KG, 2304*KG,
+                         2209*KG, 2116*KG, 2025*KG, 1936*KG, 1849*KG, 1764*KG, 1681*KG, 1600*KG, 1521*KG, 1444*KG, 1369*KG, 1296*KG, 1225*KG, 1156*KG, 1089*KG, 1024*KG,
                          961*KG, 900*KG, 841*KG, 784*KG, 729*KG, 676*KG, 625*KG, 576*KG, 529*KG, 484*KG, 441*KG, 400*KG, 361*KG, 324*KG, 289*KG, 256*KG,
-                         225*KG, 196*KG, 169*KG, 144*KG, 121*KG, 100*KG, 81*KG, 64*KG, 49*KG, 36*KG, 25*KG, 16*KG, 9*KG, 4*KG, 1*KG, 
-                         0*KG, 1*KG, 4*KG, 9*KG, 16*KG, 25*KG, 36*KG, 49*KG, 64*KG, 81*KG, 100*KG, 121*KG, 144*KG, 169*KG, 196*KG, 225*KG, 
-                         256*KG, 289*KG, 324*KG, 361*KG, 400*KG, 441*KG, 484*KG, 529*KG, 576*KG, 625*KG, 676*KG, 729*KG, 784*KG, 841*KG, 900*KG, 961*KG, 
-                         1024*KG, 1089*KG, 1156*KG, 1225*KG, 1296*KG, 1369*KG, 1444*KG, 1521*KG, 1600*KG, 1681*KG, 1764*KG, 1849*KG, 1936*KG, 2025*KG, 2116*KG, 2209*KG, 
-                         2304*KG, 2401*KG, 2500*KG, 2601*KG, 2704*KG, 2809*KG, 2916*KG, 3025*KG, 3136*KG, 3249*KG, 3364*KG, 3481*KG, 3600*KG, 3721*KG, 3844*KG, 3969*KG, 
-                         4096*KG, 4225*KG, 4356*KG, 4489*KG, 4624*KG, 4761*KG, 4900*KG, 5041*KG, 5184*KG, 5329*KG, 5476*KG, 5625*KG, 5776*KG, 5929*KG, 6084*KG, 6241*KG, 
-                         6400*KG, 6561*KG, 6724*KG, 6889*KG, 7056*KG, 7225*KG, 7396*KG, 7569*KG, 7744*KG, 7921*KG, 8100*KG, 8281*KG, 8464*KG, 8649*KG, 8836*KG, 9025*KG, 
+                         225*KG, 196*KG, 169*KG, 144*KG, 121*KG, 100*KG, 81*KG, 64*KG, 49*KG, 36*KG, 25*KG, 16*KG, 9*KG, 4*KG, 1*KG,
+                         0*KG, 1*KG, 4*KG, 9*KG, 16*KG, 25*KG, 36*KG, 49*KG, 64*KG, 81*KG, 100*KG, 121*KG, 144*KG, 169*KG, 196*KG, 225*KG,
+                         256*KG, 289*KG, 324*KG, 361*KG, 400*KG, 441*KG, 484*KG, 529*KG, 576*KG, 625*KG, 676*KG, 729*KG, 784*KG, 841*KG, 900*KG, 961*KG,
+                         1024*KG, 1089*KG, 1156*KG, 1225*KG, 1296*KG, 1369*KG, 1444*KG, 1521*KG, 1600*KG, 1681*KG, 1764*KG, 1849*KG, 1936*KG, 2025*KG, 2116*KG, 2209*KG,
+                         2304*KG, 2401*KG, 2500*KG, 2601*KG, 2704*KG, 2809*KG, 2916*KG, 3025*KG, 3136*KG, 3249*KG, 3364*KG, 3481*KG, 3600*KG, 3721*KG, 3844*KG, 3969*KG,
+                         4096*KG, 4225*KG, 4356*KG, 4489*KG, 4624*KG, 4761*KG, 4900*KG, 5041*KG, 5184*KG, 5329*KG, 5476*KG, 5625*KG, 5776*KG, 5929*KG, 6084*KG, 6241*KG,
+                         6400*KG, 6561*KG, 6724*KG, 6889*KG, 7056*KG, 7225*KG, 7396*KG, 7569*KG, 7744*KG, 7921*KG, 8100*KG, 8281*KG, 8464*KG, 8649*KG, 8836*KG, 9025*KG,
                          9216*KG, 9409*KG, 9604*KG, 9801*KG, 10000*KG, 10201*KG, 10404*KG, 10609*KG, 10816*KG, 11025*KG, 11236*KG, 11449*KG, 11664*KG, 11881*KG, 12100*KG, 12321*KG,
                          12544*KG, 12769*KG, 12996*KG, 13225*KG, 13456*KG, 13689*KG, 13924*KG, 14161*KG, 14400*KG, 14641*KG, 14884*KG, 15129*KG, 15376*KG, 15625*KG, 15876*KG, 16129*KG,
-                         16384*KG, 16641*KG, 16900*KG, 17161*KG, 17424*KG, 17689*KG, 17956*KG, 18225*KG, 18496*KG, 18769*KG, 19044*KG, 19321*KG, 19600*KG, 19881*KG, 20164*KG, 20449*KG, 
-                         20736*KG, 21025*KG, 21316*KG, 21609*KG, 21904*KG, 22201*KG, 22500*KG, 22801*KG, 23104*KG, 23409*KG, 23716*KG, 24025*KG, 24336*KG, 24649*KG, 24964*KG, 25281*KG, 
-                         25600*KG, 25921*KG, 26244*KG, 26569*KG, 26896*KG, 27225*KG, 27556*KG, 27889*KG, 28224*KG, 28561*KG, 28900*KG, 29241*KG, 29584*KG, 29929*KG, 30276*KG, 30625*KG, 
-                         30976*KG, 31329*KG, 31684*KG, 32041*KG, 32400*KG, 32761*KG, 33124*KG, 33489*KG, 33856*KG, 34225*KG, 34596*KG, 34969*KG, 35344*KG, 35721*KG, 36100*KG, 36481*KG, 
-                         36864*KG, 37249*KG, 37636*KG, 38025*KG, 38416*KG, 38809*KG, 39204*KG, 39601*KG, 40000*KG, 40401*KG, 40804*KG, 41209*KG, 41616*KG, 42025*KG, 42436*KG, 42849*KG, 
-                         43264*KG, 43681*KG, 44100*KG, 44521*KG, 44944*KG, 45369*KG, 45796*KG, 46225*KG, 46656*KG, 47089*KG, 47524*KG, 47961*KG, 48400*KG, 48841*KG, 49284*KG, 49729*KG, 
-                         50176*KG, 50625*KG, 51076*KG, 51529*KG, 51984*KG, 52441*KG, 52900*KG, 53361*KG, 53824*KG, 54289*KG, 54756*KG, 55225*KG, 55696*KG, 56169*KG, 56644*KG, 57121*KG, 
-                         57600*KG, 58081*KG, 58564*KG, 59049*KG, 59536*KG, 60025*KG, 60516*KG, 61009*KG, 61504*KG, 62001*KG, 62500*KG, 63001*KG, 63504*KG, 64009*KG, 64516*KG, 65025*KG}; 
+                         16384*KG, 16641*KG, 16900*KG, 17161*KG, 17424*KG, 17689*KG, 17956*KG, 18225*KG, 18496*KG, 18769*KG, 19044*KG, 19321*KG, 19600*KG, 19881*KG, 20164*KG, 20449*KG,
+                         20736*KG, 21025*KG, 21316*KG, 21609*KG, 21904*KG, 22201*KG, 22500*KG, 22801*KG, 23104*KG, 23409*KG, 23716*KG, 24025*KG, 24336*KG, 24649*KG, 24964*KG, 25281*KG,
+                         25600*KG, 25921*KG, 26244*KG, 26569*KG, 26896*KG, 27225*KG, 27556*KG, 27889*KG, 28224*KG, 28561*KG, 28900*KG, 29241*KG, 29584*KG, 29929*KG, 30276*KG, 30625*KG,
+                         30976*KG, 31329*KG, 31684*KG, 32041*KG, 32400*KG, 32761*KG, 33124*KG, 33489*KG, 33856*KG, 34225*KG, 34596*KG, 34969*KG, 35344*KG, 35721*KG, 36100*KG, 36481*KG,
+                         36864*KG, 37249*KG, 37636*KG, 38025*KG, 38416*KG, 38809*KG, 39204*KG, 39601*KG, 40000*KG, 40401*KG, 40804*KG, 41209*KG, 41616*KG, 42025*KG, 42436*KG, 42849*KG,
+                         43264*KG, 43681*KG, 44100*KG, 44521*KG, 44944*KG, 45369*KG, 45796*KG, 46225*KG, 46656*KG, 47089*KG, 47524*KG, 47961*KG, 48400*KG, 48841*KG, 49284*KG, 49729*KG,
+                         50176*KG, 50625*KG, 51076*KG, 51529*KG, 51984*KG, 52441*KG, 52900*KG, 53361*KG, 53824*KG, 54289*KG, 54756*KG, 55225*KG, 55696*KG, 56169*KG, 56644*KG, 57121*KG,
+                         57600*KG, 58081*KG, 58564*KG, 59049*KG, 59536*KG, 60025*KG, 60516*KG, 61009*KG, 61504*KG, 62001*KG, 62500*KG, 63001*KG, 63504*KG, 64009*KG, 64516*KG, 65025*KG};
 
 // Table for fast implementation of squaring for numbers in the interval [-255, 255] multiplied by the perceptual weight for blue.
 const unsigned int square_table_percep_blue[511] = {
-                         65025*KB, 64516*KB, 64009*KB, 63504*KB, 63001*KB, 62500*KB, 62001*KB, 61504*KB, 61009*KB, 60516*KB, 60025*KB, 59536*KB, 59049*KB, 58564*KB, 58081*KB, 57600*KB, 
-                         57121*KB, 56644*KB, 56169*KB, 55696*KB, 55225*KB, 54756*KB, 54289*KB, 53824*KB, 53361*KB, 52900*KB, 52441*KB, 51984*KB, 51529*KB, 51076*KB, 50625*KB, 50176*KB, 
-                         49729*KB, 49284*KB, 48841*KB, 48400*KB, 47961*KB, 47524*KB, 47089*KB, 46656*KB, 46225*KB, 45796*KB, 45369*KB, 44944*KB, 44521*KB, 44100*KB, 43681*KB, 43264*KB, 
-                         42849*KB, 42436*KB, 42025*KB, 41616*KB, 41209*KB, 40804*KB, 40401*KB, 40000*KB, 39601*KB, 39204*KB, 38809*KB, 38416*KB, 38025*KB, 37636*KB, 37249*KB, 36864*KB, 
-                         36481*KB, 36100*KB, 35721*KB, 35344*KB, 34969*KB, 34596*KB, 34225*KB, 33856*KB, 33489*KB, 33124*KB, 32761*KB, 32400*KB, 32041*KB, 31684*KB, 31329*KB, 30976*KB, 
-                         30625*KB, 30276*KB, 29929*KB, 29584*KB, 29241*KB, 28900*KB, 28561*KB, 28224*KB, 27889*KB, 27556*KB, 27225*KB, 26896*KB, 26569*KB, 26244*KB, 25921*KB, 25600*KB, 
-                         25281*KB, 24964*KB, 24649*KB, 24336*KB, 24025*KB, 23716*KB, 23409*KB, 23104*KB, 22801*KB, 22500*KB, 22201*KB, 21904*KB, 21609*KB, 21316*KB, 21025*KB, 20736*KB, 
-                         20449*KB, 20164*KB, 19881*KB, 19600*KB, 19321*KB, 19044*KB, 18769*KB, 18496*KB, 18225*KB, 17956*KB, 17689*KB, 17424*KB, 17161*KB, 16900*KB, 16641*KB, 16384*KB, 
-                         16129*KB, 15876*KB, 15625*KB, 15376*KB, 15129*KB, 14884*KB, 14641*KB, 14400*KB, 14161*KB, 13924*KB, 13689*KB, 13456*KB, 13225*KB, 12996*KB, 12769*KB, 12544*KB, 
-                         12321*KB, 12100*KB, 11881*KB, 11664*KB, 11449*KB, 11236*KB, 11025*KB, 10816*KB, 10609*KB, 10404*KB, 10201*KB, 10000*KB, 9801*KB, 9604*KB, 9409*KB, 9216*KB, 
-                         9025*KB, 8836*KB, 8649*KB, 8464*KB, 8281*KB, 8100*KB, 7921*KB, 7744*KB, 7569*KB, 7396*KB, 7225*KB, 7056*KB, 6889*KB, 6724*KB, 6561*KB, 6400*KB, 
-                         6241*KB, 6084*KB, 5929*KB, 5776*KB, 5625*KB, 5476*KB, 5329*KB, 5184*KB, 5041*KB, 4900*KB, 4761*KB, 4624*KB, 4489*KB, 4356*KB, 4225*KB, 4096*KB, 
-                         3969*KB, 3844*KB, 3721*KB, 3600*KB, 3481*KB, 3364*KB, 3249*KB, 3136*KB, 3025*KB, 2916*KB, 2809*KB, 2704*KB, 2601*KB, 2500*KB, 2401*KB, 2304*KB, 
-                         2209*KB, 2116*KB, 2025*KB, 1936*KB, 1849*KB, 1764*KB, 1681*KB, 1600*KB, 1521*KB, 1444*KB, 1369*KB, 1296*KB, 1225*KB, 1156*KB, 1089*KB, 1024*KB, 
+                         65025*KB, 64516*KB, 64009*KB, 63504*KB, 63001*KB, 62500*KB, 62001*KB, 61504*KB, 61009*KB, 60516*KB, 60025*KB, 59536*KB, 59049*KB, 58564*KB, 58081*KB, 57600*KB,
+                         57121*KB, 56644*KB, 56169*KB, 55696*KB, 55225*KB, 54756*KB, 54289*KB, 53824*KB, 53361*KB, 52900*KB, 52441*KB, 51984*KB, 51529*KB, 51076*KB, 50625*KB, 50176*KB,
+                         49729*KB, 49284*KB, 48841*KB, 48400*KB, 47961*KB, 47524*KB, 47089*KB, 46656*KB, 46225*KB, 45796*KB, 45369*KB, 44944*KB, 44521*KB, 44100*KB, 43681*KB, 43264*KB,
+                         42849*KB, 42436*KB, 42025*KB, 41616*KB, 41209*KB, 40804*KB, 40401*KB, 40000*KB, 39601*KB, 39204*KB, 38809*KB, 38416*KB, 38025*KB, 37636*KB, 37249*KB, 36864*KB,
+                         36481*KB, 36100*KB, 35721*KB, 35344*KB, 34969*KB, 34596*KB, 34225*KB, 33856*KB, 33489*KB, 33124*KB, 32761*KB, 32400*KB, 32041*KB, 31684*KB, 31329*KB, 30976*KB,
+                         30625*KB, 30276*KB, 29929*KB, 29584*KB, 29241*KB, 28900*KB, 28561*KB, 28224*KB, 27889*KB, 27556*KB, 27225*KB, 26896*KB, 26569*KB, 26244*KB, 25921*KB, 25600*KB,
+                         25281*KB, 24964*KB, 24649*KB, 24336*KB, 24025*KB, 23716*KB, 23409*KB, 23104*KB, 22801*KB, 22500*KB, 22201*KB, 21904*KB, 21609*KB, 21316*KB, 21025*KB, 20736*KB,
+                         20449*KB, 20164*KB, 19881*KB, 19600*KB, 19321*KB, 19044*KB, 18769*KB, 18496*KB, 18225*KB, 17956*KB, 17689*KB, 17424*KB, 17161*KB, 16900*KB, 16641*KB, 16384*KB,
+                         16129*KB, 15876*KB, 15625*KB, 15376*KB, 15129*KB, 14884*KB, 14641*KB, 14400*KB, 14161*KB, 13924*KB, 13689*KB, 13456*KB, 13225*KB, 12996*KB, 12769*KB, 12544*KB,
+                         12321*KB, 12100*KB, 11881*KB, 11664*KB, 11449*KB, 11236*KB, 11025*KB, 10816*KB, 10609*KB, 10404*KB, 10201*KB, 10000*KB, 9801*KB, 9604*KB, 9409*KB, 9216*KB,
+                         9025*KB, 8836*KB, 8649*KB, 8464*KB, 8281*KB, 8100*KB, 7921*KB, 7744*KB, 7569*KB, 7396*KB, 7225*KB, 7056*KB, 6889*KB, 6724*KB, 6561*KB, 6400*KB,
+                         6241*KB, 6084*KB, 5929*KB, 5776*KB, 5625*KB, 5476*KB, 5329*KB, 5184*KB, 5041*KB, 4900*KB, 4761*KB, 4624*KB, 4489*KB, 4356*KB, 4225*KB, 4096*KB,
+                         3969*KB, 3844*KB, 3721*KB, 3600*KB, 3481*KB, 3364*KB, 3249*KB, 3136*KB, 3025*KB, 2916*KB, 2809*KB, 2704*KB, 2601*KB, 2500*KB, 2401*KB, 2304*KB,
+                         2209*KB, 2116*KB, 2025*KB, 1936*KB, 1849*KB, 1764*KB, 1681*KB, 1600*KB, 1521*KB, 1444*KB, 1369*KB, 1296*KB, 1225*KB, 1156*KB, 1089*KB, 1024*KB,
                          961*KB, 900*KB, 841*KB, 784*KB, 729*KB, 676*KB, 625*KB, 576*KB, 529*KB, 484*KB, 441*KB, 400*KB, 361*KB, 324*KB, 289*KB, 256*KB,
-                         225*KB, 196*KB, 169*KB, 144*KB, 121*KB, 100*KB, 81*KB, 64*KB, 49*KB, 36*KB, 25*KB, 16*KB, 9*KB, 4*KB, 1*KB, 
-                         0*KB, 1*KB, 4*KB, 9*KB, 16*KB, 25*KB, 36*KB, 49*KB, 64*KB, 81*KB, 100*KB, 121*KB, 144*KB, 169*KB, 196*KB, 225*KB, 
-                         256*KB, 289*KB, 324*KB, 361*KB, 400*KB, 441*KB, 484*KB, 529*KB, 576*KB, 625*KB, 676*KB, 729*KB, 784*KB, 841*KB, 900*KB, 961*KB, 
-                         1024*KB, 1089*KB, 1156*KB, 1225*KB, 1296*KB, 1369*KB, 1444*KB, 1521*KB, 1600*KB, 1681*KB, 1764*KB, 1849*KB, 1936*KB, 2025*KB, 2116*KB, 2209*KB, 
-                         2304*KB, 2401*KB, 2500*KB, 2601*KB, 2704*KB, 2809*KB, 2916*KB, 3025*KB, 3136*KB, 3249*KB, 3364*KB, 3481*KB, 3600*KB, 3721*KB, 3844*KB, 3969*KB, 
-                         4096*KB, 4225*KB, 4356*KB, 4489*KB, 4624*KB, 4761*KB, 4900*KB, 5041*KB, 5184*KB, 5329*KB, 5476*KB, 5625*KB, 5776*KB, 5929*KB, 6084*KB, 6241*KB, 
-                         6400*KB, 6561*KB, 6724*KB, 6889*KB, 7056*KB, 7225*KB, 7396*KB, 7569*KB, 7744*KB, 7921*KB, 8100*KB, 8281*KB, 8464*KB, 8649*KB, 8836*KB, 9025*KB, 
+                         225*KB, 196*KB, 169*KB, 144*KB, 121*KB, 100*KB, 81*KB, 64*KB, 49*KB, 36*KB, 25*KB, 16*KB, 9*KB, 4*KB, 1*KB,
+                         0*KB, 1*KB, 4*KB, 9*KB, 16*KB, 25*KB, 36*KB, 49*KB, 64*KB, 81*KB, 100*KB, 121*KB, 144*KB, 169*KB, 196*KB, 225*KB,
+                         256*KB, 289*KB, 324*KB, 361*KB, 400*KB, 441*KB, 484*KB, 529*KB, 576*KB, 625*KB, 676*KB, 729*KB, 784*KB, 841*KB, 900*KB, 961*KB,
+                         1024*KB, 1089*KB, 1156*KB, 1225*KB, 1296*KB, 1369*KB, 1444*KB, 1521*KB, 1600*KB, 1681*KB, 1764*KB, 1849*KB, 1936*KB, 2025*KB, 2116*KB, 2209*KB,
+                         2304*KB, 2401*KB, 2500*KB, 2601*KB, 2704*KB, 2809*KB, 2916*KB, 3025*KB, 3136*KB, 3249*KB, 3364*KB, 3481*KB, 3600*KB, 3721*KB, 3844*KB, 3969*KB,
+                         4096*KB, 4225*KB, 4356*KB, 4489*KB, 4624*KB, 4761*KB, 4900*KB, 5041*KB, 5184*KB, 5329*KB, 5476*KB, 5625*KB, 5776*KB, 5929*KB, 6084*KB, 6241*KB,
+                         6400*KB, 6561*KB, 6724*KB, 6889*KB, 7056*KB, 7225*KB, 7396*KB, 7569*KB, 7744*KB, 7921*KB, 8100*KB, 8281*KB, 8464*KB, 8649*KB, 8836*KB, 9025*KB,
                          9216*KB, 9409*KB, 9604*KB, 9801*KB, 10000*KB, 10201*KB, 10404*KB, 10609*KB, 10816*KB, 11025*KB, 11236*KB, 11449*KB, 11664*KB, 11881*KB, 12100*KB, 12321*KB,
                          12544*KB, 12769*KB, 12996*KB, 13225*KB, 13456*KB, 13689*KB, 13924*KB, 14161*KB, 14400*KB, 14641*KB, 14884*KB, 15129*KB, 15376*KB, 15625*KB, 15876*KB, 16129*KB,
-                         16384*KB, 16641*KB, 16900*KB, 17161*KB, 17424*KB, 17689*KB, 17956*KB, 18225*KB, 18496*KB, 18769*KB, 19044*KB, 19321*KB, 19600*KB, 19881*KB, 20164*KB, 20449*KB, 
-                         20736*KB, 21025*KB, 21316*KB, 21609*KB, 21904*KB, 22201*KB, 22500*KB, 22801*KB, 23104*KB, 23409*KB, 23716*KB, 24025*KB, 24336*KB, 24649*KB, 24964*KB, 25281*KB, 
-                         25600*KB, 25921*KB, 26244*KB, 26569*KB, 26896*KB, 27225*KB, 27556*KB, 27889*KB, 28224*KB, 28561*KB, 28900*KB, 29241*KB, 29584*KB, 29929*KB, 30276*KB, 30625*KB, 
-                         30976*KB, 31329*KB, 31684*KB, 32041*KB, 32400*KB, 32761*KB, 33124*KB, 33489*KB, 33856*KB, 34225*KB, 34596*KB, 34969*KB, 35344*KB, 35721*KB, 36100*KB, 36481*KB, 
-                         36864*KB, 37249*KB, 37636*KB, 38025*KB, 38416*KB, 38809*KB, 39204*KB, 39601*KB, 40000*KB, 40401*KB, 40804*KB, 41209*KB, 41616*KB, 42025*KB, 42436*KB, 42849*KB, 
-                         43264*KB, 43681*KB, 44100*KB, 44521*KB, 44944*KB, 45369*KB, 45796*KB, 46225*KB, 46656*KB, 47089*KB, 47524*KB, 47961*KB, 48400*KB, 48841*KB, 49284*KB, 49729*KB, 
-                         50176*KB, 50625*KB, 51076*KB, 51529*KB, 51984*KB, 52441*KB, 52900*KB, 53361*KB, 53824*KB, 54289*KB, 54756*KB, 55225*KB, 55696*KB, 56169*KB, 56644*KB, 57121*KB, 
-                         57600*KB, 58081*KB, 58564*KB, 59049*KB, 59536*KB, 60025*KB, 60516*KB, 61009*KB, 61504*KB, 62001*KB, 62500*KB, 63001*KB, 63504*KB, 64009*KB, 64516*KB, 65025*KB}; 
+                         16384*KB, 16641*KB, 16900*KB, 17161*KB, 17424*KB, 17689*KB, 17956*KB, 18225*KB, 18496*KB, 18769*KB, 19044*KB, 19321*KB, 19600*KB, 19881*KB, 20164*KB, 20449*KB,
+                         20736*KB, 21025*KB, 21316*KB, 21609*KB, 21904*KB, 22201*KB, 22500*KB, 22801*KB, 23104*KB, 23409*KB, 23716*KB, 24025*KB, 24336*KB, 24649*KB, 24964*KB, 25281*KB,
+                         25600*KB, 25921*KB, 26244*KB, 26569*KB, 26896*KB, 27225*KB, 27556*KB, 27889*KB, 28224*KB, 28561*KB, 28900*KB, 29241*KB, 29584*KB, 29929*KB, 30276*KB, 30625*KB,
+                         30976*KB, 31329*KB, 31684*KB, 32041*KB, 32400*KB, 32761*KB, 33124*KB, 33489*KB, 33856*KB, 34225*KB, 34596*KB, 34969*KB, 35344*KB, 35721*KB, 36100*KB, 36481*KB,
+                         36864*KB, 37249*KB, 37636*KB, 38025*KB, 38416*KB, 38809*KB, 39204*KB, 39601*KB, 40000*KB, 40401*KB, 40804*KB, 41209*KB, 41616*KB, 42025*KB, 42436*KB, 42849*KB,
+                         43264*KB, 43681*KB, 44100*KB, 44521*KB, 44944*KB, 45369*KB, 45796*KB, 46225*KB, 46656*KB, 47089*KB, 47524*KB, 47961*KB, 48400*KB, 48841*KB, 49284*KB, 49729*KB,
+                         50176*KB, 50625*KB, 51076*KB, 51529*KB, 51984*KB, 52441*KB, 52900*KB, 53361*KB, 53824*KB, 54289*KB, 54756*KB, 55225*KB, 55696*KB, 56169*KB, 56644*KB, 57121*KB,
+                         57600*KB, 58081*KB, 58564*KB, 59049*KB, 59536*KB, 60025*KB, 60516*KB, 61009*KB, 61504*KB, 62001*KB, 62500*KB, 63001*KB, 63504*KB, 64009*KB, 64516*KB, 65025*KB};
 
 // Find the best table to use for a 2x4 area by testing all.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
@@ -1439,7 +1441,7 @@ int tryalltables_3bittable2x4(uint8 *img,int width,int height,int startx,int sta
     int err;
     unsigned int pixel_indices_MSB, pixel_indices_LSB;
 
-    for(q=0;q<16;q+=2)        // try all the 8 tables. 
+    for(q=0;q<16;q+=2)        // try all the 8 tables.
     {
         err=compressBlockWithTable2x4(img,width,height,startx,starty,avg_color,q,&pixel_indices_MSB, &pixel_indices_LSB);
 
@@ -1455,7 +1457,7 @@ int tryalltables_3bittable2x4(uint8 *img,int width,int height,int startx,int sta
 }
 
 // Find the best table to use for a 2x4 area by testing all.
-// Uses perceptual weighting. 
+// Uses perceptual weighting.
 // Uses fixed point implementation where 1000 equals 1.0
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 unsigned int tryalltables_3bittable2x4percep1000(uint8 *img,int width,int height,int startx,int starty,uint8 *avg_color, unsigned int &best_table,unsigned int &best_pixel_indices_MSB, unsigned int &best_pixel_indices_LSB)
@@ -1465,7 +1467,7 @@ unsigned int tryalltables_3bittable2x4percep1000(uint8 *img,int width,int height
     unsigned int err;
     unsigned int pixel_indices_MSB, pixel_indices_LSB;
 
-    for(q=0;q<16;q+=2)        // try all the 8 tables. 
+    for(q=0;q<16;q+=2)        // try all the 8 tables.
     {
 
         err=compressBlockWithTable2x4percep1000(img,width,height,startx,starty,avg_color,q,&pixel_indices_MSB, &pixel_indices_LSB);
@@ -1484,7 +1486,7 @@ unsigned int tryalltables_3bittable2x4percep1000(uint8 *img,int width,int height
 }
 
 // Find the best table to use for a 2x4 area by testing all.
-// Uses perceptual weighting. 
+// Uses perceptual weighting.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 int tryalltables_3bittable2x4percep(uint8 *img,int width,int height,int startx,int starty,uint8 *avg_color, unsigned int &best_table,unsigned int &best_pixel_indices_MSB, unsigned int &best_pixel_indices_LSB)
 {
@@ -1493,7 +1495,7 @@ int tryalltables_3bittable2x4percep(uint8 *img,int width,int height,int startx,i
     float err;
     unsigned int pixel_indices_MSB, pixel_indices_LSB;
 
-    for(q=0;q<16;q+=2)        // try all the 8 tables. 
+    for(q=0;q<16;q+=2)        // try all the 8 tables.
     {
         err=compressBlockWithTable2x4percep(img,width,height,startx,starty,avg_color,q,&pixel_indices_MSB, &pixel_indices_LSB);
 
@@ -1518,7 +1520,7 @@ int tryalltables_3bittable4x2(uint8 *img,int width,int height,int startx,int sta
     int err;
     unsigned int pixel_indices_MSB, pixel_indices_LSB;
 
-    for(q=0;q<16;q+=2)        // try all the 8 tables. 
+    for(q=0;q<16;q+=2)        // try all the 8 tables.
     {
         err=compressBlockWithTable4x2(img,width,height,startx,starty,avg_color,q,&pixel_indices_MSB, &pixel_indices_LSB);
 
@@ -1535,7 +1537,7 @@ int tryalltables_3bittable4x2(uint8 *img,int width,int height,int startx,int sta
 }
 
 // Find the best table to use for a 4x2 area by testing all.
-// Uses perceptual weighting. 
+// Uses perceptual weighting.
 // Uses fixed point implementation where 1000 equals 1.0
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 unsigned int tryalltables_3bittable4x2percep1000(uint8 *img,int width,int height,int startx,int starty,uint8 *avg_color, unsigned int &best_table,unsigned int &best_pixel_indices_MSB, unsigned int &best_pixel_indices_LSB)
@@ -1545,7 +1547,7 @@ unsigned int tryalltables_3bittable4x2percep1000(uint8 *img,int width,int height
     unsigned int err;
     unsigned int pixel_indices_MSB, pixel_indices_LSB;
 
-    for(q=0;q<16;q+=2)        // try all the 8 tables. 
+    for(q=0;q<16;q+=2)        // try all the 8 tables.
     {
         err=compressBlockWithTable4x2percep1000(img,width,height,startx,starty,avg_color,q,&pixel_indices_MSB, &pixel_indices_LSB);
 
@@ -1561,7 +1563,7 @@ unsigned int tryalltables_3bittable4x2percep1000(uint8 *img,int width,int height
 }
 
 // Find the best table to use for a 4x2 area by testing all.
-// Uses perceptual weighting. 
+// Uses perceptual weighting.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 int tryalltables_3bittable4x2percep(uint8 *img,int width,int height,int startx,int starty,uint8 *avg_color, unsigned int &best_table,unsigned int &best_pixel_indices_MSB, unsigned int &best_pixel_indices_LSB)
 {
@@ -1570,7 +1572,7 @@ int tryalltables_3bittable4x2percep(uint8 *img,int width,int height,int startx,i
     float err;
     unsigned int pixel_indices_MSB, pixel_indices_LSB;
 
-    for(q=0;q<16;q+=2)        // try all the 8 tables. 
+    for(q=0;q<16;q+=2)        // try all the 8 tables.
     {
         err=compressBlockWithTable4x2percep(img,width,height,startx,starty,avg_color,q,&pixel_indices_MSB, &pixel_indices_LSB);
 
@@ -1585,13 +1587,13 @@ int tryalltables_3bittable4x2percep(uint8 *img,int width,int height,int startx,i
     return (int) min_error;
 }
 
-// The below code quantizes a float RGB value to RGB444. 
+// The below code quantizes a float RGB value to RGB444.
 //
 // The format often allows a pixel to completely compensate an intensity error of the base
 // color. Hence the closest RGB444 point may not be the best, and the code below uses
 // this fact to find a better RGB444 color as the base color.
 //
-// (See the presentation http://www.jacobstrom.com/publications/PACKMAN.ppt for more info.) 
+// (See the presentation http://www.jacobstrom.com/publications/PACKMAN.ppt for more info.)
 //
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 void quantize444ColorCombined(float *avg_col_in, int *enc_color, uint8 *avg_color)
@@ -1613,7 +1615,7 @@ void quantize444ColorCombined(float *avg_col_in, int *enc_color, uint8 *avg_colo
 
     int red_4bit_low, green_4bit_low, blue_4bit_low;
     int red_4bit_high, green_4bit_high, blue_4bit_high;
-    
+
     // These are the values that we approximate with:
     int red_low, green_low, blue_low;
     int red_high, green_high, blue_high;
@@ -1695,7 +1697,7 @@ void quantize444ColorCombined(float *avg_col_in, int *enc_color, uint8 *avg_colo
         // Since the step size is always 17 in RGB444 format (15*17=255),
         // kr = kg = kb = 17, which means that case 0 and case 7 will
         // always have equal projected error. Choose the one that is
-        // closer to the desired color. 
+        // closer to the desired color.
         if(dr*dr + dg*dg + db*db > 3*8*8)
         {
             enc_color[0] = high_color[0];
@@ -1714,32 +1716,32 @@ void quantize444ColorCombined(float *avg_col_in, int *enc_color, uint8 *avg_colo
         enc_color[1] = low_color[1];
         enc_color[2] = low_color[2];
         break;
-    case 2:    
+    case 2:
         enc_color[0] = low_color[0];
         enc_color[1] = high_color[1];
         enc_color[2] = low_color[2];
         break;
-    case 3:    
+    case 3:
         enc_color[0] = low_color[0];
         enc_color[1] = low_color[1];
         enc_color[2] = high_color[2];
         break;
-    case 4:    
+    case 4:
         enc_color[0] = high_color[0];
         enc_color[1] = high_color[1];
         enc_color[2] = low_color[2];
         break;
-    case 5:    
+    case 5:
         enc_color[0] = high_color[0];
         enc_color[1] = low_color[1];
         enc_color[2] = high_color[2];
         break;
-    case 6:    
+    case 6:
         enc_color[0] = low_color[0];
         enc_color[1] = high_color[1];
         enc_color[2] = high_color[2];
         break;
-    case 7:    
+    case 7:
         if(dr*dr + dg*dg + db*db > 3*8*8)
         {
             enc_color[0] = high_color[0];
@@ -1757,16 +1759,16 @@ void quantize444ColorCombined(float *avg_col_in, int *enc_color, uint8 *avg_colo
     // Expand 5-bit encoded color to 8-bit color
     avg_color[0] = (enc_color[0] << 3) | (enc_color[0] >> 2);
     avg_color[1] = (enc_color[1] << 3) | (enc_color[1] >> 2);
-    avg_color[2] = (enc_color[2] << 3) | (enc_color[2] >> 2);    
+    avg_color[2] = (enc_color[2] << 3) | (enc_color[2] >> 2);
 }
 
-// The below code quantizes a float RGB value to RGB555. 
+// The below code quantizes a float RGB value to RGB555.
 //
 // The format often allows a pixel to completely compensate an intensity error of the base
 // color. Hence the closest RGB555 point may not be the best, and the code below uses
 // this fact to find a better RGB555 color as the base color.
 //
-// (See the presentation http://www.jacobstrom.com/publications/PACKMAN.ppt for more info.) 
+// (See the presentation http://www.jacobstrom.com/publications/PACKMAN.ppt for more info.)
 //
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 void quantize555ColorCombined(float *avg_col_in, int *enc_color, uint8 *avg_color)
@@ -1788,7 +1790,7 @@ void quantize555ColorCombined(float *avg_col_in, int *enc_color, uint8 *avg_colo
 
     int red_5bit_low, green_5bit_low, blue_5bit_low;
     int red_5bit_high, green_5bit_high, blue_5bit_high;
-    
+
     // These are the values that we approximate with:
     int red_low, green_low, blue_low;
     int red_high, green_high, blue_high;
@@ -1876,32 +1878,32 @@ void quantize555ColorCombined(float *avg_col_in, int *enc_color, uint8 *avg_colo
         enc_color[1] = low_color[1];
         enc_color[2] = low_color[2];
         break;
-    case 2:    
+    case 2:
         enc_color[0] = low_color[0];
         enc_color[1] = high_color[1];
         enc_color[2] = low_color[2];
         break;
-    case 3:    
+    case 3:
         enc_color[0] = low_color[0];
         enc_color[1] = low_color[1];
         enc_color[2] = high_color[2];
         break;
-    case 4:    
+    case 4:
         enc_color[0] = high_color[0];
         enc_color[1] = high_color[1];
         enc_color[2] = low_color[2];
         break;
-    case 5:    
+    case 5:
         enc_color[0] = high_color[0];
         enc_color[1] = low_color[1];
         enc_color[2] = high_color[2];
         break;
-    case 6:    
+    case 6:
         enc_color[0] = low_color[0];
         enc_color[1] = high_color[1];
         enc_color[2] = high_color[2];
         break;
-    case 7:    
+    case 7:
         enc_color[0] = high_color[0];
         enc_color[1] = high_color[1];
         enc_color[2] = high_color[2];
@@ -1912,16 +1914,16 @@ void quantize555ColorCombined(float *avg_col_in, int *enc_color, uint8 *avg_colo
     avg_color[0] = (enc_color[0] << 3) | (enc_color[0] >> 2);
     avg_color[1] = (enc_color[1] << 3) | (enc_color[1] >> 2);
     avg_color[2] = (enc_color[2] << 3) | (enc_color[2] >> 2);
-    
+
 }
 
-// The below code quantizes a float RGB value to RGB444. 
+// The below code quantizes a float RGB value to RGB444.
 //
 // The format often allows a pixel to completely compensate an intensity error of the base
 // color. Hence the closest RGB444 point may not be the best, and the code below uses
 // this fact to find a better RGB444 color as the base color.
 //
-// (See the presentation http://www.jacobstrom.com/publications/PACKMAN.ppt for more info.) 
+// (See the presentation http://www.jacobstrom.com/publications/PACKMAN.ppt for more info.)
 //
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 void quantize444ColorCombinedPerceptual(float *avg_col_in, int *enc_color, uint8 *avg_color)
@@ -1943,7 +1945,7 @@ void quantize444ColorCombinedPerceptual(float *avg_col_in, int *enc_color, uint8
 
     int red_4bit_low, green_4bit_low, blue_4bit_low;
     int red_4bit_high, green_4bit_high, blue_4bit_high;
-    
+
     // These are the values that we approximate with:
     int red_low, green_low, blue_low;
     int red_high, green_high, blue_high;
@@ -1990,8 +1992,8 @@ void quantize444ColorCombinedPerceptual(float *avg_col_in, int *enc_color, uint8
     db = blue_low - blue_average;
 
     // Perceptual weights to use
-    wR2 = (float) PERCEPTUAL_WEIGHT_R_SQUARED; 
-    wG2 = (float) PERCEPTUAL_WEIGHT_G_SQUARED; 
+    wR2 = (float) PERCEPTUAL_WEIGHT_R_SQUARED;
+    wG2 = (float) PERCEPTUAL_WEIGHT_G_SQUARED;
     wB2 = (float) PERCEPTUAL_WEIGHT_B_SQUARED;
 
     lowhightable[0] = wR2*wG2*SQUARE( (dr+ 0) - (dg+ 0) ) + wR2*wB2*SQUARE( (dr+ 0) - (db+ 0) ) + wG2*wB2*SQUARE( (dg+ 0) - (db+ 0) );
@@ -2031,32 +2033,32 @@ void quantize444ColorCombinedPerceptual(float *avg_col_in, int *enc_color, uint8
         enc_color[1] = low_color[1];
         enc_color[2] = low_color[2];
         break;
-    case 2:    
+    case 2:
         enc_color[0] = low_color[0];
         enc_color[1] = high_color[1];
         enc_color[2] = low_color[2];
         break;
-    case 3:    
+    case 3:
         enc_color[0] = low_color[0];
         enc_color[1] = low_color[1];
         enc_color[2] = high_color[2];
         break;
-    case 4:    
+    case 4:
         enc_color[0] = high_color[0];
         enc_color[1] = high_color[1];
         enc_color[2] = low_color[2];
         break;
-    case 5:    
+    case 5:
         enc_color[0] = high_color[0];
         enc_color[1] = low_color[1];
         enc_color[2] = high_color[2];
         break;
-    case 6:    
+    case 6:
         enc_color[0] = low_color[0];
         enc_color[1] = high_color[1];
         enc_color[2] = high_color[2];
         break;
-    case 7:    
+    case 7:
         enc_color[0] = high_color[0];
         enc_color[1] = high_color[1];
         enc_color[2] = high_color[2];
@@ -2069,13 +2071,13 @@ void quantize444ColorCombinedPerceptual(float *avg_col_in, int *enc_color, uint8
     avg_color[2] = (enc_color[2] << 4) | enc_color[2];
 }
 
-// The below code quantizes a float RGB value to RGB555. 
+// The below code quantizes a float RGB value to RGB555.
 //
 // The format often allows a pixel to completely compensate an intensity error of the base
 // color. Hence the closest RGB555 point may not be the best, and the code below uses
 // this fact to find a better RGB555 color as the base color.
 //
-// (See the presentation http://www.jacobstrom.com/publications/PACKMAN.ppt for more info.) 
+// (See the presentation http://www.jacobstrom.com/publications/PACKMAN.ppt for more info.)
 //
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 void quantize555ColorCombinedPerceptual(float *avg_col_in, int *enc_color, uint8 *avg_color)
@@ -2097,7 +2099,7 @@ void quantize555ColorCombinedPerceptual(float *avg_col_in, int *enc_color, uint8
 
     int red_5bit_low, green_5bit_low, blue_5bit_low;
     int red_5bit_high, green_5bit_high, blue_5bit_high;
-    
+
     // These are the values that we approximate with:
     int red_low, green_low, blue_low;
     int red_high, green_high, blue_high;
@@ -2144,8 +2146,8 @@ void quantize555ColorCombinedPerceptual(float *avg_col_in, int *enc_color, uint8
     db = blue_low - blue_average;
 
     // Perceptual weights to use
-    wR2 = (float) PERCEPTUAL_WEIGHT_R_SQUARED; 
-    wG2 = (float) PERCEPTUAL_WEIGHT_G_SQUARED; 
+    wR2 = (float) PERCEPTUAL_WEIGHT_R_SQUARED;
+    wG2 = (float) PERCEPTUAL_WEIGHT_G_SQUARED;
     wB2 = (float) PERCEPTUAL_WEIGHT_B_SQUARED;
 
     lowhightable[0] = wR2*wG2*SQUARE( (dr+ 0) - (dg+ 0) ) + wR2*wB2*SQUARE( (dr+ 0) - (db+ 0) ) + wG2*wB2*SQUARE( (dg+ 0) - (db+ 0) );
@@ -2185,32 +2187,32 @@ void quantize555ColorCombinedPerceptual(float *avg_col_in, int *enc_color, uint8
         enc_color[1] = low_color[1];
         enc_color[2] = low_color[2];
         break;
-    case 2:    
+    case 2:
         enc_color[0] = low_color[0];
         enc_color[1] = high_color[1];
         enc_color[2] = low_color[2];
         break;
-    case 3:    
+    case 3:
         enc_color[0] = low_color[0];
         enc_color[1] = low_color[1];
         enc_color[2] = high_color[2];
         break;
-    case 4:    
+    case 4:
         enc_color[0] = high_color[0];
         enc_color[1] = high_color[1];
         enc_color[2] = low_color[2];
         break;
-    case 5:    
+    case 5:
         enc_color[0] = high_color[0];
         enc_color[1] = low_color[1];
         enc_color[2] = high_color[2];
         break;
-    case 6:    
+    case 6:
         enc_color[0] = low_color[0];
         enc_color[1] = high_color[1];
         enc_color[2] = high_color[2];
         break;
-    case 7:    
+    case 7:
         enc_color[0] = high_color[0];
         enc_color[1] = high_color[1];
         enc_color[2] = high_color[2];
@@ -2264,33 +2266,33 @@ unsigned int compressBlockOnlyIndividualAveragePerceptual1000(uint8 *img,int wid
     avg_color_quant2[1] = enc_color2[1] << 4 | (enc_color2[1] );
     avg_color_quant2[2] = enc_color2[2] << 4 | (enc_color2[2] );
 
-    // Pack bits into the first word. 
+    // Pack bits into the first word.
 
     //     ETC1_RGB8_OES:
-    // 
+    //
     //     a) bit layout in bits 63 through 32 if diffbit = 0
-    // 
-    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+    //
+    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
     //      ---------------------------------------------------------------------------------------------------
     //     | base col1 | base col2 | base col1 | base col2 | base col1 | base col2 | table  | table  |diff|flip|
     //     | R1 (4bits)| R2 (4bits)| G1 (4bits)| G2 (4bits)| B1 (4bits)| B2 (4bits)| cw 1   | cw 2   |bit |bit |
     //      ---------------------------------------------------------------------------------------------------
-    //     
+    //
     //     b) bit layout in bits 63 through 32 if diffbit = 1
-    // 
-    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+    //
+    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
     //      ---------------------------------------------------------------------------------------------------
     //     | base col1    | dcol 2 | base col1    | dcol 2 | base col 1   | dcol 2 | table  | table  |diff|flip|
     //     | R1' (5 bits) | dR2    | G1' (5 bits) | dG2    | B1' (5 bits) | dB2    | cw 1   | cw 2   |bit |bit |
     //      ---------------------------------------------------------------------------------------------------
-    // 
+    //
     //     c) bit layout in bits 31 through 0 (in both cases)
-    // 
+    //
     //      31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10  9  8  7  6  5  4  3   2   1  0
     //      --------------------------------------------------------------------------------------------------
-    //     |       most significant pixel index bits       |         least significant pixel index bits       |  
+    //     |       most significant pixel index bits       |         least significant pixel index bits       |
     //     | p| o| n| m| l| k| j| i| h| g| f| e| d| c| b| a| p| o| n| m| l| k| j| i| h| g| f| e| d| c | b | a |
-    //      --------------------------------------------------------------------------------------------------      
+    //      --------------------------------------------------------------------------------------------------
 
     compressed1_norm = 0;
     PUTBITSHIGH( compressed1_norm, diffbit,       1, 33);
@@ -2312,7 +2314,7 @@ unsigned int compressBlockOnlyIndividualAveragePerceptual1000(uint8 *img,int wid
     best_enc_color2[0] = enc_color2[0];
     best_enc_color2[1] = enc_color2[1];
     best_enc_color2[2] = enc_color2[2];
-    
+
     best_color_left[0] = enc_color1[0];
     best_color_left[1] = enc_color1[1];
     best_color_left[2] = enc_color1[2];
@@ -2346,7 +2348,7 @@ unsigned int compressBlockOnlyIndividualAveragePerceptual1000(uint8 *img,int wid
     computeAverageColor4x2noQuantFloat(img,width,height,startx,starty+2,avg_color_float2);
 
     // First test if avg_color1 is similar enough to avg_color2 so that
-    // we can use differential coding of colors. 
+    // we can use differential coding of colors.
 
     enc_color1[0] = int( JAS_ROUND(15.0*avg_color_float1[0]/255.0) );
     enc_color1[1] = int( JAS_ROUND(15.0*avg_color_float1[1]/255.0) );
@@ -2371,7 +2373,7 @@ unsigned int compressBlockOnlyIndividualAveragePerceptual1000(uint8 *img,int wid
     avg_color_quant2[1] = enc_color2[1] << 4 | (enc_color2[1] );
     avg_color_quant2[2] = enc_color2[2] << 4 | (enc_color2[2] );
 
-    // Pack bits into the first word. 
+    // Pack bits into the first word.
 
     compressed1_flip = 0;
     PUTBITSHIGH( compressed1_flip, diffbit,       1, 33);
@@ -2395,10 +2397,10 @@ unsigned int compressBlockOnlyIndividualAveragePerceptual1000(uint8 *img,int wid
 
     best_pixel_indices1_MSB |= (best_pixel_indices2_MSB << 2);
     best_pixel_indices1_LSB |= (best_pixel_indices2_LSB << 2);
-    
+
     compressed2_flip = ((best_pixel_indices1_MSB & 0xffff) << 16) | (best_pixel_indices1_LSB & 0xffff);
 
-    // Now lets see which is the best table to use. Only 8 tables are possible. 
+    // Now lets see which is the best table to use. Only 8 tables are possible.
 
     if(norm_err <= flip_err)
     {
@@ -2463,33 +2465,33 @@ int compressBlockOnlyIndividualAverage(uint8 *img,int width,int height,int start
     avg_color_quant2[1] = enc_color2[1] << 4 | (enc_color2[1] );
     avg_color_quant2[2] = enc_color2[2] << 4 | (enc_color2[2] );
 
-    // Pack bits into the first word. 
+    // Pack bits into the first word.
 
     //     ETC1_RGB8_OES:
-    // 
+    //
     //     a) bit layout in bits 63 through 32 if diffbit = 0
-    // 
-    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+    //
+    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
     //      ---------------------------------------------------------------------------------------------------
     //     | base col1 | base col2 | base col1 | base col2 | base col1 | base col2 | table  | table  |diff|flip|
     //     | R1 (4bits)| R2 (4bits)| G1 (4bits)| G2 (4bits)| B1 (4bits)| B2 (4bits)| cw 1   | cw 2   |bit |bit |
     //      ---------------------------------------------------------------------------------------------------
-    //     
+    //
     //     b) bit layout in bits 63 through 32 if diffbit = 1
-    // 
-    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+    //
+    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
     //      ---------------------------------------------------------------------------------------------------
     //     | base col1    | dcol 2 | base col1    | dcol 2 | base col 1   | dcol 2 | table  | table  |diff|flip|
     //     | R1' (5 bits) | dR2    | G1' (5 bits) | dG2    | B1' (5 bits) | dB2    | cw 1   | cw 2   |bit |bit |
     //      ---------------------------------------------------------------------------------------------------
-    // 
+    //
     //     c) bit layout in bits 31 through 0 (in both cases)
-    // 
+    //
     //      31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10  9  8  7  6  5  4  3   2   1  0
     //      --------------------------------------------------------------------------------------------------
-    //     |       most significant pixel index bits       |         least significant pixel index bits       |  
+    //     |       most significant pixel index bits       |         least significant pixel index bits       |
     //     | p| o| n| m| l| k| j| i| h| g| f| e| d| c| b| a| p| o| n| m| l| k| j| i| h| g| f| e| d| c | b | a |
-    //      --------------------------------------------------------------------------------------------------      
+    //      --------------------------------------------------------------------------------------------------
 
     compressed1_norm = 0;
     PUTBITSHIGH( compressed1_norm, diffbit,       1, 33);
@@ -2545,7 +2547,7 @@ int compressBlockOnlyIndividualAverage(uint8 *img,int width,int height,int start
     computeAverageColor4x2noQuantFloat(img,width,height,startx,starty+2,avg_color_float2);
 
     // First test if avg_color1 is similar enough to avg_color2 so that
-    // we can use differential coding of colors. 
+    // we can use differential coding of colors.
 
     enc_color1[0] = int( JAS_ROUND(15.0*avg_color_float1[0]/255.0) );
     enc_color1[1] = int( JAS_ROUND(15.0*avg_color_float1[1]/255.0) );
@@ -2570,7 +2572,7 @@ int compressBlockOnlyIndividualAverage(uint8 *img,int width,int height,int start
     avg_color_quant2[1] = enc_color2[1] << 4 | (enc_color2[1] );
     avg_color_quant2[2] = enc_color2[2] << 4 | (enc_color2[2] );
 
-    // Pack bits into the first word. 
+    // Pack bits into the first word.
 
     compressed1_flip = 0;
     PUTBITSHIGH( compressed1_flip, diffbit,       1, 33);
@@ -2594,10 +2596,10 @@ int compressBlockOnlyIndividualAverage(uint8 *img,int width,int height,int start
 
     best_pixel_indices1_MSB |= (best_pixel_indices2_MSB << 2);
     best_pixel_indices1_LSB |= (best_pixel_indices2_LSB << 2);
-    
+
     compressed2_flip = ((best_pixel_indices1_MSB & 0xffff) << 16) | (best_pixel_indices1_LSB & 0xffff);
 
-    // Now lets see which is the best table to use. Only 8 tables are possible. 
+    // Now lets see which is the best table to use. Only 8 tables are possible.
 
     if(norm_err <= flip_err)
     {
@@ -2647,7 +2649,7 @@ void compressBlockDiffFlipAverage(uint8 *img,int width,int height,int startx,int
     computeAverageColor2x4noQuantFloat(img,width,height,startx+2,starty,avg_color_float2);
 
     // First test if avg_color1 is similar enough to avg_color2 so that
-    // we can use differential coding of colors. 
+    // we can use differential coding of colors.
 
     float eps;
 
@@ -2658,8 +2660,8 @@ void compressBlockDiffFlipAverage(uint8 *img,int width,int height,int startx,int
     enc_color2[1] = int( JAS_ROUND(31.0*avg_color_float2[1]/255.0) );
     enc_color2[2] = int( JAS_ROUND(31.0*avg_color_float2[2]/255.0) );
 
-    diff[0] = enc_color2[0]-enc_color1[0];    
-    diff[1] = enc_color2[1]-enc_color1[1];    
+    diff[0] = enc_color2[0]-enc_color1[0];
+    diff[1] = enc_color2[1]-enc_color1[1];
     diff[2] = enc_color2[2]-enc_color1[2];
 
     if( (diff[0] >= -4) && (diff[0] <= 3) && (diff[1] >= -4) && (diff[1] <= 3) && (diff[2] >= -4) && (diff[2] <= 3) )
@@ -2668,8 +2670,8 @@ void compressBlockDiffFlipAverage(uint8 *img,int width,int height,int startx,int
 
         // The difference to be coded:
 
-        diff[0] = enc_color2[0]-enc_color1[0];    
-        diff[1] = enc_color2[1]-enc_color1[1];    
+        diff[0] = enc_color2[0]-enc_color1[0];
+        diff[1] = enc_color2[1]-enc_color1[1];
         diff[2] = enc_color2[2]-enc_color1[2];
 
         avg_color_quant1[0] = enc_color1[0] << 3 | (enc_color1[0] >> 2);
@@ -2679,33 +2681,33 @@ void compressBlockDiffFlipAverage(uint8 *img,int width,int height,int startx,int
         avg_color_quant2[1] = enc_color2[1] << 3 | (enc_color2[1] >> 2);
         avg_color_quant2[2] = enc_color2[2] << 3 | (enc_color2[2] >> 2);
 
-        // Pack bits into the first word. 
+        // Pack bits into the first word.
 
         //     ETC1_RGB8_OES:
-        // 
+        //
         //     a) bit layout in bits 63 through 32 if diffbit = 0
-        // 
-        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+        //
+        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
         //      ---------------------------------------------------------------------------------------------------
         //     | base col1 | base col2 | base col1 | base col2 | base col1 | base col2 | table  | table  |diff|flip|
         //     | R1 (4bits)| R2 (4bits)| G1 (4bits)| G2 (4bits)| B1 (4bits)| B2 (4bits)| cw 1   | cw 2   |bit |bit |
         //      ---------------------------------------------------------------------------------------------------
-        //     
+        //
         //     b) bit layout in bits 63 through 32 if diffbit = 1
-        // 
-        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+        //
+        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
         //      ---------------------------------------------------------------------------------------------------
         //     | base col1    | dcol 2 | base col1    | dcol 2 | base col 1   | dcol 2 | table  | table  |diff|flip|
         //     | R1' (5 bits) | dR2    | G1' (5 bits) | dG2    | B1' (5 bits) | dB2    | cw 1   | cw 2   |bit |bit |
         //      ---------------------------------------------------------------------------------------------------
-        // 
+        //
         //     c) bit layout in bits 31 through 0 (in both cases)
-        // 
+        //
         //      31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10  9  8  7  6  5  4  3   2   1  0
         //      --------------------------------------------------------------------------------------------------
-        //     |       most significant pixel index bits       |         least significant pixel index bits       |  
+        //     |       most significant pixel index bits       |         least significant pixel index bits       |
         //     | p| o| n| m| l| k| j| i| h| g| f| e| d| c| b| a| p| o| n| m| l| k| j| i| h| g| f| e| d| c | b | a |
-        //      --------------------------------------------------------------------------------------------------      
+        //      --------------------------------------------------------------------------------------------------
 
         compressed1_norm = 0;
         PUTBITSHIGH( compressed1_norm, diffbit,       1, 33);
@@ -2753,16 +2755,16 @@ void compressBlockDiffFlipAverage(uint8 *img,int width,int height,int startx,int
         enc_color2[0] = int( ((float) avg_color_float2[0] / (17.0)) +0.5 + eps);
         enc_color2[1] = int( ((float) avg_color_float2[1] / (17.0)) +0.5 + eps);
         enc_color2[2] = int( ((float) avg_color_float2[2] / (17.0)) +0.5 + eps);
-        avg_color_quant1[0] = enc_color1[0] << 4 | enc_color1[0]; 
-        avg_color_quant1[1] = enc_color1[1] << 4 | enc_color1[1]; 
+        avg_color_quant1[0] = enc_color1[0] << 4 | enc_color1[0];
+        avg_color_quant1[1] = enc_color1[1] << 4 | enc_color1[1];
         avg_color_quant1[2] = enc_color1[2] << 4 | enc_color1[2];
-        avg_color_quant2[0] = enc_color2[0] << 4 | enc_color2[0]; 
-        avg_color_quant2[1] = enc_color2[1] << 4 | enc_color2[1]; 
+        avg_color_quant2[0] = enc_color2[0] << 4 | enc_color2[0];
+        avg_color_quant2[1] = enc_color2[1] << 4 | enc_color2[1];
         avg_color_quant2[2] = enc_color2[2] << 4 | enc_color2[2];
 
-        // Pack bits into the first word. 
+        // Pack bits into the first word.
 
-        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
         //      ---------------------------------------------------------------------------------------------------
         //     | base col1 | base col2 | base col1 | base col2 | base col1 | base col2 | table  | table  |diff|flip|
         //     | R1 (4bits)| R2 (4bits)| G1 (4bits)| G2 (4bits)| B1 (4bits)| B2 (4bits)| cw 1   | cw 2   |bit |bit |
@@ -2781,7 +2783,7 @@ void compressBlockDiffFlipAverage(uint8 *img,int width,int height,int startx,int
         unsigned int best_pixel_indices1_LSB;
         unsigned int best_pixel_indices2_MSB;
         unsigned int best_pixel_indices2_LSB;
-        
+
         // left part of block
         norm_err = tryalltables_3bittable2x4(img,width,height,startx,starty,avg_color_quant1,best_table1,best_pixel_indices1_MSB, best_pixel_indices1_LSB);
 
@@ -2805,7 +2807,7 @@ void compressBlockDiffFlipAverage(uint8 *img,int width,int height,int startx,int
     computeAverageColor4x2noQuantFloat(img,width,height,startx,starty+2,avg_color_float2);
 
     // First test if avg_color1 is similar enough to avg_color2 so that
-    // we can use differential coding of colors. 
+    // we can use differential coding of colors.
 
     enc_color1[0] = int( JAS_ROUND(31.0*avg_color_float1[0]/255.0) );
     enc_color1[1] = int( JAS_ROUND(31.0*avg_color_float1[1]/255.0) );
@@ -2814,8 +2816,8 @@ void compressBlockDiffFlipAverage(uint8 *img,int width,int height,int startx,int
     enc_color2[1] = int( JAS_ROUND(31.0*avg_color_float2[1]/255.0) );
     enc_color2[2] = int( JAS_ROUND(31.0*avg_color_float2[2]/255.0) );
 
-    diff[0] = enc_color2[0]-enc_color1[0];    
-    diff[1] = enc_color2[1]-enc_color1[1];    
+    diff[0] = enc_color2[0]-enc_color1[0];
+    diff[1] = enc_color2[1]-enc_color1[1];
     diff[2] = enc_color2[2]-enc_color1[2];
 
     if( (diff[0] >= -4) && (diff[0] <= 3) && (diff[1] >= -4) && (diff[1] <= 3) && (diff[2] >= -4) && (diff[2] <= 3) )
@@ -2824,8 +2826,8 @@ void compressBlockDiffFlipAverage(uint8 *img,int width,int height,int startx,int
 
         // The difference to be coded:
 
-        diff[0] = enc_color2[0]-enc_color1[0];    
-        diff[1] = enc_color2[1]-enc_color1[1];    
+        diff[0] = enc_color2[0]-enc_color1[0];
+        diff[1] = enc_color2[1]-enc_color1[1];
         diff[2] = enc_color2[2]-enc_color1[2];
 
         avg_color_quant1[0] = enc_color1[0] << 3 | (enc_color1[0] >> 2);
@@ -2835,7 +2837,7 @@ void compressBlockDiffFlipAverage(uint8 *img,int width,int height,int startx,int
         avg_color_quant2[1] = enc_color2[1] << 3 | (enc_color2[1] >> 2);
         avg_color_quant2[2] = enc_color2[2] << 3 | (enc_color2[2] >> 2);
 
-        // Pack bits into the first word. 
+        // Pack bits into the first word.
 
         compressed1_flip = 0;
         PUTBITSHIGH( compressed1_flip, diffbit,       1, 33);
@@ -2862,7 +2864,7 @@ void compressBlockDiffFlipAverage(uint8 *img,int width,int height,int startx,int
 
         best_pixel_indices1_MSB |= (best_pixel_indices2_MSB << 2);
         best_pixel_indices1_LSB |= (best_pixel_indices2_LSB << 2);
-        
+
         compressed2_flip = ((best_pixel_indices1_MSB & 0xffff) << 16) | (best_pixel_indices1_LSB & 0xffff);
     }
     else
@@ -2879,21 +2881,21 @@ void compressBlockDiffFlipAverage(uint8 *img,int width,int height,int startx,int
         enc_color2[1] = int( ((float) avg_color_float2[1] / (17.0)) +0.5 + eps);
         enc_color2[2] = int( ((float) avg_color_float2[2] / (17.0)) +0.5 + eps);
 
-        avg_color_quant1[0] = enc_color1[0] << 4 | enc_color1[0]; 
-        avg_color_quant1[1] = enc_color1[1] << 4 | enc_color1[1]; 
+        avg_color_quant1[0] = enc_color1[0] << 4 | enc_color1[0];
+        avg_color_quant1[1] = enc_color1[1] << 4 | enc_color1[1];
         avg_color_quant1[2] = enc_color1[2] << 4 | enc_color1[2];
-        avg_color_quant2[0] = enc_color2[0] << 4 | enc_color2[0]; 
-        avg_color_quant2[1] = enc_color2[1] << 4 | enc_color2[1]; 
+        avg_color_quant2[0] = enc_color2[0] << 4 | enc_color2[0];
+        avg_color_quant2[1] = enc_color2[1] << 4 | enc_color2[1];
         avg_color_quant2[2] = enc_color2[2] << 4 | enc_color2[2];
 
-        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
         //      ---------------------------------------------------------------------------------------------------
         //     | base col1 | base col2 | base col1 | base col2 | base col1 | base col2 | table  | table  |diff|flip|
         //     | R1 (4bits)| R2 (4bits)| G1 (4bits)| G2 (4bits)| B1 (4bits)| B2 (4bits)| cw 1   | cw 2   |bit |bit |
         //      ---------------------------------------------------------------------------------------------------
 
 
-        // Pack bits into the first word. 
+        // Pack bits into the first word.
 
         compressed1_flip = 0;
         PUTBITSHIGH( compressed1_flip, diffbit,       1, 33);
@@ -2920,11 +2922,11 @@ void compressBlockDiffFlipAverage(uint8 *img,int width,int height,int startx,int
 
         best_pixel_indices1_MSB |= (best_pixel_indices2_MSB << 2);
         best_pixel_indices1_LSB |= (best_pixel_indices2_LSB << 2);
-        
+
         compressed2_flip = ((best_pixel_indices1_MSB & 0xffff) << 16) | (best_pixel_indices1_LSB & 0xffff);
     }
 
-    // Now lets see which is the best table to use. Only 8 tables are possible. 
+    // Now lets see which is the best table to use. Only 8 tables are possible.
 
     if(norm_err <= flip_err)
     {
@@ -2966,7 +2968,7 @@ int compressBlockOnlyDiffFlipAverage(uint8 *img,int width,int height,int startx,
     computeAverageColor2x4noQuantFloat(img,width,height,startx+2,starty,avg_color_float2);
 
     // First test if avg_color1 is similar enough to avg_color2 so that
-    // we can use differential coding of colors. 
+    // we can use differential coding of colors.
 
     enc_color1[0] = int( JAS_ROUND(31.0*avg_color_float1[0]/255.0) );
     enc_color1[1] = int( JAS_ROUND(31.0*avg_color_float1[1]/255.0) );
@@ -2975,8 +2977,8 @@ int compressBlockOnlyDiffFlipAverage(uint8 *img,int width,int height,int startx,
     enc_color2[1] = int( JAS_ROUND(31.0*avg_color_float2[1]/255.0) );
     enc_color2[2] = int( JAS_ROUND(31.0*avg_color_float2[2]/255.0) );
 
-    diff[0] = enc_color2[0]-enc_color1[0];    
-    diff[1] = enc_color2[1]-enc_color1[1];    
+    diff[0] = enc_color2[0]-enc_color1[0];
+    diff[1] = enc_color2[1]-enc_color1[1];
     diff[2] = enc_color2[2]-enc_color1[2];
 
     if( !((diff[0] >= -4) && (diff[0] <= 3) && (diff[1] >= -4) && (diff[1] <= 3) && (diff[2] >= -4) && (diff[2] <= 3)) )
@@ -2988,8 +2990,8 @@ int compressBlockOnlyDiffFlipAverage(uint8 *img,int width,int height,int startx,
         enc_color2[0] = enc_color1[0];
         enc_color2[1] = enc_color1[1];
         enc_color2[2] = enc_color1[2];
-        diff[0] = enc_color2[0]-enc_color1[0];    
-        diff[1] = enc_color2[1]-enc_color1[1];    
+        diff[0] = enc_color2[0]-enc_color1[0];
+        diff[1] = enc_color2[1]-enc_color1[1];
         diff[2] = enc_color2[2]-enc_color1[2];
     }
 
@@ -2997,8 +2999,8 @@ int compressBlockOnlyDiffFlipAverage(uint8 *img,int width,int height,int startx,
 
     // The difference to be coded:
 
-    diff[0] = enc_color2[0]-enc_color1[0];    
-    diff[1] = enc_color2[1]-enc_color1[1];    
+    diff[0] = enc_color2[0]-enc_color1[0];
+    diff[1] = enc_color2[1]-enc_color1[1];
     diff[2] = enc_color2[2]-enc_color1[2];
 
     avg_color_quant1[0] = enc_color1[0] << 3 | (enc_color1[0] >> 2);
@@ -3008,33 +3010,33 @@ int compressBlockOnlyDiffFlipAverage(uint8 *img,int width,int height,int startx,
     avg_color_quant2[1] = enc_color2[1] << 3 | (enc_color2[1] >> 2);
     avg_color_quant2[2] = enc_color2[2] << 3 | (enc_color2[2] >> 2);
 
-    // Pack bits into the first word. 
+    // Pack bits into the first word.
 
     //     ETC1_RGB8_OES:
-    // 
+    //
     //     a) bit layout in bits 63 through 32 if diffbit = 0
-    // 
-    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+    //
+    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
     //      ---------------------------------------------------------------------------------------------------
     //     | base col1 | base col2 | base col1 | base col2 | base col1 | base col2 | table  | table  |diff|flip|
     //     | R1 (4bits)| R2 (4bits)| G1 (4bits)| G2 (4bits)| B1 (4bits)| B2 (4bits)| cw 1   | cw 2   |bit |bit |
     //      ---------------------------------------------------------------------------------------------------
-    //     
+    //
     //     b) bit layout in bits 63 through 32 if diffbit = 1
-    // 
-    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+    //
+    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
     //      ---------------------------------------------------------------------------------------------------
     //     | base col1    | dcol 2 | base col1    | dcol 2 | base col 1   | dcol 2 | table  | table  |diff|flip|
     //     | R1' (5 bits) | dR2    | G1' (5 bits) | dG2    | B1' (5 bits) | dB2    | cw 1   | cw 2   |bit |bit |
     //      ---------------------------------------------------------------------------------------------------
-    // 
+    //
     //     c) bit layout in bits 31 through 0 (in both cases)
-    // 
+    //
     //      31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10  9  8  7  6  5  4  3   2   1  0
     //      --------------------------------------------------------------------------------------------------
-    //     |       most significant pixel index bits       |         least significant pixel index bits       |  
+    //     |       most significant pixel index bits       |         least significant pixel index bits       |
     //     | p| o| n| m| l| k| j| i| h| g| f| e| d| c| b| a| p| o| n| m| l| k| j| i| h| g| f| e| d| c | b | a |
-    //      --------------------------------------------------------------------------------------------------      
+    //      --------------------------------------------------------------------------------------------------
 
     compressed1_norm = 0;
     PUTBITSHIGH( compressed1_norm, diffbit,       1, 33);
@@ -3081,7 +3083,7 @@ int compressBlockOnlyDiffFlipAverage(uint8 *img,int width,int height,int startx,
     computeAverageColor4x2noQuantFloat(img,width,height,startx,starty+2,avg_color_float2);
 
     // First test if avg_color1 is similar enough to avg_color2 so that
-    // we can use differential coding of colors. 
+    // we can use differential coding of colors.
 
     enc_color1[0] = int( JAS_ROUND(31.0*avg_color_float1[0]/255.0) );
     enc_color1[1] = int( JAS_ROUND(31.0*avg_color_float1[1]/255.0) );
@@ -3090,8 +3092,8 @@ int compressBlockOnlyDiffFlipAverage(uint8 *img,int width,int height,int startx,
     enc_color2[1] = int( JAS_ROUND(31.0*avg_color_float2[1]/255.0) );
     enc_color2[2] = int( JAS_ROUND(31.0*avg_color_float2[2]/255.0) );
 
-    diff[0] = enc_color2[0]-enc_color1[0];    
-    diff[1] = enc_color2[1]-enc_color1[1];    
+    diff[0] = enc_color2[0]-enc_color1[0];
+    diff[1] = enc_color2[1]-enc_color1[1];
     diff[2] = enc_color2[2]-enc_color1[2];
 
     if( !((diff[0] >= -4) && (diff[0] <= 3) && (diff[1] >= -4) && (diff[1] <= 3) && (diff[2] >= -4) && (diff[2] <= 3)) )
@@ -3103,16 +3105,16 @@ int compressBlockOnlyDiffFlipAverage(uint8 *img,int width,int height,int startx,
         enc_color2[0] = enc_color1[0];
         enc_color2[1] = enc_color1[1];
         enc_color2[2] = enc_color1[2];
-        diff[0] = enc_color2[0]-enc_color1[0];    
-        diff[1] = enc_color2[1]-enc_color1[1];    
+        diff[0] = enc_color2[0]-enc_color1[0];
+        diff[1] = enc_color2[1]-enc_color1[1];
         diff[2] = enc_color2[2]-enc_color1[2];
     }
     diffbit = 1;
 
     // The difference to be coded:
 
-    diff[0] = enc_color2[0]-enc_color1[0];    
-    diff[1] = enc_color2[1]-enc_color1[1];    
+    diff[0] = enc_color2[0]-enc_color1[0];
+    diff[1] = enc_color2[1]-enc_color1[1];
     diff[2] = enc_color2[2]-enc_color1[2];
 
     avg_color_quant1[0] = enc_color1[0] << 3 | (enc_color1[0] >> 2);
@@ -3122,7 +3124,7 @@ int compressBlockOnlyDiffFlipAverage(uint8 *img,int width,int height,int startx,
     avg_color_quant2[1] = enc_color2[1] << 3 | (enc_color2[1] >> 2);
     avg_color_quant2[2] = enc_color2[2] << 3 | (enc_color2[2] >> 2);
 
-    // Pack bits into the first word. 
+    // Pack bits into the first word.
 
     compressed1_flip = 0;
     PUTBITSHIGH( compressed1_flip, diffbit,       1, 33);
@@ -3144,10 +3146,10 @@ int compressBlockOnlyDiffFlipAverage(uint8 *img,int width,int height,int startx,
 
     best_pixel_indices1_MSB |= (best_pixel_indices2_MSB << 2);
     best_pixel_indices1_LSB |= (best_pixel_indices2_LSB << 2);
-    
+
     compressed2_flip = ((best_pixel_indices1_MSB & 0xffff) << 16) | (best_pixel_indices1_LSB & 0xffff);
 
-    // Now lets see which is the best table to use. Only 8 tables are possible. 
+    // Now lets see which is the best table to use. Only 8 tables are possible.
 
     if(norm_err <= flip_err)
     {
@@ -3200,7 +3202,7 @@ unsigned int compressBlockOnlyDiffFlipAveragePerceptual1000(uint8 *img,int width
     computeAverageColor2x4noQuantFloat(img,width,height,startx+2,starty,avg_color_float2);
 
     // First test if avg_color1 is similar enough to avg_color2 so that
-    // we can use differential coding of colors. 
+    // we can use differential coding of colors.
 
     enc_color1[0] = int( JAS_ROUND(31.0*avg_color_float1[0]/255.0) );
     enc_color1[1] = int( JAS_ROUND(31.0*avg_color_float1[1]/255.0) );
@@ -3209,8 +3211,8 @@ unsigned int compressBlockOnlyDiffFlipAveragePerceptual1000(uint8 *img,int width
     enc_color2[1] = int( JAS_ROUND(31.0*avg_color_float2[1]/255.0) );
     enc_color2[2] = int( JAS_ROUND(31.0*avg_color_float2[2]/255.0) );
 
-    diff[0] = enc_color2[0]-enc_color1[0];    
-    diff[1] = enc_color2[1]-enc_color1[1];    
+    diff[0] = enc_color2[0]-enc_color1[0];
+    diff[1] = enc_color2[1]-enc_color1[1];
     diff[2] = enc_color2[2]-enc_color1[2];
 
     if( !((diff[0] >= -4) && (diff[0] <= 3) && (diff[1] >= -4) && (diff[1] <= 3) && (diff[2] >= -4) && (diff[2] <= 3)) )
@@ -3230,8 +3232,8 @@ unsigned int compressBlockOnlyDiffFlipAveragePerceptual1000(uint8 *img,int width
 
         // The difference to be coded:
 
-        diff[0] = enc_color2[0]-enc_color1[0];    
-        diff[1] = enc_color2[1]-enc_color1[1];    
+        diff[0] = enc_color2[0]-enc_color1[0];
+        diff[1] = enc_color2[1]-enc_color1[1];
         diff[2] = enc_color2[2]-enc_color1[2];
 
         avg_color_quant1[0] = enc_color1[0] << 3 | (enc_color1[0] >> 2);
@@ -3241,33 +3243,33 @@ unsigned int compressBlockOnlyDiffFlipAveragePerceptual1000(uint8 *img,int width
         avg_color_quant2[1] = enc_color2[1] << 3 | (enc_color2[1] >> 2);
         avg_color_quant2[2] = enc_color2[2] << 3 | (enc_color2[2] >> 2);
 
-        // Pack bits into the first word. 
+        // Pack bits into the first word.
 
         //     ETC1_RGB8_OES:
-        // 
+        //
         //     a) bit layout in bits 63 through 32 if diffbit = 0
-        // 
-        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+        //
+        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
         //      ---------------------------------------------------------------------------------------------------
         //     | base col1 | base col2 | base col1 | base col2 | base col1 | base col2 | table  | table  |diff|flip|
         //     | R1 (4bits)| R2 (4bits)| G1 (4bits)| G2 (4bits)| B1 (4bits)| B2 (4bits)| cw 1   | cw 2   |bit |bit |
         //      ---------------------------------------------------------------------------------------------------
-        //     
+        //
         //     b) bit layout in bits 63 through 32 if diffbit = 1
-        // 
-        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+        //
+        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
         //      ---------------------------------------------------------------------------------------------------
         //     | base col1    | dcol 2 | base col1    | dcol 2 | base col 1   | dcol 2 | table  | table  |diff|flip|
         //     | R1' (5 bits) | dR2    | G1' (5 bits) | dG2    | B1' (5 bits) | dB2    | cw 1   | cw 2   |bit |bit |
         //      ---------------------------------------------------------------------------------------------------
-        // 
+        //
         //     c) bit layout in bits 31 through 0 (in both cases)
-        // 
+        //
         //      31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10  9  8  7  6  5  4  3   2   1  0
         //      --------------------------------------------------------------------------------------------------
-        //     |       most significant pixel index bits       |         least significant pixel index bits       |  
+        //     |       most significant pixel index bits       |         least significant pixel index bits       |
         //     | p| o| n| m| l| k| j| i| h| g| f| e| d| c| b| a| p| o| n| m| l| k| j| i| h| g| f| e| d| c | b | a |
-        //      --------------------------------------------------------------------------------------------------      
+        //      --------------------------------------------------------------------------------------------------
 
         compressed1_norm = 0;
         PUTBITSHIGH( compressed1_norm, diffbit,       1, 33);
@@ -3285,7 +3287,7 @@ unsigned int compressBlockOnlyDiffFlipAveragePerceptual1000(uint8 *img,int width
 
         norm_err = 0;
 
-        // left part of block 
+        // left part of block
         norm_err = tryalltables_3bittable2x4percep1000(img,width,height,startx,starty,avg_color_quant1,best_table1,best_pixel_indices1_MSB, best_pixel_indices1_LSB);
 
         // right part of block
@@ -3308,7 +3310,7 @@ unsigned int compressBlockOnlyDiffFlipAveragePerceptual1000(uint8 *img,int width
     computeAverageColor4x2noQuantFloat(img,width,height,startx,starty+2,avg_color_float2);
 
     // First test if avg_color1 is similar enough to avg_color2 so that
-    // we can use differential coding of colors. 
+    // we can use differential coding of colors.
 
     enc_color1[0] = int( JAS_ROUND(31.0*avg_color_float1[0]/255.0) );
     enc_color1[1] = int( JAS_ROUND(31.0*avg_color_float1[1]/255.0) );
@@ -3317,8 +3319,8 @@ unsigned int compressBlockOnlyDiffFlipAveragePerceptual1000(uint8 *img,int width
     enc_color2[1] = int( JAS_ROUND(31.0*avg_color_float2[1]/255.0) );
     enc_color2[2] = int( JAS_ROUND(31.0*avg_color_float2[2]/255.0) );
 
-    diff[0] = enc_color2[0]-enc_color1[0];    
-    diff[1] = enc_color2[1]-enc_color1[1];    
+    diff[0] = enc_color2[0]-enc_color1[0];
+    diff[1] = enc_color2[1]-enc_color1[1];
     diff[2] = enc_color2[2]-enc_color1[2];
 
     if( !((diff[0] >= -4) && (diff[0] <= 3) && (diff[1] >= -4) && (diff[1] <= 3) && (diff[2] >= -4) && (diff[2] <= 3)) )
@@ -3337,8 +3339,8 @@ unsigned int compressBlockOnlyDiffFlipAveragePerceptual1000(uint8 *img,int width
 
         // The difference to be coded:
 
-        diff[0] = enc_color2[0]-enc_color1[0];    
-        diff[1] = enc_color2[1]-enc_color1[1];    
+        diff[0] = enc_color2[0]-enc_color1[0];
+        diff[1] = enc_color2[1]-enc_color1[1];
         diff[2] = enc_color2[2]-enc_color1[2];
 
         avg_color_quant1[0] = enc_color1[0] << 3 | (enc_color1[0] >> 2);
@@ -3348,7 +3350,7 @@ unsigned int compressBlockOnlyDiffFlipAveragePerceptual1000(uint8 *img,int width
         avg_color_quant2[1] = enc_color2[1] << 3 | (enc_color2[1] >> 2);
         avg_color_quant2[2] = enc_color2[2] << 3 | (enc_color2[2] >> 2);
 
-        // Pack bits into the first word. 
+        // Pack bits into the first word.
 
         compressed1_flip = 0;
         PUTBITSHIGH( compressed1_flip, diffbit,       1, 33);
@@ -3375,7 +3377,7 @@ unsigned int compressBlockOnlyDiffFlipAveragePerceptual1000(uint8 *img,int width
 
         best_pixel_indices1_MSB |= (best_pixel_indices2_MSB << 2);
         best_pixel_indices1_LSB |= (best_pixel_indices2_LSB << 2);
-        
+
         compressed2_flip = ((best_pixel_indices1_MSB & 0xffff) << 16) | (best_pixel_indices1_LSB & 0xffff);
     }
     unsigned int best_err;
@@ -3422,7 +3424,7 @@ double compressBlockDiffFlipAveragePerceptual(uint8 *img,int width,int height,in
     computeAverageColor2x4noQuantFloat(img,width,height,startx+2,starty,avg_color_float2);
 
     // First test if avg_color1 is similar enough to avg_color2 so that
-    // we can use differential coding of colors. 
+    // we can use differential coding of colors.
 
     float eps;
 
@@ -3433,8 +3435,8 @@ double compressBlockDiffFlipAveragePerceptual(uint8 *img,int width,int height,in
     enc_color2[1] = int( JAS_ROUND(31.0*avg_color_float2[1]/255.0) );
     enc_color2[2] = int( JAS_ROUND(31.0*avg_color_float2[2]/255.0) );
 
-    diff[0] = enc_color2[0]-enc_color1[0];    
-    diff[1] = enc_color2[1]-enc_color1[1];    
+    diff[0] = enc_color2[0]-enc_color1[0];
+    diff[1] = enc_color2[1]-enc_color1[1];
     diff[2] = enc_color2[2]-enc_color1[2];
 
     if( (diff[0] >= -4) && (diff[0] <= 3) && (diff[1] >= -4) && (diff[1] <= 3) && (diff[2] >= -4) && (diff[2] <= 3) )
@@ -3442,8 +3444,8 @@ double compressBlockDiffFlipAveragePerceptual(uint8 *img,int width,int height,in
         diffbit = 1;
 
         // The difference to be coded:
-        diff[0] = enc_color2[0]-enc_color1[0];    
-        diff[1] = enc_color2[1]-enc_color1[1];    
+        diff[0] = enc_color2[0]-enc_color1[0];
+        diff[1] = enc_color2[1]-enc_color1[1];
         diff[2] = enc_color2[2]-enc_color1[2];
 
         avg_color_quant1[0] = enc_color1[0] << 3 | (enc_color1[0] >> 2);
@@ -3453,33 +3455,33 @@ double compressBlockDiffFlipAveragePerceptual(uint8 *img,int width,int height,in
         avg_color_quant2[1] = enc_color2[1] << 3 | (enc_color2[1] >> 2);
         avg_color_quant2[2] = enc_color2[2] << 3 | (enc_color2[2] >> 2);
 
-        // Pack bits into the first word. 
+        // Pack bits into the first word.
 
         //     ETC1_RGB8_OES:
-        // 
+        //
         //     a) bit layout in bits 63 through 32 if diffbit = 0
-        // 
-        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+        //
+        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
         //      ---------------------------------------------------------------------------------------------------
         //     | base col1 | base col2 | base col1 | base col2 | base col1 | base col2 | table  | table  |diff|flip|
         //     | R1 (4bits)| R2 (4bits)| G1 (4bits)| G2 (4bits)| B1 (4bits)| B2 (4bits)| cw 1   | cw 2   |bit |bit |
         //      ---------------------------------------------------------------------------------------------------
-        //     
+        //
         //     b) bit layout in bits 63 through 32 if diffbit = 1
-        // 
-        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+        //
+        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
         //      ---------------------------------------------------------------------------------------------------
         //     | base col1    | dcol 2 | base col1    | dcol 2 | base col 1   | dcol 2 | table  | table  |diff|flip|
         //     | R1' (5 bits) | dR2    | G1' (5 bits) | dG2    | B1' (5 bits) | dB2    | cw 1   | cw 2   |bit |bit |
         //      ---------------------------------------------------------------------------------------------------
-        // 
+        //
         //     c) bit layout in bits 31 through 0 (in both cases)
-        // 
+        //
         //      31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10  9  8  7  6  5  4  3   2   1  0
         //      --------------------------------------------------------------------------------------------------
-        //     |       most significant pixel index bits       |         least significant pixel index bits       |  
+        //     |       most significant pixel index bits       |         least significant pixel index bits       |
         //     | p| o| n| m| l| k| j| i| h| g| f| e| d| c| b| a| p| o| n| m| l| k| j| i| h| g| f| e| d| c | b | a |
-        //      --------------------------------------------------------------------------------------------------      
+        //      --------------------------------------------------------------------------------------------------
 
         compressed1_norm = 0;
         PUTBITSHIGH( compressed1_norm, diffbit,       1, 33);
@@ -3497,7 +3499,7 @@ double compressBlockDiffFlipAveragePerceptual(uint8 *img,int width,int height,in
 
         norm_err = 0;
 
-        // left part of block 
+        // left part of block
         norm_err = tryalltables_3bittable2x4percep(img,width,height,startx,starty,avg_color_quant1,best_table1,best_pixel_indices1_MSB, best_pixel_indices1_LSB);
 
         // right part of block
@@ -3527,16 +3529,16 @@ double compressBlockDiffFlipAveragePerceptual(uint8 *img,int width,int height,in
         enc_color2[0] = int( ((float) avg_color_float2[0] / (17.0)) +0.5 + eps);
         enc_color2[1] = int( ((float) avg_color_float2[1] / (17.0)) +0.5 + eps);
         enc_color2[2] = int( ((float) avg_color_float2[2] / (17.0)) +0.5 + eps);
-        avg_color_quant1[0] = enc_color1[0] << 4 | enc_color1[0]; 
-        avg_color_quant1[1] = enc_color1[1] << 4 | enc_color1[1]; 
+        avg_color_quant1[0] = enc_color1[0] << 4 | enc_color1[0];
+        avg_color_quant1[1] = enc_color1[1] << 4 | enc_color1[1];
         avg_color_quant1[2] = enc_color1[2] << 4 | enc_color1[2];
-        avg_color_quant2[0] = enc_color2[0] << 4 | enc_color2[0]; 
-        avg_color_quant2[1] = enc_color2[1] << 4 | enc_color2[1]; 
+        avg_color_quant2[0] = enc_color2[0] << 4 | enc_color2[0];
+        avg_color_quant2[1] = enc_color2[1] << 4 | enc_color2[1];
         avg_color_quant2[2] = enc_color2[2] << 4 | enc_color2[2];
-    
-        // Pack bits into the first word. 
 
-        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+        // Pack bits into the first word.
+
+        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
         //      ---------------------------------------------------------------------------------------------------
         //     | base col1 | base col2 | base col1 | base col2 | base col1 | base col2 | table  | table  |diff|flip|
         //     | R1 (4bits)| R2 (4bits)| G1 (4bits)| G2 (4bits)| B1 (4bits)| B2 (4bits)| cw 1   | cw 2   |bit |bit |
@@ -3555,7 +3557,7 @@ double compressBlockDiffFlipAveragePerceptual(uint8 *img,int width,int height,in
         unsigned int best_pixel_indices1_LSB;
         unsigned int best_pixel_indices2_MSB;
         unsigned int best_pixel_indices2_LSB;
-        
+
         // left part of block
         norm_err = tryalltables_3bittable2x4percep(img,width,height,startx,starty,avg_color_quant1,best_table1,best_pixel_indices1_MSB, best_pixel_indices1_LSB);
 
@@ -3579,7 +3581,7 @@ double compressBlockDiffFlipAveragePerceptual(uint8 *img,int width,int height,in
     computeAverageColor4x2noQuantFloat(img,width,height,startx,starty+2,avg_color_float2);
 
     // First test if avg_color1 is similar enough to avg_color2 so that
-    // we can use differential coding of colors. 
+    // we can use differential coding of colors.
 
     enc_color1[0] = int( JAS_ROUND(31.0*avg_color_float1[0]/255.0) );
     enc_color1[1] = int( JAS_ROUND(31.0*avg_color_float1[1]/255.0) );
@@ -3588,8 +3590,8 @@ double compressBlockDiffFlipAveragePerceptual(uint8 *img,int width,int height,in
     enc_color2[1] = int( JAS_ROUND(31.0*avg_color_float2[1]/255.0) );
     enc_color2[2] = int( JAS_ROUND(31.0*avg_color_float2[2]/255.0) );
 
-    diff[0] = enc_color2[0]-enc_color1[0];    
-    diff[1] = enc_color2[1]-enc_color1[1];    
+    diff[0] = enc_color2[0]-enc_color1[0];
+    diff[1] = enc_color2[1]-enc_color1[1];
     diff[2] = enc_color2[2]-enc_color1[2];
 
     if( (diff[0] >= -4) && (diff[0] <= 3) && (diff[1] >= -4) && (diff[1] <= 3) && (diff[2] >= -4) && (diff[2] <= 3) )
@@ -3598,8 +3600,8 @@ double compressBlockDiffFlipAveragePerceptual(uint8 *img,int width,int height,in
 
         // The difference to be coded:
 
-        diff[0] = enc_color2[0]-enc_color1[0];    
-        diff[1] = enc_color2[1]-enc_color1[1];    
+        diff[0] = enc_color2[0]-enc_color1[0];
+        diff[1] = enc_color2[1]-enc_color1[1];
         diff[2] = enc_color2[2]-enc_color1[2];
 
         avg_color_quant1[0] = enc_color1[0] << 3 | (enc_color1[0] >> 2);
@@ -3609,7 +3611,7 @@ double compressBlockDiffFlipAveragePerceptual(uint8 *img,int width,int height,in
         avg_color_quant2[1] = enc_color2[1] << 3 | (enc_color2[1] >> 2);
         avg_color_quant2[2] = enc_color2[2] << 3 | (enc_color2[2] >> 2);
 
-        // Pack bits into the first word. 
+        // Pack bits into the first word.
 
         compressed1_flip = 0;
         PUTBITSHIGH( compressed1_flip, diffbit,       1, 33);
@@ -3636,7 +3638,7 @@ double compressBlockDiffFlipAveragePerceptual(uint8 *img,int width,int height,in
 
         best_pixel_indices1_MSB |= (best_pixel_indices2_MSB << 2);
         best_pixel_indices1_LSB |= (best_pixel_indices2_LSB << 2);
-        
+
         compressed2_flip = ((best_pixel_indices1_MSB & 0xffff) << 16) | (best_pixel_indices1_LSB & 0xffff);
     }
     else
@@ -3653,20 +3655,20 @@ double compressBlockDiffFlipAveragePerceptual(uint8 *img,int width,int height,in
         enc_color2[1] = int( ((float) avg_color_float2[1] / (17.0)) +0.5 + eps);
         enc_color2[2] = int( ((float) avg_color_float2[2] / (17.0)) +0.5 + eps);
 
-        avg_color_quant1[0] = enc_color1[0] << 4 | enc_color1[0]; 
-        avg_color_quant1[1] = enc_color1[1] << 4 | enc_color1[1]; 
+        avg_color_quant1[0] = enc_color1[0] << 4 | enc_color1[0];
+        avg_color_quant1[1] = enc_color1[1] << 4 | enc_color1[1];
         avg_color_quant1[2] = enc_color1[2] << 4 | enc_color1[2];
-        avg_color_quant2[0] = enc_color2[0] << 4 | enc_color2[0]; 
-        avg_color_quant2[1] = enc_color2[1] << 4 | enc_color2[1]; 
+        avg_color_quant2[0] = enc_color2[0] << 4 | enc_color2[0];
+        avg_color_quant2[1] = enc_color2[1] << 4 | enc_color2[1];
         avg_color_quant2[2] = enc_color2[2] << 4 | enc_color2[2];
 
-        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
         //      ---------------------------------------------------------------------------------------------------
         //     | base col1 | base col2 | base col1 | base col2 | base col1 | base col2 | table  | table  |diff|flip|
         //     | R1 (4bits)| R2 (4bits)| G1 (4bits)| G2 (4bits)| B1 (4bits)| B2 (4bits)| cw 1   | cw 2   |bit |bit |
         //      ---------------------------------------------------------------------------------------------------
 
-        // Pack bits into the first word. 
+        // Pack bits into the first word.
 
         compressed1_flip = 0;
         PUTBITSHIGH( compressed1_flip, diffbit,       1, 33);
@@ -3693,12 +3695,12 @@ double compressBlockDiffFlipAveragePerceptual(uint8 *img,int width,int height,in
 
         best_pixel_indices1_MSB |= (best_pixel_indices2_MSB << 2);
         best_pixel_indices1_LSB |= (best_pixel_indices2_LSB << 2);
-        
+
         compressed2_flip = ((best_pixel_indices1_MSB & 0xffff) << 16) | (best_pixel_indices1_LSB & 0xffff);
     }
 
-    // Now lets see which is the best table to use. Only 8 tables are possible. 
-    
+    // Now lets see which is the best table to use. Only 8 tables are possible.
+
     double best_err;
 
     if(norm_err <= flip_err)
@@ -3778,7 +3780,7 @@ void transposeMatrix( dMatrix *mat)
 }
 
 // In the planar mode in ETC2, the block can be partitioned as follows:
-// 
+//
 // O A  A  A  H
 // B D1 D3 C3
 // B D2 C2 D5
@@ -3794,8 +3796,8 @@ unsigned int calcBBBred(uint8 *block, int colorO, int colorV)
     colorV = (colorV << 2) | (colorV >> 4);
 
     unsigned int error = 0;
-    
-    // Now first column: B B B 
+
+    // Now first column: B B B
     /* unroll loop for( yy=0; (yy<4) && (error <= best_error_sofar); yy++)*/
     {
         error = error + square_table[(block[4*4 + 0] - clamp_table[ ((((colorV-colorO) + 4*colorO)+2)>>2) + 255])+255];
@@ -3818,7 +3820,7 @@ unsigned int calcCCCred(uint8 *block, int colorH, int colorV)
     error = error + square_table[(block[4*4*3 + 4 + 0] - clamp_table[ (((colorH + 3*colorV)+2)>>2) + 255])+255];
     error = error + square_table[(block[4*4*2 + 4*2 + 0] - clamp_table[ (((2*colorH + 2*colorV)+2)>>2) + 255])+255];
     error = error + square_table[(block[4*4 + 4*3 + 0] - clamp_table[ (((3*colorH + colorV)+2)>>2) + 255])+255];
-    
+
     return error;
 }
 
@@ -3839,7 +3841,7 @@ unsigned int calcLowestPossibleRedOHperceptual(uint8 *block, int colorO, int col
         error = error + square_table_percep_red[(block[4*2] - clamp_table[ (((  ((colorH-colorO)<<1) + 4*colorO)+2)>>2) + 255])+255];
         error = error + square_table_percep_red[(block[4*3] - clamp_table[ ((( 3*(colorH-colorO) + 4*colorO)+2)>>2) + 255])+255];
     }
-    
+
     return error;
 }
 
@@ -3859,12 +3861,12 @@ unsigned int calcLowestPossibleRedOH(uint8 *block, int colorO, int colorH, unsig
         error = error + square_table[(block[4*2] - clamp_table[ (((  ((colorH-colorO)<<1) + 4*colorO)+2)>>2) + 255])+255];
         error = error + square_table[(block[4*3] - clamp_table[ ((( 3*(colorH-colorO) + 4*colorO)+2)>>2) + 255])+255];
     }
-    
+
     return error;
 }
 
 // Calculating the minimum error for the block (in planar mode) if we know the red component for O and H and V.
-// Uses perceptual error metric. 
+// Uses perceptual error metric.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 unsigned int calcErrorPlanarOnlyRedPerceptual(uint8 *block, int colorO, int colorH, int colorV, unsigned int lowest_possible_error, unsigned int BBBvalue, unsigned int CCCvalue, unsigned int best_error_sofar)
 {
@@ -3880,7 +3882,7 @@ unsigned int calcErrorPlanarOnlyRedPerceptual(uint8 *block, int colorO, int colo
     //                                    B C1 D4 D6
     int xpart_times_4;
 
-    // The first part: O A A A. It equals lowest_possible_error previously calculated. 
+    // The first part: O A A A. It equals lowest_possible_error previously calculated.
     // lowest_possible_error is OAAA, BBBvalue is BBB and CCCvalue is C1C2C3.
     error = lowest_possible_error + BBBvalue + CCCvalue;
 
@@ -3904,7 +3906,7 @@ unsigned int calcErrorPlanarOnlyRedPerceptual(uint8 *block, int colorO, int colo
         }
     }
     return error;
-} 
+}
 
 // Calculating the minimum error for the block (in planar mode) if we know the red component for O and H and V.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
@@ -3922,7 +3924,7 @@ unsigned int calcErrorPlanarOnlyRed(uint8 *block, int colorO, int colorH, int co
     //                                    B C1 D4 D6
     int xpart_times_4;
 
-    // The first part: O A A A. It equals lowest_possible_error previously calculated. 
+    // The first part: O A A A. It equals lowest_possible_error previously calculated.
     // lowest_possible_error is OAAA, BBBvalue is BBB and CCCvalue is C1C2C3.
     error = lowest_possible_error + BBBvalue + CCCvalue;
 
@@ -3995,8 +3997,8 @@ unsigned int calcBBBgreen(uint8 *block, int colorO, int colorV)
     colorV = (colorV << 1) | (colorV >> 6);
 
     unsigned int error = 0;
-    
-    // Now first column: B B B 
+
+    // Now first column: B B B
     /* unroll loop for( yy=0; (yy<4) && (error <= best_error_sofar); yy++)*/
     {
         error = error + square_table[(block[4*4 + 1] - clamp_table[ ((((colorV-colorO) + 4*colorO)+2)>>2) + 255])+255];
@@ -4020,7 +4022,7 @@ unsigned int calcCCCgreen(uint8 *block, int colorH, int colorV)
     error = error + square_table[(block[4*4*3 + 4 + 1] - clamp_table[ (((colorH + 3*colorV)+2)>>2) + 255])+255];
     error = error + square_table[(block[4*4*2 + 4*2 + 1] - clamp_table[ (((2*colorH + 2*colorV)+2)>>2) + 255])+255];
     error = error + square_table[(block[4*4 + 4*3 + 1] - clamp_table[ (((3*colorH + colorV)+2)>>2) + 255])+255];
-    
+
     return error;
 }
 
@@ -4042,7 +4044,7 @@ unsigned int calcErrorPlanarOnlyGreenPerceptual(uint8 *block, int colorO, int co
 
     int xpart_times_4;
 
-    // The first part: O A A A. It equals lowest_possible_error previously calculated. 
+    // The first part: O A A A. It equals lowest_possible_error previously calculated.
     // lowest_possible_error is OAAA, BBBvalue is BBB and CCCvalue is C1C2C3.
     error = lowest_possible_error + BBBvalue + CCCvalue;
 
@@ -4084,7 +4086,7 @@ unsigned int calcErrorPlanarOnlyGreen(uint8 *block, int colorO, int colorH, int 
     //                                    B C1 D4 D6
     int xpart_times_4;
 
-    // The first part: O A A A. It equals lowest_possible_error previously calculated. 
+    // The first part: O A A A. It equals lowest_possible_error previously calculated.
     // lowest_possible_error is OAAA, BBBvalue is BBB and CCCvalue is C1C2C3.
     error = lowest_possible_error + BBBvalue + CCCvalue;
 
@@ -4119,8 +4121,8 @@ unsigned int calcBBBbluePerceptual(uint8 *block, int colorO, int colorV)
     colorV = (colorV << 2) | (colorV >> 4);
 
     unsigned int error = 0;
-    
-    // Now first column: B B B 
+
+    // Now first column: B B B
     /* unroll loop for( yy=0; (yy<4) && (error <= best_error_sofar); yy++)*/
     {
         error = error + square_table_percep_blue[(block[4*4 + 2] - clamp_table[ ((((colorV-colorO) + 4*colorO)+2)>>2) + 255])+255];
@@ -4139,8 +4141,8 @@ unsigned int calcBBBblue(uint8 *block, int colorO, int colorV)
     colorV = (colorV << 2) | (colorV >> 4);
 
     unsigned int error = 0;
-    
-    // Now first column: B B B 
+
+    // Now first column: B B B
     /* unroll loop for( yy=0; (yy<4) && (error <= best_error_sofar); yy++)*/
     {
         error = error + square_table[(block[4*4 + 2] - clamp_table[ ((((colorV-colorO) + 4*colorO)+2)>>2) + 255])+255];
@@ -4164,7 +4166,7 @@ unsigned int calcCCCbluePerceptual(uint8 *block, int colorH, int colorV)
     error = error + square_table_percep_blue[(block[4*4*3 + 4 + 2] - clamp_table[ (((colorH + 3*colorV)+2)>>2) + 255])+255];
     error = error + square_table_percep_blue[(block[4*4*2 + 4*2 + 2] - clamp_table[ (((2*colorH + 2*colorV)+2)>>2) + 255])+255];
     error = error + square_table_percep_blue[(block[4*4 + 4*3 + 2] - clamp_table[ (((3*colorH + colorV)+2)>>2) + 255])+255];
-    
+
     return error;
 }
 
@@ -4180,7 +4182,7 @@ unsigned int calcCCCblue(uint8 *block, int colorH, int colorV)
     error = error + square_table[(block[4*4*3 + 4 + 2] - clamp_table[ (((colorH + 3*colorV)+2)>>2) + 255])+255];
     error = error + square_table[(block[4*4*2 + 4*2 + 2] - clamp_table[ (((2*colorH + 2*colorV)+2)>>2) + 255])+255];
     error = error + square_table[(block[4*4 + 4*3 + 2] - clamp_table[ (((3*colorH + colorV)+2)>>2) + 255])+255];
-    
+
     return error;
 }
 
@@ -4201,7 +4203,7 @@ unsigned int calcLowestPossibleBlueOHperceptual(uint8 *block, int colorO, int co
         error = error + square_table_percep_blue[(block[4*2+2] - clamp_table[ (((  ((colorH-colorO)<<1) + 4*colorO)+2)>>2) + 255])+255];
         error = error + square_table_percep_blue[(block[4*3+2] - clamp_table[ ((( 3*(colorH-colorO) + 4*colorO)+2)>>2) + 255])+255];
     }
-    
+
     return error;
 }
 
@@ -4221,7 +4223,7 @@ unsigned int calcLowestPossibleBlueOH(uint8 *block, int colorO, int colorH, unsi
         error = error + square_table[(block[4*2+2] - clamp_table[ (((  ((colorH-colorO)<<1) + 4*colorO)+2)>>2) + 255])+255];
         error = error + square_table[(block[4*3+2] - clamp_table[ ((( 3*(colorH-colorO) + 4*colorO)+2)>>2) + 255])+255];
     }
-    
+
     return error;
 }
 
@@ -4242,7 +4244,7 @@ unsigned int calcErrorPlanarOnlyBluePerceptual(uint8 *block, int colorO, int col
     //                                    B C1 D4 D6
     int xpart_times_4;
 
-    // The first part: O A A A. It equals lowest_possible_error previously calculated. 
+    // The first part: O A A A. It equals lowest_possible_error previously calculated.
     // lowest_possible_error is OAAA, BBBvalue is BBB and CCCvalue is C1C2C3.
     error = lowest_possible_error + BBBvalue + CCCvalue;
 
@@ -4265,7 +4267,7 @@ unsigned int calcErrorPlanarOnlyBluePerceptual(uint8 *block, int colorO, int col
             error = error + square_table_percep_blue[(block[4*4*3 + 4*3 + 2] - clamp_table[ (((xpart_times_4 + 3*(colorV-colorO) + 4*colorO)+2)>>2) + 255])+255];
         }
     }
-    
+
     return error;
 }
 
@@ -4285,7 +4287,7 @@ unsigned int calcErrorPlanarOnlyBlue(uint8 *block, int colorO, int colorH, int c
     //                                    B C1 D4 D6
     int xpart_times_4;
 
-    // The first part: O A A A. It equals lowest_possible_error previously calculated. 
+    // The first part: O A A A. It equals lowest_possible_error previously calculated.
     // lowest_possible_error is OAAA, BBBvalue is BBB and CCCvalue is C1C2C3.
     error = lowest_possible_error + BBBvalue + CCCvalue;
 
@@ -4314,9 +4316,9 @@ unsigned int calcErrorPlanarOnlyBlue(uint8 *block, int colorO, int colorH, int c
 
 
 
-// This function uses least squares in order to determine the best values of the plane. 
+// This function uses least squares in order to determine the best values of the plane.
 // This is close to optimal, but not quite, due to nonlinearities in the expantion from 6 and 7 bits to 8, and
-// in the clamping to a number between 0 and the maximum. 
+// in the clamping to a number between 0 and the maximum.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 void compressBlockPlanar57(uint8 *img, int width,int height,int startx,int starty, unsigned int &compressed57_1, unsigned int &compressed57_2)
 {
@@ -4326,7 +4328,7 @@ void compressBlockPlanar57(uint8 *img, int width,int height,int startx,int start
     // Use least squares to find the solution with the smallest error.
     // That is, find the vector x so that |Ax-b|^2 is minimized, where
     // x = [Ro Rr Rv]';
-    // A = [1 3/4 2/4 1/4 3/4 2/4 1/4  0  2/4 1/4  0  -1/4  1/4  0  -1/4 -2/4 ; 
+    // A = [1 3/4 2/4 1/4 3/4 2/4 1/4  0  2/4 1/4  0  -1/4  1/4  0  -1/4 -2/4 ;
     //      0 1/4 2/4 3/4  0  1/4 2/4 3/4  0  1/4 2/4  3/4   0  1/4  2/4  3/4 ;
     //      0  0   0   0  1/4 1/4 1/4 1/4 2/4 2/4 2/4  2/4; 3/4 3/4  3/4  3/4]';
     // b = [r11 r12 r13 r14 r21 r22 r23 r24 r31 r32 r33 r34 r41 r42 r43 r44];
@@ -4336,35 +4338,35 @@ void compressBlockPlanar57(uint8 *img, int width,int height,int startx,int start
     // C is always the same, so we have calculated it off-line here.
     //                          = C * D
     int xx,yy, cc;
-    double coeffsA[48]= { 1.00, 0.00, 0.00, 
+    double coeffsA[48]= { 1.00, 0.00, 0.00,
                           0.75, 0.25, 0.00,
-                          0.50, 0.50, 0.00, 
-                          0.25, 0.75, 0.00, 
-                          0.75, 0.00, 0.25, 
+                          0.50, 0.50, 0.00,
+                          0.25, 0.75, 0.00,
+                          0.75, 0.00, 0.25,
                           0.50, 0.25, 0.25,
-                          0.25, 0.50, 0.25, 
+                          0.25, 0.50, 0.25,
                           0.00, 0.75, 0.25,
-                          0.50, 0.00, 0.50, 
+                          0.50, 0.00, 0.50,
                           0.25, 0.25, 0.50,
-                          0.00, 0.50, 0.50, 
-                         -0.25, 0.75, 0.50, 
-                          0.25, 0.00, 0.75, 
+                          0.00, 0.50, 0.50,
+                         -0.25, 0.75, 0.50,
+                          0.25, 0.00, 0.75,
                           0.00, 0.25, 0.75,
-                         -0.25, 0.50, 0.75, 
+                         -0.25, 0.50, 0.75,
                          -0.50, 0.75, 0.75};
 
     double coeffsC[9] = {0.2875, -0.0125, -0.0125, -0.0125, 0.4875, -0.3125, -0.0125, -0.3125, 0.4875};
     double colorO[3], colorH[3], colorV[3];
     uint8 colorO8[3], colorH8[3], colorV8[3];
-    
+
     dMatrix *D_matrix;
     dMatrix *x_vector;
 
-    dMatrix A_matrix; A_matrix.width = 3; A_matrix.height = 16; 
+    dMatrix A_matrix; A_matrix.width = 3; A_matrix.height = 16;
     A_matrix.data = coeffsA;
-    dMatrix C_matrix; C_matrix.width = 3; C_matrix.height = 3; 
+    dMatrix C_matrix; C_matrix.width = 3; C_matrix.height = 3;
     C_matrix.data = coeffsC;
-    dMatrix b_vector; b_vector.width = 1; b_vector.height = 16; 
+    dMatrix b_vector; b_vector.width = 1; b_vector.height = 16;
     b_vector.data = (double*) malloc(sizeof(double)*b_vector.width*b_vector.height);
     transposeMatrix(&A_matrix);
 
@@ -4436,14 +4438,14 @@ void compressBlockPlanar57(uint8 *img, int width,int height,int startx,int start
 
     // Pack bits in 57 bits
 
-    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33 32 
+    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33 32
     //      ------------------------------------------------------------------------------------------------
     //     | R0              | G0                 | B0              | RH              | GH                  |
     //      ------------------------------------------------------------------------------------------------
     //
     //      31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10  9  8  7  6  5  4  3  2  1  0
     //      ------------------------------------------------------------------------------------------------
-    //     | BH              | RV              |  GV                | BV               | not used           |   
+    //     | BH              | RV              |  GV                | BV               | not used           |
     //      ------------------------------------------------------------------------------------------------
 
     compressed57_1 = 0;
@@ -4459,28 +4461,28 @@ void compressBlockPlanar57(uint8 *img, int width,int height,int startx,int start
     PUTBITS(     compressed57_2, colorV8[2], 6, 12);
 }
 
-// During search it is not convenient to store the bits the way they are stored in the 
+// During search it is not convenient to store the bits the way they are stored in the
 // file format. Hence, after search, it is converted to this format.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 void stuff57bits(unsigned int planar57_word1, unsigned int planar57_word2, unsigned int &planar_word1, unsigned int &planar_word2)
 {
     // Put bits in twotimer configuration for 57 bits (red and green dont overflow, green does)
-    // 
+    //
     // Go from this bit layout:
     //
-    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33 32 
+    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33 32
     //      -----------------------------------------------------------------------------------------------
     //     |R0               |G01G02              |B01B02  ;B03     |RH1           |RH2|GH                 |
     //      -----------------------------------------------------------------------------------------------
     //
     //      31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10  9  8  7  6  5  4  3  2  1  0
     //      -----------------------------------------------------------------------------------------------
-    //     |BH               |RV               |GV                  |BV                | not used          |   
+    //     |BH               |RV               |GV                  |BV                | not used          |
     //      -----------------------------------------------------------------------------------------------
     //
     //  To this:
-    // 
-    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33 32 
+    //
+    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33 32
     //      ------------------------------------------------------------------------------------------------
     //     |//|R0               |G01|/|G02              |B01|/ // //|B02  |//|B03     |RH1           |df|RH2|
     //      ------------------------------------------------------------------------------------------------
@@ -4490,7 +4492,7 @@ void stuff57bits(unsigned int planar57_word1, unsigned int planar57_word2, unsig
     //     |GH                  |BH               |RV               |GV                   |BV              |
     //      -----------------------------------------------------------------------------------------------
     //
-    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
     //      ---------------------------------------------------------------------------------------------------
     //     | base col1    | dcol 2 | base col1    | dcol 2 | base col 1   | dcol 2 | table  | table  |diff|flip|
     //     | R1' (5 bits) | dR2    | G1' (5 bits) | dG2    | B1' (5 bits) | dB2    | cw 1   | cw 2   |bit |bit |
@@ -4552,13 +4554,13 @@ void stuff57bits(unsigned int planar57_word1, unsigned int planar57_word2, unsig
     PUTBITSHIGH( planar_word1, 1,  1, 33);
 }
 
-// During search it is not convenient to store the bits the way they are stored in the 
+// During search it is not convenient to store the bits the way they are stored in the
 // file format. Hence, after search, it is converted to this format.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 void stuff58bits(unsigned int thumbH58_word1, unsigned int thumbH58_word2, unsigned int &thumbH_word1, unsigned int &thumbH_word2)
 {
     // Put bits in twotimer configuration for 58 (red doesn't overflow, green does)
-    // 
+    //
     // Go from this bit layout:
     //
     //
@@ -4569,8 +4571,8 @@ void stuff58bits(unsigned int thumbH58_word1, unsigned int thumbH58_word2, unsig
     //     |---------------------------------------index bits----------------------------------------------|
     //
     //  To this:
-    // 
-    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33 32 
+    //
+    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33 32
     //      -----------------------------------------------------------------------------------------------
     //     |//|R0         |G0      |// // //|G0|B0|//|B0b     |R1         |G1         |B0         |d2|df|d1|
     //      -----------------------------------------------------------------------------------------------
@@ -4578,7 +4580,7 @@ void stuff58bits(unsigned int thumbH58_word1, unsigned int thumbH58_word2, unsig
     //     |31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10 09 08 07 06 05 04 03 02 01 00|
     //     |---------------------------------------index bits----------------------------------------------|
     //
-    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33 32 
+    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33 32
     //      -----------------------------------------------------------------------------------------------
     //     | base col1    | dcol 2 | base col1    | dcol 2 | base col 1   | dcol 2 | table  | table  |df|fp|
     //     | R1' (5 bits) | dR2    | G1' (5 bits) | dG2    | B1' (5 bits) | dB2    | cw 1   | cw 2   |bt|bt|
@@ -4592,8 +4594,8 @@ void stuff58bits(unsigned int thumbH58_word1, unsigned int thumbH58_word2, unsig
     //     |-------empty-----|part0---------------|part1|part2------------------------------------------|part3|
     //
     //  To this:
-    // 
-    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33 32 
+    //
+    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33 32
     //      --------------------------------------------------------------------------------------------------|
     //     |//|part0               |// // //|part1|//|part2                                          |df|part3|
     //      --------------------------------------------------------------------------------------------------|
@@ -4674,13 +4676,13 @@ void stuff58bitsDiffFalse(unsigned int thumbH58_word1, unsigned int thumbH58_wor
 
 }
 
-// During search it is not convenient to store the bits the way they are stored in the 
+// During search it is not convenient to store the bits the way they are stored in the
 // file format. Hence, after search, it is converted to this format.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 void stuff59bits(unsigned int thumbT59_word1, unsigned int thumbT59_word2, unsigned int &thumbT_word1, unsigned int &thumbT_word2)
 {
     // Put bits in twotimer configuration for 59 (red overflows)
-    // 
+    //
     // Go from this bit layout:
     //
     //     |63 62 61 60 59|58 57 56 55|54 53 52 51|50 49 48 47|46 45 44 43|42 41 40 39|38 37 36 35|34 33 32|
@@ -4691,8 +4693,8 @@ void stuff59bits(unsigned int thumbT59_word1, unsigned int thumbT59_word2, unsig
     //
     //
     //  To this:
-    // 
-    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33 32 
+    //
+    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33 32
     //      -----------------------------------------------------------------------------------------------
     //     |// // //|R0a  |//|R0b  |G0         |B0         |R1         |G1         |B1          |da  |df|db|
     //      -----------------------------------------------------------------------------------------------
@@ -4700,7 +4702,7 @@ void stuff59bits(unsigned int thumbT59_word1, unsigned int thumbT59_word2, unsig
     //     |31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10 09 08 07 06 05 04 03 02 01 00|
     //     |----------------------------------------index bits---------------------------------------------|
     //
-    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33 32 
+    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33 32
     //      -----------------------------------------------------------------------------------------------
     //     | base col1    | dcol 2 | base col1    | dcol 2 | base col 1   | dcol 2 | table  | table  |df|fp|
     //     | R1' (5 bits) | dR2    | G1' (5 bits) | dG2    | B1' (5 bits) | dB2    | cw 1   | cw 2   |bt|bt|
@@ -4717,7 +4719,7 @@ void stuff59bits(unsigned int thumbT59_word1, unsigned int thumbT59_word2, unsig
     PUTBITSHIGH( thumbT_word1, R0a,  2, 60);
     // Fix db (lowest bit of d)
     PUTBITSHIGH( thumbT_word1, thumbT59_word1,  1, 32);
-    // 
+    //
     // Make sure that red overflows:
     a = GETBITSHIGH( thumbT_word1, 1, 60);
     b = GETBITSHIGH( thumbT_word1, 1, 59);
@@ -4766,7 +4768,7 @@ void decompressBlockPlanar57errorPerComponent(unsigned int compressed57_1, unsig
     colorV[0] = (colorV[0] << 2) | (colorV[0] >> 4);
     colorV[1] = (colorV[1] << 1) | (colorV[1] >> 6);
     colorV[2] = (colorV[2] << 2) | (colorV[2] >> 4);
-    
+
     int xx, yy;
 
     for( xx=0; xx<4; xx++)
@@ -4786,7 +4788,7 @@ void decompressBlockPlanar57errorPerComponent(unsigned int compressed57_1, unsig
     {
         for( yy=0; yy<4; yy++)
         {
-            error_red = error_red + SQUARE(srcimg[3*width*(starty+yy) + 3*(startx+xx) + 0] - img[3*width*(starty+yy) + 3*(startx+xx) + 0]); 
+            error_red = error_red + SQUARE(srcimg[3*width*(starty+yy) + 3*(startx+xx) + 0] - img[3*width*(starty+yy) + 3*(startx+xx) + 0]);
             error_green = error_green + SQUARE(srcimg[3*width*(starty+yy) + 3*(startx+xx) + 1] - img[3*width*(starty+yy) + 3*(startx+xx) + 1]);
             error_blue = error_blue + SQUARE(srcimg[3*width*(starty+yy) + 3*(startx+xx) + 2] - img[3*width*(starty+yy) + 3*(startx+xx) + 2]);
 
@@ -4794,8 +4796,8 @@ void decompressBlockPlanar57errorPerComponent(unsigned int compressed57_1, unsig
     }
 }
 
-// Compress using both individual and differential mode in ETC1/ETC2 using combined color 
-// quantization. Both flip modes are tried. 
+// Compress using both individual and differential mode in ETC1/ETC2 using combined color
+// quantization. Both flip modes are tried.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 void compressBlockDiffFlipCombined(uint8 *img,int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2)
 {
@@ -4819,7 +4821,7 @@ void compressBlockDiffFlipCombined(uint8 *img,int width,int height,int startx,in
     computeAverageColor2x4noQuantFloat(img,width,height,startx+2,starty,avg_color_float2);
 
     // First test if avg_color1 is similar enough to avg_color2 so that
-    // we can use differential coding of colors. 
+    // we can use differential coding of colors.
 
     float eps;
 
@@ -4828,8 +4830,8 @@ void compressBlockDiffFlipCombined(uint8 *img,int width,int height,int startx,in
     quantize555ColorCombined(avg_color_float1, enc_color1, dummy);
     quantize555ColorCombined(avg_color_float2, enc_color2, dummy);
 
-    diff[0] = enc_color2[0]-enc_color1[0];    
-    diff[1] = enc_color2[1]-enc_color1[1];    
+    diff[0] = enc_color2[0]-enc_color1[0];
+    diff[1] = enc_color2[1]-enc_color1[1];
     diff[2] = enc_color2[2]-enc_color1[2];
 
     if( (diff[0] >= -4) && (diff[0] <= 3) && (diff[1] >= -4) && (diff[1] <= 3) && (diff[2] >= -4) && (diff[2] <= 3) )
@@ -4838,8 +4840,8 @@ void compressBlockDiffFlipCombined(uint8 *img,int width,int height,int startx,in
 
         // The difference to be coded:
 
-        diff[0] = enc_color2[0]-enc_color1[0];    
-        diff[1] = enc_color2[1]-enc_color1[1];    
+        diff[0] = enc_color2[0]-enc_color1[0];
+        diff[1] = enc_color2[1]-enc_color1[1];
         diff[2] = enc_color2[2]-enc_color1[2];
 
         avg_color_quant1[0] = enc_color1[0] << 3 | (enc_color1[0] >> 2);
@@ -4849,33 +4851,33 @@ void compressBlockDiffFlipCombined(uint8 *img,int width,int height,int startx,in
         avg_color_quant2[1] = enc_color2[1] << 3 | (enc_color2[1] >> 2);
         avg_color_quant2[2] = enc_color2[2] << 3 | (enc_color2[2] >> 2);
 
-        // Pack bits into the first word. 
+        // Pack bits into the first word.
 
         //     ETC1_RGB8_OES:
-        // 
+        //
         //     a) bit layout in bits 63 through 32 if diffbit = 0
-        // 
-        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+        //
+        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
         //      ---------------------------------------------------------------------------------------------------
         //     | base col1 | base col2 | base col1 | base col2 | base col1 | base col2 | table  | table  |diff|flip|
         //     | R1 (4bits)| R2 (4bits)| G1 (4bits)| G2 (4bits)| B1 (4bits)| B2 (4bits)| cw 1   | cw 2   |bit |bit |
         //      ---------------------------------------------------------------------------------------------------
-        //     
+        //
         //     b) bit layout in bits 63 through 32 if diffbit = 1
-        // 
-        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+        //
+        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
         //      ---------------------------------------------------------------------------------------------------
         //     | base col1    | dcol 2 | base col1    | dcol 2 | base col 1   | dcol 2 | table  | table  |diff|flip|
         //     | R1' (5 bits) | dR2    | G1' (5 bits) | dG2    | B1' (5 bits) | dB2    | cw 1   | cw 2   |bit |bit |
         //      ---------------------------------------------------------------------------------------------------
-        // 
+        //
         //     c) bit layout in bits 31 through 0 (in both cases)
-        // 
+        //
         //      31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10  9  8  7  6  5  4  3   2   1  0
         //      --------------------------------------------------------------------------------------------------
-        //     |       most significant pixel index bits       |         least significant pixel index bits       |  
+        //     |       most significant pixel index bits       |         least significant pixel index bits       |
         //     | p| o| n| m| l| k| j| i| h| g| f| e| d| c| b| a| p| o| n| m| l| k| j| i| h| g| f| e| d| c | b | a |
-        //      --------------------------------------------------------------------------------------------------      
+        //      --------------------------------------------------------------------------------------------------
 
         compressed1_norm = 0;
         PUTBITSHIGH( compressed1_norm, diffbit,       1, 33);
@@ -4922,17 +4924,17 @@ void compressBlockDiffFlipCombined(uint8 *img,int width,int height,int startx,in
         quantize444ColorCombined(avg_color_float1, enc_color1, dummy);
         quantize444ColorCombined(avg_color_float2, enc_color2, dummy);
 
-        avg_color_quant1[0] = enc_color1[0] << 4 | enc_color1[0]; 
-        avg_color_quant1[1] = enc_color1[1] << 4 | enc_color1[1]; 
+        avg_color_quant1[0] = enc_color1[0] << 4 | enc_color1[0];
+        avg_color_quant1[1] = enc_color1[1] << 4 | enc_color1[1];
         avg_color_quant1[2] = enc_color1[2] << 4 | enc_color1[2];
-        avg_color_quant2[0] = enc_color2[0] << 4 | enc_color2[0]; 
-        avg_color_quant2[1] = enc_color2[1] << 4 | enc_color2[1]; 
+        avg_color_quant2[0] = enc_color2[0] << 4 | enc_color2[0];
+        avg_color_quant2[1] = enc_color2[1] << 4 | enc_color2[1];
         avg_color_quant2[2] = enc_color2[2] << 4 | enc_color2[2];
-    
 
-        // Pack bits into the first word. 
 
-        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+        // Pack bits into the first word.
+
+        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
         //      ---------------------------------------------------------------------------------------------------
         //     | base col1 | base col2 | base col1 | base col2 | base col1 | base col2 | table  | table  |diff|flip|
         //     | R1 (4bits)| R2 (4bits)| G1 (4bits)| G2 (4bits)| B1 (4bits)| B2 (4bits)| cw 1   | cw 2   |bit |bit |
@@ -4975,13 +4977,13 @@ void compressBlockDiffFlipCombined(uint8 *img,int width,int height,int startx,in
     computeAverageColor4x2noQuantFloat(img,width,height,startx,starty+2,avg_color_float2);
 
     // First test if avg_color1 is similar enough to avg_color2 so that
-    // we can use differential coding of colors. 
+    // we can use differential coding of colors.
 
     quantize555ColorCombined(avg_color_float1, enc_color1, dummy);
     quantize555ColorCombined(avg_color_float2, enc_color2, dummy);
 
-    diff[0] = enc_color2[0]-enc_color1[0];    
-    diff[1] = enc_color2[1]-enc_color1[1];    
+    diff[0] = enc_color2[0]-enc_color1[0];
+    diff[1] = enc_color2[1]-enc_color1[1];
     diff[2] = enc_color2[2]-enc_color1[2];
 
     if( (diff[0] >= -4) && (diff[0] <= 3) && (diff[1] >= -4) && (diff[1] <= 3) && (diff[2] >= -4) && (diff[2] <= 3) )
@@ -4990,8 +4992,8 @@ void compressBlockDiffFlipCombined(uint8 *img,int width,int height,int startx,in
 
         // The difference to be coded:
 
-        diff[0] = enc_color2[0]-enc_color1[0];    
-        diff[1] = enc_color2[1]-enc_color1[1];    
+        diff[0] = enc_color2[0]-enc_color1[0];
+        diff[1] = enc_color2[1]-enc_color1[1];
         diff[2] = enc_color2[2]-enc_color1[2];
 
         avg_color_quant1[0] = enc_color1[0] << 3 | (enc_color1[0] >> 2);
@@ -5001,7 +5003,7 @@ void compressBlockDiffFlipCombined(uint8 *img,int width,int height,int startx,in
         avg_color_quant2[1] = enc_color2[1] << 3 | (enc_color2[1] >> 2);
         avg_color_quant2[2] = enc_color2[2] << 3 | (enc_color2[2] >> 2);
 
-        // Pack bits into the first word. 
+        // Pack bits into the first word.
 
         compressed1_flip = 0;
         PUTBITSHIGH( compressed1_flip, diffbit,       1, 33);
@@ -5028,7 +5030,7 @@ void compressBlockDiffFlipCombined(uint8 *img,int width,int height,int startx,in
 
         best_pixel_indices1_MSB |= (best_pixel_indices2_MSB << 2);
         best_pixel_indices1_LSB |= (best_pixel_indices2_LSB << 2);
-        
+
         compressed2_flip = ((best_pixel_indices1_MSB & 0xffff) << 16) | (best_pixel_indices1_LSB & 0xffff);
     }
     else
@@ -5042,21 +5044,21 @@ void compressBlockDiffFlipCombined(uint8 *img,int width,int height,int startx,in
         quantize444ColorCombined(avg_color_float1, enc_color1, dummy);
         quantize444ColorCombined(avg_color_float2, enc_color2, dummy);
 
-        avg_color_quant1[0] = enc_color1[0] << 4 | enc_color1[0]; 
-        avg_color_quant1[1] = enc_color1[1] << 4 | enc_color1[1]; 
+        avg_color_quant1[0] = enc_color1[0] << 4 | enc_color1[0];
+        avg_color_quant1[1] = enc_color1[1] << 4 | enc_color1[1];
         avg_color_quant1[2] = enc_color1[2] << 4 | enc_color1[2];
-        avg_color_quant2[0] = enc_color2[0] << 4 | enc_color2[0]; 
-        avg_color_quant2[1] = enc_color2[1] << 4 | enc_color2[1]; 
+        avg_color_quant2[0] = enc_color2[0] << 4 | enc_color2[0];
+        avg_color_quant2[1] = enc_color2[1] << 4 | enc_color2[1];
         avg_color_quant2[2] = enc_color2[2] << 4 | enc_color2[2];
 
-        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
         //      ---------------------------------------------------------------------------------------------------
         //     | base col1 | base col2 | base col1 | base col2 | base col1 | base col2 | table  | table  |diff|flip|
         //     | R1 (4bits)| R2 (4bits)| G1 (4bits)| G2 (4bits)| B1 (4bits)| B2 (4bits)| cw 1   | cw 2   |bit |bit |
         //      ---------------------------------------------------------------------------------------------------
 
 
-        // Pack bits into the first word. 
+        // Pack bits into the first word.
         compressed1_flip = 0;
         PUTBITSHIGH( compressed1_flip, diffbit,       1, 33);
          PUTBITSHIGH( compressed1_flip, enc_color1[0], 4, 63);
@@ -5082,11 +5084,11 @@ void compressBlockDiffFlipCombined(uint8 *img,int width,int height,int startx,in
 
         best_pixel_indices1_MSB |= (best_pixel_indices2_MSB << 2);
         best_pixel_indices1_LSB |= (best_pixel_indices2_LSB << 2);
-        
+
         compressed2_flip = ((best_pixel_indices1_MSB & 0xffff) << 16) | (best_pixel_indices1_LSB & 0xffff);
     }
 
-    // Now lets see which is the best table to use. Only 8 tables are possible. 
+    // Now lets see which is the best table to use. Only 8 tables are possible.
 
     if(norm_err <= flip_err)
     {
@@ -5103,7 +5105,7 @@ void compressBlockDiffFlipCombined(uint8 *img,int width,int height,int startx,in
 // Calculation of the two block colors using the LBG-algorithm
 // The following method scales down the intensity, since this can be compensated for anyway by both the H and T mode.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-void computeColorLBGHalfIntensityFast(uint8 *img,int width,int startx,int starty, uint8 (LBG_colors)[2][3]) 
+void computeColorLBGHalfIntensityFast(uint8 *img,int width,int startx,int starty, uint8 (LBG_colors)[2][3])
 {
     uint8 block_mask[4][4];
 
@@ -5127,13 +5129,13 @@ void computeColorLBGHalfIntensityFast(uint8 *img,int width,int startx,int starty
     int seeding;
     bool continue_iterate;
 
-    max_v[R] = -512.0;   max_v[G] = -512.0;   max_v[B] = -512.0; 
+    max_v[R] = -512.0;   max_v[G] = -512.0;   max_v[B] = -512.0;
     min_v[R] =  512.0;   min_v[G] =  512.0;   min_v[B] =  512.0;
 
     // resolve trainingdata
-    for (y = 0; y < BLOCKHEIGHT; ++y) 
+    for (y = 0; y < BLOCKHEIGHT; ++y)
     {
-        for (x = 0; x < BLOCKWIDTH; ++x) 
+        for (x = 0; x < BLOCKWIDTH; ++x)
         {
             red = img[3*((starty+y)*width+startx+x)+R];
             green = img[3*((starty+y)*width+startx+x)+G];
@@ -5146,11 +5148,11 @@ void computeColorLBGHalfIntensityFast(uint8 *img,int width,int startx,int starty
             // q = [0, sqrt(3)*255], r = [-255/sqrt(2), 255/sqrt(2)], s = [-2*255/sqrt(6), 2*255/sqrt(6)];
             //
             // The LGB algorithm will only act on the r and s variables and not on q.
-            // 
+            //
             original_colors[x][y][R] = (1.0/sqrt(1.0*3))*red + (1.0/sqrt(1.0*3))*green + (1.0/sqrt(1.0*3))*blue;
             original_colors[x][y][G] = (1.0/sqrt(1.0*2))*red - (1.0/sqrt(1.0*2))*green;
             original_colors[x][y][B] = (1.0/sqrt(1.0*6))*red + (1.0/sqrt(1.0*6))*green - (2.0/sqrt(1.0*6))*blue;
-        
+
             // find max
             if (original_colors[x][y][R] > max_v[R]) max_v[R] = original_colors[x][y][R];
             if (original_colors[x][y][G] > max_v[G]) max_v[G] = original_colors[x][y][G];
@@ -5162,8 +5164,8 @@ void computeColorLBGHalfIntensityFast(uint8 *img,int width,int startx,int starty
         }
     }
 
-    D = 512*512*3*16.0; 
-    bestD = 512*512*3*16.0; 
+    D = 512*512*3*16.0;
+    bestD = 512*512*3*16.0;
 
     continue_seeding = true;
 
@@ -5174,14 +5176,14 @@ void computeColorLBGHalfIntensityFast(uint8 *img,int width,int startx,int starty
         continue_seeding = false;
 
         // calculate seeds
-        for (uint8 s = 0; s < 2; ++s) 
+        for (uint8 s = 0; s < 2; ++s)
         {
-            for (uint8 c = 0; c < 3; ++c) 
-            { 
+            for (uint8 c = 0; c < 3; ++c)
+            {
                 current_colors[s][c] = double((double(rand())/RAND_MAX)*(max_v[c]-min_v[c])) + min_v[c];
             }
         }
-        
+
         // divide into two quantization sets and calculate distortion
 
         continue_iterate = true;
@@ -5190,23 +5192,23 @@ void computeColorLBGHalfIntensityFast(uint8 *img,int width,int startx,int starty
             oldD = D;
             D = 0;
             int n = 0;
-            for (y = 0; y < BLOCKHEIGHT; ++y) 
+            for (y = 0; y < BLOCKHEIGHT; ++y)
             {
-                for (int x1 = 0; x1 < BLOCKWIDTH; ++x1) 
+                for (int x1 = 0; x1 < BLOCKWIDTH; ++x1)
                 {
-                    error_a = 0.5*SQUARE(original_colors[x1][y][R] - current_colors[0][R]) + 
+                    error_a = 0.5*SQUARE(original_colors[x1][y][R] - current_colors[0][R]) +
                               SQUARE(original_colors[x1][y][G] - current_colors[0][G]) +
                               SQUARE(original_colors[x1][y][B] - current_colors[0][B]);
-                    error_b = 0.5*SQUARE(original_colors[x1][y][R] - current_colors[1][R]) + 
+                    error_b = 0.5*SQUARE(original_colors[x1][y][R] - current_colors[1][R]) +
                               SQUARE(original_colors[x1][y][G] - current_colors[1][G]) +
                               SQUARE(original_colors[x1][y][B] - current_colors[1][B]);
-                    if (error_a < error_b) 
+                    if (error_a < error_b)
                     {
                         block_mask[x1][y] = 0;
-                        D += error_a; 
+                        D += error_a;
                         ++n;
-                    } 
-                    else 
+                    }
+                    else
                     {
                         block_mask[x1][y] = 1;
                         D += error_b;
@@ -5215,7 +5217,7 @@ void computeColorLBGHalfIntensityFast(uint8 *img,int width,int startx,int starty
             }
 
             // compare with old distortion
-            if (D == 0) 
+            if (D == 0)
             {
                 // Perfect score -- we dont need to go further iterations.
                 continue_iterate = false;
@@ -5227,18 +5229,18 @@ void computeColorLBGHalfIntensityFast(uint8 *img,int width,int startx,int starty
                 continue_iterate = false;
                 continue_seeding = false;
             }
-            if (D < bestD) 
+            if (D < bestD)
             {
                 bestD = D;
-                for(uint8 s = 0; s < 2; ++s) 
+                for(uint8 s = 0; s < 2; ++s)
                 {
-                    for(uint8 c = 0; c < 3; ++c) 
+                    for(uint8 c = 0; c < 3; ++c)
                     {
                         best_colors[s][c] = current_colors[s][c];
                     }
                 }
             }
-            if (n == 0 || n == BLOCKWIDTH*BLOCKHEIGHT) 
+            if (n == 0 || n == BLOCKWIDTH*BLOCKHEIGHT)
             {
                 // All colors end up in the same voroni region. We need to reseed.
                 continue_iterate = false;
@@ -5256,9 +5258,9 @@ void computeColorLBGHalfIntensityFast(uint8 *img,int width,int startx,int starty
                 t_color[1][G] = 0;
                 t_color[1][B] = 0;
 
-                for (y = 0; y < BLOCKHEIGHT; ++y) 
+                for (y = 0; y < BLOCKHEIGHT; ++y)
                 {
-                    for (int x1 = 0; x1 < BLOCKWIDTH; ++x1) 
+                    for (int x1 = 0; x1 < BLOCKWIDTH; ++x1)
                     {
                         // use dummy value for q-parameter
                         t_color[block_mask[x1][y]][R] += original_colors[x1][y][R];
@@ -5298,7 +5300,7 @@ void computeColorLBGHalfIntensityFast(uint8 *img,int width,int startx,int starty
 // The following method scales down the intensity, since this can be compensated for anyway by both the H and T mode.
 // Faster version
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-void computeColorLBGNotIntensityFast(uint8 *img,int width,int startx,int starty, uint8 (LBG_colors)[2][3]) 
+void computeColorLBGNotIntensityFast(uint8 *img,int width,int startx,int starty, uint8 (LBG_colors)[2][3])
 {
     uint8 block_mask[4][4];
 
@@ -5322,13 +5324,13 @@ void computeColorLBGNotIntensityFast(uint8 *img,int width,int startx,int starty,
     int seeding;
     bool continue_iterate;
 
-    max_v[R] = -512.0;   max_v[G] = -512.0;   max_v[B] = -512.0; 
+    max_v[R] = -512.0;   max_v[G] = -512.0;   max_v[B] = -512.0;
     min_v[R] =  512.0;   min_v[G] =  512.0;   min_v[B] =  512.0;
 
     // resolve trainingdata
-    for (y = 0; y < BLOCKHEIGHT; ++y) 
+    for (y = 0; y < BLOCKHEIGHT; ++y)
     {
-        for (x = 0; x < BLOCKWIDTH; ++x) 
+        for (x = 0; x < BLOCKWIDTH; ++x)
         {
             red = img[3*((starty+y)*width+startx+x)+R];
             green = img[3*((starty+y)*width+startx+x)+G];
@@ -5341,11 +5343,11 @@ void computeColorLBGNotIntensityFast(uint8 *img,int width,int startx,int starty,
             // q = [0, sqrt(1.0*3)*255], r = [-255/sqrt(1.0*2), 255/sqrt(1.0*2)], s = [-2*255/sqrt(1.0*6), 2*255/sqrt(1.0*6)];
             //
             // The LGB algorithm will only act on the r and s variables and not on q.
-            // 
+            //
             original_colors[x][y][R] = (1.0/sqrt(1.0*3))*red + (1.0/sqrt(1.0*3))*green + (1.0/sqrt(1.0*3))*blue;
             original_colors[x][y][G] = (1.0/sqrt(1.0*2))*red - (1.0/sqrt(1.0*2))*green;
             original_colors[x][y][B] = (1.0/sqrt(1.0*6))*red + (1.0/sqrt(1.0*6))*green - (2.0/sqrt(1.0*6))*blue;
-        
+
             // find max
             if (original_colors[x][y][R] > max_v[R]) max_v[R] = original_colors[x][y][R];
             if (original_colors[x][y][G] > max_v[G]) max_v[G] = original_colors[x][y][G];
@@ -5357,8 +5359,8 @@ void computeColorLBGNotIntensityFast(uint8 *img,int width,int startx,int starty,
         }
     }
 
-    D = 512*512*3*16.0; 
-    bestD = 512*512*3*16.0; 
+    D = 512*512*3*16.0;
+    bestD = 512*512*3*16.0;
 
     continue_seeding = true;
 
@@ -5369,10 +5371,10 @@ void computeColorLBGNotIntensityFast(uint8 *img,int width,int startx,int starty,
         continue_seeding = false;
 
         // calculate seeds
-        for (uint8 s = 0; s < 2; ++s) 
+        for (uint8 s = 0; s < 2; ++s)
         {
-            for (uint8 c = 0; c < 3; ++c) 
-            { 
+            for (uint8 c = 0; c < 3; ++c)
+            {
                 current_colors[s][c] = double((double(rand())/RAND_MAX)*(max_v[c]-min_v[c])) + min_v[c];
             }
         }
@@ -5384,23 +5386,23 @@ void computeColorLBGNotIntensityFast(uint8 *img,int width,int startx,int starty,
             oldD = D;
             D = 0;
             int n = 0;
-            for (y = 0; y < BLOCKHEIGHT; ++y) 
+            for (y = 0; y < BLOCKHEIGHT; ++y)
             {
-                for (int x1 = 0; x1 < BLOCKWIDTH; ++x1) 
+                for (int x1 = 0; x1 < BLOCKWIDTH; ++x1)
                 {
-                    error_a = 0.0*SQUARE(original_colors[x1][y][R] - current_colors[0][R]) + 
+                    error_a = 0.0*SQUARE(original_colors[x1][y][R] - current_colors[0][R]) +
                               SQUARE(original_colors[x1][y][G] - current_colors[0][G]) +
                               SQUARE(original_colors[x1][y][B] - current_colors[0][B]);
-                    error_b = 0.0*SQUARE(original_colors[x1][y][R] - current_colors[1][R]) + 
+                    error_b = 0.0*SQUARE(original_colors[x1][y][R] - current_colors[1][R]) +
                               SQUARE(original_colors[x1][y][G] - current_colors[1][G]) +
                               SQUARE(original_colors[x1][y][B] - current_colors[1][B]);
-                    if (error_a < error_b) 
+                    if (error_a < error_b)
                     {
                         block_mask[x1][y] = 0;
-                        D += error_a; 
+                        D += error_a;
                         ++n;
-                    } 
-                    else 
+                    }
+                    else
                     {
                         block_mask[x1][y] = 1;
                         D += error_b;
@@ -5409,7 +5411,7 @@ void computeColorLBGNotIntensityFast(uint8 *img,int width,int startx,int starty,
             }
 
             // compare with old distortion
-            if (D == 0) 
+            if (D == 0)
             {
                 // Perfect score -- we dont need to go further iterations.
                 continue_iterate = false;
@@ -5421,18 +5423,18 @@ void computeColorLBGNotIntensityFast(uint8 *img,int width,int startx,int starty,
                 continue_iterate = false;
                 continue_seeding = false;
             }
-            if (D < bestD) 
+            if (D < bestD)
             {
                 bestD = D;
-                for(uint8 s = 0; s < 2; ++s) 
+                for(uint8 s = 0; s < 2; ++s)
                 {
-                    for(uint8 c = 0; c < 3; ++c) 
+                    for(uint8 c = 0; c < 3; ++c)
                     {
                         best_colors[s][c] = current_colors[s][c];
                     }
                 }
             }
-            if (n == 0 || n == BLOCKWIDTH*BLOCKHEIGHT) 
+            if (n == 0 || n == BLOCKWIDTH*BLOCKHEIGHT)
             {
                 // All colors end up in the same voroni region. We need to reseed.
                 continue_iterate = false;
@@ -5450,9 +5452,9 @@ void computeColorLBGNotIntensityFast(uint8 *img,int width,int startx,int starty,
                 t_color[1][G] = 0;
                 t_color[1][B] = 0;
 
-                for (y = 0; y < BLOCKHEIGHT; ++y) 
+                for (y = 0; y < BLOCKHEIGHT; ++y)
                 {
-                    for (int x1 = 0; x1 < BLOCKWIDTH; ++x1) 
+                    for (int x1 = 0; x1 < BLOCKWIDTH; ++x1)
                     {
                         // use dummy value for q-parameter
                         t_color[block_mask[x1][y]][R] += original_colors[x1][y][R];
@@ -5491,7 +5493,7 @@ void computeColorLBGNotIntensityFast(uint8 *img,int width,int startx,int starty,
 // Calculation of the two block colors using the LBG-algorithm
 // The following method completely ignores the intensity, since this can be compensated for anyway by both the H and T mode.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-void computeColorLBGNotIntensity(uint8 *img,int width,int startx,int starty, uint8 (LBG_colors)[2][3]) 
+void computeColorLBGNotIntensity(uint8 *img,int width,int startx,int starty, uint8 (LBG_colors)[2][3])
 {
     uint8 block_mask[4][4];
 
@@ -5515,13 +5517,13 @@ void computeColorLBGNotIntensity(uint8 *img,int width,int startx,int starty, uin
     int seeding;
     bool continue_iterate;
 
-    max_v[R] = -512.0;   max_v[G] = -512.0;   max_v[B] = -512.0; 
+    max_v[R] = -512.0;   max_v[G] = -512.0;   max_v[B] = -512.0;
     min_v[R] =  512.0;   min_v[G] =  512.0;   min_v[B] =  512.0;
 
     // resolve trainingdata
-    for (y = 0; y < BLOCKHEIGHT; ++y) 
+    for (y = 0; y < BLOCKHEIGHT; ++y)
     {
-        for (x = 0; x < BLOCKWIDTH; ++x) 
+        for (x = 0; x < BLOCKWIDTH; ++x)
         {
             red = img[3*((starty+y)*width+startx+x)+R];
             green = img[3*((starty+y)*width+startx+x)+G];
@@ -5534,7 +5536,7 @@ void computeColorLBGNotIntensity(uint8 *img,int width,int startx,int starty, uin
             // q = [0, sqrt(1.0*3)*255], r = [-255/sqrt(1.0*2), 255/sqrt(1.0*2)], s = [-2*255/sqrt(1.0*6), 2*255/sqrt(1.0*6)];
             //
             // The LGB algorithm will only act on the r and s variables and not on q.
-            // 
+            //
             original_colors[x][y][R] = (1.0/sqrt(1.0*3))*red + (1.0/sqrt(1.0*3))*green + (1.0/sqrt(1.0*3))*blue;
             original_colors[x][y][G] = (1.0/sqrt(1.0*2))*red - (1.0/sqrt(1.0*2))*green;
             original_colors[x][y][B] = (1.0/sqrt(1.0*6))*red + (1.0/sqrt(1.0*6))*green - (2.0/sqrt(1.0*6))*blue;
@@ -5550,8 +5552,8 @@ void computeColorLBGNotIntensity(uint8 *img,int width,int startx,int starty, uin
         }
     }
 
-    D = 512*512*3*16.0; 
-    bestD = 512*512*3*16.0; 
+    D = 512*512*3*16.0;
+    bestD = 512*512*3*16.0;
 
     continue_seeding = true;
 
@@ -5562,14 +5564,14 @@ void computeColorLBGNotIntensity(uint8 *img,int width,int startx,int starty, uin
         continue_seeding = false;
 
         // calculate seeds
-        for (uint8 s = 0; s < 2; ++s) 
+        for (uint8 s = 0; s < 2; ++s)
         {
-            for (uint8 c = 0; c < 3; ++c) 
-            { 
+            for (uint8 c = 0; c < 3; ++c)
+            {
                 current_colors[s][c] = double((double(rand())/RAND_MAX)*(max_v[c]-min_v[c])) + min_v[c];
             }
         }
-        
+
         // divide into two quantization sets and calculate distortion
 
         continue_iterate = true;
@@ -5578,23 +5580,23 @@ void computeColorLBGNotIntensity(uint8 *img,int width,int startx,int starty, uin
             oldD = D;
             D = 0;
             int n = 0;
-            for (y = 0; y < BLOCKHEIGHT; ++y) 
+            for (y = 0; y < BLOCKHEIGHT; ++y)
             {
-                for (int x1 = 0; x1 < BLOCKWIDTH; ++x1) 
+                for (int x1 = 0; x1 < BLOCKWIDTH; ++x1)
                 {
-                    error_a = 0.0*SQUARE(original_colors[x1][y][R] - current_colors[0][R]) + 
+                    error_a = 0.0*SQUARE(original_colors[x1][y][R] - current_colors[0][R]) +
                               SQUARE(original_colors[x1][y][G] - current_colors[0][G]) +
                               SQUARE(original_colors[x1][y][B] - current_colors[0][B]);
-                    error_b = 0.0*SQUARE(original_colors[x1][y][R] - current_colors[1][R]) + 
+                    error_b = 0.0*SQUARE(original_colors[x1][y][R] - current_colors[1][R]) +
                               SQUARE(original_colors[x1][y][G] - current_colors[1][G]) +
                               SQUARE(original_colors[x1][y][B] - current_colors[1][B]);
-                    if (error_a < error_b) 
+                    if (error_a < error_b)
                     {
                         block_mask[x1][y] = 0;
-                        D += error_a; 
+                        D += error_a;
                         ++n;
-                    } 
-                    else 
+                    }
+                    else
                     {
                         block_mask[x1][y] = 1;
                         D += error_b;
@@ -5603,7 +5605,7 @@ void computeColorLBGNotIntensity(uint8 *img,int width,int startx,int starty, uin
             }
 
             // compare with old distortion
-            if (D == 0) 
+            if (D == 0)
             {
                 // Perfect score -- we dont need to go further iterations.
                 continue_iterate = false;
@@ -5615,18 +5617,18 @@ void computeColorLBGNotIntensity(uint8 *img,int width,int startx,int starty, uin
                 continue_iterate = false;
                 continue_seeding = true;
             }
-            if (D < bestD) 
+            if (D < bestD)
             {
                 bestD = D;
-                for(uint8 s = 0; s < 2; ++s) 
+                for(uint8 s = 0; s < 2; ++s)
                 {
-                    for(uint8 c = 0; c < 3; ++c) 
+                    for(uint8 c = 0; c < 3; ++c)
                     {
                         best_colors[s][c] = current_colors[s][c];
                     }
                 }
             }
-            if (n == 0 || n == BLOCKWIDTH*BLOCKHEIGHT) 
+            if (n == 0 || n == BLOCKWIDTH*BLOCKHEIGHT)
             {
                 // All colors end up in the same voroni region. We need to reseed.
                 continue_iterate = false;
@@ -5644,9 +5646,9 @@ void computeColorLBGNotIntensity(uint8 *img,int width,int startx,int starty, uin
                 t_color[1][G] = 0;
                 t_color[1][B] = 0;
 
-                for (y = 0; y < BLOCKHEIGHT; ++y) 
+                for (y = 0; y < BLOCKHEIGHT; ++y)
                 {
-                    for (int x1 = 0; x1 < BLOCKWIDTH; ++x1) 
+                    for (int x1 = 0; x1 < BLOCKWIDTH; ++x1)
                     {
                         // use dummy value for q-parameter
                         t_color[block_mask[x1][y]][R] += original_colors[x1][y][R];
@@ -5684,7 +5686,7 @@ void computeColorLBGNotIntensity(uint8 *img,int width,int startx,int starty, uin
 
 // Calculation of the two block colors using the LBG-algorithm
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-void computeColorLBG(uint8 *img,int width,int startx,int starty, uint8 (LBG_colors)[2][3]) 
+void computeColorLBG(uint8 *img,int width,int startx,int starty, uint8 (LBG_colors)[2][3])
 {
     uint8 block_mask[4][4];
 
@@ -5708,13 +5710,13 @@ void computeColorLBG(uint8 *img,int width,int startx,int starty, uint8 (LBG_colo
     int seeding;
     bool continue_iterate;
 
-    max_v[R] = -512.0;   max_v[G] = -512.0;   max_v[B] = -512.0; 
+    max_v[R] = -512.0;   max_v[G] = -512.0;   max_v[B] = -512.0;
     min_v[R] =  512.0;   min_v[G] =  512.0;   min_v[B] =  512.0;
 
     // resolve trainingdata
-    for (y = 0; y < BLOCKHEIGHT; ++y) 
+    for (y = 0; y < BLOCKHEIGHT; ++y)
     {
-        for (x = 0; x < BLOCKWIDTH; ++x) 
+        for (x = 0; x < BLOCKWIDTH; ++x)
         {
             red = img[3*((starty+y)*width+startx+x)+R];
             green = img[3*((starty+y)*width+startx+x)+G];
@@ -5735,8 +5737,8 @@ void computeColorLBG(uint8 *img,int width,int startx,int starty, uint8 (LBG_colo
         }
     }
 
-    D = 512*512*3*16.0; 
-    bestD = 512*512*3*16.0; 
+    D = 512*512*3*16.0;
+    bestD = 512*512*3*16.0;
 
     continue_seeding = true;
 
@@ -5747,14 +5749,14 @@ void computeColorLBG(uint8 *img,int width,int startx,int starty, uint8 (LBG_colo
         continue_seeding = false;
 
         // calculate seeds
-        for (uint8 s = 0; s < 2; ++s) 
+        for (uint8 s = 0; s < 2; ++s)
         {
-            for (uint8 c = 0; c < 3; ++c) 
-            { 
+            for (uint8 c = 0; c < 3; ++c)
+            {
                 current_colors[s][c] = double((double(rand())/RAND_MAX)*(max_v[c]-min_v[c])) + min_v[c];
             }
         }
-        
+
         // divide into two quantization sets and calculate distortion
 
         continue_iterate = true;
@@ -5763,23 +5765,23 @@ void computeColorLBG(uint8 *img,int width,int startx,int starty, uint8 (LBG_colo
             oldD = D;
             D = 0;
             int n = 0;
-            for (y = 0; y < BLOCKHEIGHT; ++y) 
+            for (y = 0; y < BLOCKHEIGHT; ++y)
             {
-                for (int x1 = 0; x1 < BLOCKWIDTH; ++x1) 
+                for (int x1 = 0; x1 < BLOCKWIDTH; ++x1)
                 {
-                    error_a = SQUARE(original_colors[x1][y][R] - JAS_ROUND(current_colors[0][R])) + 
+                    error_a = SQUARE(original_colors[x1][y][R] - JAS_ROUND(current_colors[0][R])) +
                               SQUARE(original_colors[x1][y][G] - JAS_ROUND(current_colors[0][G])) +
                               SQUARE(original_colors[x1][y][B] - JAS_ROUND(current_colors[0][B]));
-                    error_b = SQUARE(original_colors[x1][y][R] - JAS_ROUND(current_colors[1][R])) + 
+                    error_b = SQUARE(original_colors[x1][y][R] - JAS_ROUND(current_colors[1][R])) +
                               SQUARE(original_colors[x1][y][G] - JAS_ROUND(current_colors[1][G])) +
                               SQUARE(original_colors[x1][y][B] - JAS_ROUND(current_colors[1][B]));
-                    if (error_a < error_b) 
+                    if (error_a < error_b)
                     {
                         block_mask[x1][y] = 0;
-                        D += error_a; 
+                        D += error_a;
                         ++n;
-                    } 
-                    else 
+                    }
+                    else
                     {
                         block_mask[x1][y] = 1;
                         D += error_b;
@@ -5788,7 +5790,7 @@ void computeColorLBG(uint8 *img,int width,int startx,int starty, uint8 (LBG_colo
             }
 
             // compare with old distortion
-            if (D == 0) 
+            if (D == 0)
             {
                 // Perfect score -- we dont need to go further iterations.
                 continue_iterate = false;
@@ -5800,18 +5802,18 @@ void computeColorLBG(uint8 *img,int width,int startx,int starty, uint8 (LBG_colo
                 continue_iterate = false;
                 continue_seeding = true;
             }
-            if (D < bestD) 
+            if (D < bestD)
             {
                 bestD = D;
-                for(uint8 s = 0; s < 2; ++s) 
+                for(uint8 s = 0; s < 2; ++s)
                 {
-                    for(uint8 c = 0; c < 3; ++c) 
+                    for(uint8 c = 0; c < 3; ++c)
                     {
                         best_colors[s][c] = current_colors[s][c];
                     }
                 }
             }
-            if (n == 0 || n == BLOCKWIDTH*BLOCKHEIGHT) 
+            if (n == 0 || n == BLOCKWIDTH*BLOCKHEIGHT)
             {
                 // All colors end up in the same voroni region. We need to reseed.
                 continue_iterate = false;
@@ -5829,9 +5831,9 @@ void computeColorLBG(uint8 *img,int width,int startx,int starty, uint8 (LBG_colo
                 t_color[1][G] = 0;
                 t_color[1][B] = 0;
 
-                for (y = 0; y < BLOCKHEIGHT; ++y) 
+                for (y = 0; y < BLOCKHEIGHT; ++y)
                 {
-                    for (int x1 = 0; x1 < BLOCKWIDTH; ++x1) 
+                    for (int x1 = 0; x1 < BLOCKWIDTH; ++x1)
                     {
                         // use dummy value for q-parameter
                         t_color[block_mask[x1][y]][R] += original_colors[x1][y][R];
@@ -5850,13 +5852,13 @@ void computeColorLBG(uint8 *img,int width,int startx,int starty, uint8 (LBG_colo
     }
 
     // Set the best colors as the final block colors
-    for(int s = 0; s < 2; ++s) 
+    for(int s = 0; s < 2; ++s)
     {
-        for(uint8 c = 0; c < 3; ++c) 
+        for(uint8 c = 0; c < 3; ++c)
         {
             current_colors[s][c] = best_colors[s][c];
         }
-    }        
+    }
 
     for(x=0;x<2;x++)
         for(y=0;y<3;y++)
@@ -5865,7 +5867,7 @@ void computeColorLBG(uint8 *img,int width,int startx,int starty, uint8 (LBG_colo
 
 // Calculation of the two block colors using the LBG-algorithm
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-void computeColorLBGfast(uint8 *img,int width,int startx,int starty, uint8 (LBG_colors)[2][3]) 
+void computeColorLBGfast(uint8 *img,int width,int startx,int starty, uint8 (LBG_colors)[2][3])
 {
     uint8 block_mask[4][4];
 
@@ -5888,18 +5890,18 @@ void computeColorLBGfast(uint8 *img,int width,int startx,int starty, uint8 (LBG_
     int seeding;
     bool continue_iterate;
 
-    max_v[R] = -512.0;   max_v[G] = -512.0;   max_v[B] = -512.0; 
+    max_v[R] = -512.0;   max_v[G] = -512.0;   max_v[B] = -512.0;
     min_v[R] =  512.0;   min_v[G] =  512.0;   min_v[B] =  512.0;
 
     // resolve trainingdata
-    for (y = 0; y < BLOCKHEIGHT; ++y) 
+    for (y = 0; y < BLOCKHEIGHT; ++y)
     {
-        for (x = 0; x < BLOCKWIDTH; ++x) 
+        for (x = 0; x < BLOCKWIDTH; ++x)
         {
             original_colors[x][y][R] = img[3*((starty+y)*width+startx+x)+R];
             original_colors[x][y][G] = img[3*((starty+y)*width+startx+x)+G];
             original_colors[x][y][B] = img[3*((starty+y)*width+startx+x)+B];
-        
+
             // find max
             if (original_colors[x][y][R] > max_v[R]) max_v[R] = original_colors[x][y][R];
             if (original_colors[x][y][G] > max_v[G]) max_v[G] = original_colors[x][y][G];
@@ -5911,8 +5913,8 @@ void computeColorLBGfast(uint8 *img,int width,int startx,int starty, uint8 (LBG_
         }
     }
 
-    D = 512*512*3*16.0; 
-    bestD = 512*512*3*16.0; 
+    D = 512*512*3*16.0;
+    bestD = 512*512*3*16.0;
 
     continue_seeding = true;
 
@@ -5923,14 +5925,14 @@ void computeColorLBGfast(uint8 *img,int width,int startx,int starty, uint8 (LBG_
         continue_seeding = false;
 
         // calculate seeds
-        for (uint8 s = 0; s < 2; ++s) 
+        for (uint8 s = 0; s < 2; ++s)
         {
-            for (uint8 c = 0; c < 3; ++c) 
-            { 
+            for (uint8 c = 0; c < 3; ++c)
+            {
                 current_colors[s][c] = double((double(rand())/RAND_MAX)*(max_v[c]-min_v[c])) + min_v[c];
             }
         }
-        
+
         // divide into two quantization sets and calculate distortion
         continue_iterate = true;
         for(i = 0; (i < number_of_iterations) && continue_iterate; i++)
@@ -5938,23 +5940,23 @@ void computeColorLBGfast(uint8 *img,int width,int startx,int starty, uint8 (LBG_
             oldD = D;
             D = 0;
             int n = 0;
-            for (y = 0; y < BLOCKHEIGHT; ++y) 
+            for (y = 0; y < BLOCKHEIGHT; ++y)
             {
-                for (int x1 = 0; x1 < BLOCKWIDTH; ++x1) 
+                for (int x1 = 0; x1 < BLOCKWIDTH; ++x1)
                 {
-                    error_a = SQUARE(original_colors[x1][y][R] - JAS_ROUND(current_colors[0][R])) + 
+                    error_a = SQUARE(original_colors[x1][y][R] - JAS_ROUND(current_colors[0][R])) +
                               SQUARE(original_colors[x1][y][G] - JAS_ROUND(current_colors[0][G])) +
                               SQUARE(original_colors[x1][y][B] - JAS_ROUND(current_colors[0][B]));
-                    error_b = SQUARE(original_colors[x1][y][R] - JAS_ROUND(current_colors[1][R])) + 
+                    error_b = SQUARE(original_colors[x1][y][R] - JAS_ROUND(current_colors[1][R])) +
                               SQUARE(original_colors[x1][y][G] - JAS_ROUND(current_colors[1][G])) +
                               SQUARE(original_colors[x1][y][B] - JAS_ROUND(current_colors[1][B]));
-                    if (error_a < error_b) 
+                    if (error_a < error_b)
                     {
                         block_mask[x1][y] = 0;
-                        D += error_a; 
+                        D += error_a;
                         ++n;
-                    } 
-                    else 
+                    }
+                    else
                     {
                         block_mask[x1][y] = 1;
                         D += error_b;
@@ -5963,7 +5965,7 @@ void computeColorLBGfast(uint8 *img,int width,int startx,int starty, uint8 (LBG_
             }
 
             // compare with old distortion
-            if (D == 0) 
+            if (D == 0)
             {
                 // Perfect score -- we dont need to go further iterations.
                 continue_iterate = false;
@@ -5975,18 +5977,18 @@ void computeColorLBGfast(uint8 *img,int width,int startx,int starty, uint8 (LBG_
                 continue_iterate = false;
                 continue_seeding = false;
             }
-            if (D < bestD) 
+            if (D < bestD)
             {
                 bestD = D;
-                for(uint8 s = 0; s < 2; ++s) 
+                for(uint8 s = 0; s < 2; ++s)
                 {
-                    for(uint8 c = 0; c < 3; ++c) 
+                    for(uint8 c = 0; c < 3; ++c)
                     {
                         best_colors[s][c] = current_colors[s][c];
                     }
                 }
             }
-            if (n == 0 || n == BLOCKWIDTH*BLOCKHEIGHT) 
+            if (n == 0 || n == BLOCKWIDTH*BLOCKHEIGHT)
             {
                 // All colors end up in the same voroni region. We need to reseed.
                 continue_iterate = false;
@@ -6004,9 +6006,9 @@ void computeColorLBGfast(uint8 *img,int width,int startx,int starty, uint8 (LBG_
                 t_color[1][G] = 0;
                 t_color[1][B] = 0;
 
-                for (y = 0; y < BLOCKHEIGHT; ++y) 
+                for (y = 0; y < BLOCKHEIGHT; ++y)
                 {
-                    for (int x1 = 0; x1 < BLOCKWIDTH; ++x1) 
+                    for (int x1 = 0; x1 < BLOCKWIDTH; ++x1)
                     {
                         // use dummy value for q-parameter
                         t_color[block_mask[x1][y]][R] += original_colors[x1][y][R];
@@ -6025,13 +6027,13 @@ void computeColorLBGfast(uint8 *img,int width,int startx,int starty, uint8 (LBG_
     }
 
     // Set the best colors as the final block colors
-    for(int s = 0; s < 2; ++s) 
+    for(int s = 0; s < 2; ++s)
     {
-        for(uint8 c = 0; c < 3; ++c) 
+        for(uint8 c = 0; c < 3; ++c)
         {
             current_colors[s][c] = best_colors[s][c];
         }
-    }        
+    }
 
     for(x=0;x<2;x++)
         for(y=0;y<3;y++)
@@ -6040,7 +6042,7 @@ void computeColorLBGfast(uint8 *img,int width,int startx,int starty, uint8 (LBG_
 
 // Each color component is compressed to fit in its specified number of bits
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-void compressColor(int R_B, int G_B, int B_B, uint8 (current_color)[2][3], uint8 (quantized_color)[2][3]) 
+void compressColor(int R_B, int G_B, int B_B, uint8 (current_color)[2][3], uint8 (quantized_color)[2][3])
 {
     //
     //    The color is calculated as:
@@ -6063,7 +6065,7 @@ void compressColor(int R_B, int G_B, int B_B, uint8 (current_color)[2][3], uint8
 
 // Swapping two RGB-colors
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-void swapColors(uint8 (colors)[2][3]) 
+void swapColors(uint8 (colors)[2][3])
 {
     uint8 temp = colors[0][R];
     colors[0][R] = colors[1][R];
@@ -6079,24 +6081,24 @@ void swapColors(uint8 (colors)[2][3])
 }
 
 
-// Calculate the paint colors from the block colors 
+// Calculate the paint colors from the block colors
 // using a distance d and one of the H- or T-patterns.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 
 // Calculate the error for the block at position (startx,starty)
 // The parameters needed for reconstruction are calculated as well
-// 
+//
 // Please note that the function can change the order between the two colors in colorsRGB444
 //
 // In the 59T bit mode, we only have pattern T.
 //
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-unsigned int calculateError59Tperceptual1000(uint8* srcimg, int width, int startx, int starty, uint8 (colorsRGB444)[2][3], uint8 &distance, unsigned int &pixel_indices) 
+unsigned int calculateError59Tperceptual1000(uint8* srcimg, int width, int startx, int starty, uint8 (colorsRGB444)[2][3], uint8 &distance, unsigned int &pixel_indices)
 {
 
-    unsigned int block_error = 0, 
+    unsigned int block_error = 0,
            best_block_error = MAXERR1000,
-           pixel_error, 
+           pixel_error,
            best_pixel_error;
     int diff[3];
     uint8 best_sw;
@@ -6105,34 +6107,34 @@ unsigned int calculateError59Tperceptual1000(uint8* srcimg, int width, int start
     uint8 possible_colors[4][3];
 
     // First use the colors as they are, then swap them
-    for (uint8 sw = 0; sw <2; ++sw) 
-    { 
-        if (sw == 1) 
+    for (uint8 sw = 0; sw <2; ++sw)
+    {
+        if (sw == 1)
         {
             swapColors(colorsRGB444);
         }
         decompressColor(R_BITS59T, G_BITS59T, B_BITS59T, colorsRGB444, colors);
 
         // Test all distances
-        for (uint8 d = 0; d < BINPOW(TABLE_BITS_59T); ++d) 
+        for (uint8 d = 0; d < BINPOW(TABLE_BITS_59T); ++d)
         {
             calculatePaintColors59T(d,PATTERN_T, colors, possible_colors);
-            
-            block_error = 0;    
+
+            block_error = 0;
             pixel_colors = 0;
 
             // Loop block
-            for (size_t y = 0; y < BLOCKHEIGHT; ++y) 
+            for (size_t y = 0; y < BLOCKHEIGHT; ++y)
             {
-                for (size_t x = 0; x < BLOCKWIDTH; ++x) 
+                for (size_t x = 0; x < BLOCKWIDTH; ++x)
                 {
                     best_pixel_error = MAXERR1000;
                     pixel_colors <<=2; // Make room for next value
 
                     // Loop possible block colors
-                    for (uint8 c = 0; c < 4; ++c) 
+                    for (uint8 c = 0; c < 4; ++c)
                     {
-                    
+
                         diff[R] = srcimg[3*((starty+y)*width+startx+x)+R] - CLAMP(0,possible_colors[c][R],255);
                         diff[G] = srcimg[3*((starty+y)*width+startx+x)+G] - CLAMP(0,possible_colors[c][G],255);
                         diff[B] = srcimg[3*((starty+y)*width+startx+x)+B] - CLAMP(0,possible_colors[c][B],255);
@@ -6142,17 +6144,17 @@ unsigned int calculateError59Tperceptual1000(uint8* srcimg, int width, int start
                                         PERCEPTUAL_WEIGHT_B_SQUARED_TIMES1000*SQUARE(diff[B]);
 
                         // Choose best error
-                        if (pixel_error < best_pixel_error) 
+                        if (pixel_error < best_pixel_error)
                         {
                             best_pixel_error = pixel_error;
                             pixel_colors ^= (pixel_colors & 3); // Reset the two first bits
                             pixel_colors |= c;
-                        } 
+                        }
                     }
                     block_error += best_pixel_error;
                 }
             }
-            if (block_error < best_block_error) 
+            if (block_error < best_block_error)
             {
                 best_block_error = block_error;
                 distance = d;
@@ -6160,8 +6162,8 @@ unsigned int calculateError59Tperceptual1000(uint8* srcimg, int width, int start
                 best_sw = sw;
             }
         }
-        
-        if (sw == 1 && best_sw == 0) 
+
+        if (sw == 1 && best_sw == 0)
         {
             swapColors(colorsRGB444);
         }
@@ -6172,17 +6174,17 @@ unsigned int calculateError59Tperceptual1000(uint8* srcimg, int width, int start
 
 // Calculate the error for the block at position (startx,starty)
 // The parameters needed for reconstruction is calculated as well
-// 
+//
 // Please note that the function can change the order between the two colors in colorsRGB444
 //
 // In the 59T bit mode, we only have pattern T.
 //
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-double calculateError59T(uint8* srcimg, int width, int startx, int starty, uint8 (colorsRGB444)[2][3], uint8 &distance, unsigned int &pixel_indices) 
+double calculateError59T(uint8* srcimg, int width, int startx, int starty, uint8 (colorsRGB444)[2][3], uint8 &distance, unsigned int &pixel_indices)
 {
-    double block_error = 0, 
-             best_block_error = MAXIMUM_ERROR, 
-                 pixel_error, 
+    double block_error = 0,
+             best_block_error = MAXIMUM_ERROR,
+                 pixel_error,
                  best_pixel_error;
     int diff[3];
     uint8 best_sw;
@@ -6191,34 +6193,34 @@ double calculateError59T(uint8* srcimg, int width, int startx, int starty, uint8
     uint8 possible_colors[4][3];
 
     // First use the colors as they are, then swap them
-    for (uint8 sw = 0; sw <2; ++sw) 
-    { 
-        if (sw == 1) 
+    for (uint8 sw = 0; sw <2; ++sw)
+    {
+        if (sw == 1)
         {
             swapColors(colorsRGB444);
         }
         decompressColor(R_BITS59T, G_BITS59T, B_BITS59T, colorsRGB444, colors);
 
         // Test all distances
-        for (uint8 d = 0; d < BINPOW(TABLE_BITS_59T); ++d) 
+        for (uint8 d = 0; d < BINPOW(TABLE_BITS_59T); ++d)
         {
             calculatePaintColors59T(d,PATTERN_T, colors, possible_colors);
-            
-            block_error = 0;    
+
+            block_error = 0;
             pixel_colors = 0;
 
             // Loop block
-            for (size_t y = 0; y < BLOCKHEIGHT; ++y) 
+            for (size_t y = 0; y < BLOCKHEIGHT; ++y)
             {
-                for (size_t x = 0; x < BLOCKWIDTH; ++x) 
+                for (size_t x = 0; x < BLOCKWIDTH; ++x)
                 {
                     best_pixel_error = MAXIMUM_ERROR;
                     pixel_colors <<=2; // Make room for next value
 
                     // Loop possible block colors
-                    for (uint8 c = 0; c < 4; ++c) 
+                    for (uint8 c = 0; c < 4; ++c)
                     {
-                    
+
                         diff[R] = srcimg[3*((starty+y)*width+startx+x)+R] - CLAMP(0,possible_colors[c][R],255);
                         diff[G] = srcimg[3*((starty+y)*width+startx+x)+G] - CLAMP(0,possible_colors[c][G],255);
                         diff[B] = srcimg[3*((starty+y)*width+startx+x)+B] - CLAMP(0,possible_colors[c][B],255);
@@ -6228,17 +6230,17 @@ double calculateError59T(uint8* srcimg, int width, int startx, int starty, uint8
                                         weight[B]*SQUARE(diff[B]);
 
                         // Choose best error
-                        if (pixel_error < best_pixel_error) 
+                        if (pixel_error < best_pixel_error)
                         {
                             best_pixel_error = pixel_error;
                             pixel_colors ^= (pixel_colors & 3); // Reset the two first bits
                             pixel_colors |= c;
-                        } 
+                        }
                     }
                     block_error += best_pixel_error;
                 }
             }
-            if (block_error < best_block_error) 
+            if (block_error < best_block_error)
             {
                 best_block_error = block_error;
                 distance = d;
@@ -6246,8 +6248,8 @@ double calculateError59T(uint8* srcimg, int width, int startx, int starty, uint8
                 best_sw = sw;
             }
         }
-        
-        if (sw == 1 && best_sw == 0) 
+
+        if (sw == 1 && best_sw == 0)
         {
             swapColors(colorsRGB444);
         }
@@ -6260,14 +6262,14 @@ double calculateError59T(uint8* srcimg, int width, int startx, int starty, uint8
 // The parameters needed for reconstruction is calculated as well
 //
 // In the 59T bit mode, we only have pattern T.
-// 
+//
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-unsigned int calculateError59TnoSwapPerceptual1000(uint8* srcimg, int width, int startx, int starty, uint8 (colorsRGB444)[2][3], uint8 &distance, unsigned int &pixel_indices) 
+unsigned int calculateError59TnoSwapPerceptual1000(uint8* srcimg, int width, int startx, int starty, uint8 (colorsRGB444)[2][3], uint8 &distance, unsigned int &pixel_indices)
 {
 
-    unsigned int block_error = 0, 
+    unsigned int block_error = 0,
            best_block_error = MAXERR1000,
-           pixel_error, 
+           pixel_error,
            best_pixel_error;
     int diff[3];
     unsigned int pixel_colors;
@@ -6279,25 +6281,25 @@ unsigned int calculateError59TnoSwapPerceptual1000(uint8* srcimg, int width, int
         decompressColor(R_BITS59T, G_BITS59T, B_BITS59T, colorsRGB444, colors);
 
         // Test all distances
-        for (uint8 d = 0; d < BINPOW(TABLE_BITS_59T); ++d) 
+        for (uint8 d = 0; d < BINPOW(TABLE_BITS_59T); ++d)
         {
             calculatePaintColors59T(d,PATTERN_T, colors, possible_colors);
-            
-            block_error = 0;    
+
+            block_error = 0;
             pixel_colors = 0;
 
             // Loop block
-            for (size_t y = 0; y < BLOCKHEIGHT; ++y) 
+            for (size_t y = 0; y < BLOCKHEIGHT; ++y)
             {
-                for (size_t x = 0; x < BLOCKWIDTH; ++x) 
+                for (size_t x = 0; x < BLOCKWIDTH; ++x)
                 {
                     best_pixel_error = MAXERR1000;
                     pixel_colors <<=2; // Make room for next value
 
                     // Loop possible block colors
-                    for (uint8 c = 0; c < 4; ++c) 
+                    for (uint8 c = 0; c < 4; ++c)
                     {
-                    
+
                         diff[R] = srcimg[3*((starty+y)*width+startx+x)+R] - CLAMP(0,possible_colors[c][R],255);
                         diff[G] = srcimg[3*((starty+y)*width+startx+x)+G] - CLAMP(0,possible_colors[c][G],255);
                         diff[B] = srcimg[3*((starty+y)*width+startx+x)+B] - CLAMP(0,possible_colors[c][B],255);
@@ -6307,25 +6309,25 @@ unsigned int calculateError59TnoSwapPerceptual1000(uint8* srcimg, int width, int
                                         PERCEPTUAL_WEIGHT_B_SQUARED_TIMES1000*SQUARE(diff[B]);
 
                         // Choose best error
-                        if (pixel_error < best_pixel_error) 
+                        if (pixel_error < best_pixel_error)
                         {
                             best_pixel_error = pixel_error;
                             pixel_colors ^= (pixel_colors & 3); // Reset the two first bits
                             pixel_colors |= c;
                             thebestintheworld = c;
-                        } 
+                        }
                     }
                     block_error += best_pixel_error;
                 }
             }
-            if (block_error < best_block_error) 
+            if (block_error < best_block_error)
             {
                 best_block_error = block_error;
                 distance = d;
                 pixel_indices = pixel_colors;
             }
         }
-        
+
     decompressColor(R_BITS59T, G_BITS59T, B_BITS59T, colorsRGB444, colors);
     return best_block_error;
 }
@@ -6336,11 +6338,11 @@ unsigned int calculateError59TnoSwapPerceptual1000(uint8* srcimg, int width, int
 // In the 59T bit mode, we only have pattern T.
 //
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-double calculateError59TnoSwap(uint8* srcimg, int width, int startx, int starty, uint8 (colorsRGB444)[2][3], uint8 &distance, unsigned int &pixel_indices) 
+double calculateError59TnoSwap(uint8* srcimg, int width, int startx, int starty, uint8 (colorsRGB444)[2][3], uint8 &distance, unsigned int &pixel_indices)
 {
-    double block_error = 0, 
-             best_block_error = MAXIMUM_ERROR, 
-                 pixel_error, 
+    double block_error = 0,
+             best_block_error = MAXIMUM_ERROR,
+                 pixel_error,
                  best_pixel_error;
     int diff[3];
     unsigned int pixel_colors;
@@ -6352,23 +6354,23 @@ double calculateError59TnoSwap(uint8* srcimg, int width, int startx, int starty,
     decompressColor(R_BITS59T, G_BITS59T, B_BITS59T, colorsRGB444, colors);
 
     // Test all distances
-    for (uint8 d = 0; d < BINPOW(TABLE_BITS_59T); ++d) 
+    for (uint8 d = 0; d < BINPOW(TABLE_BITS_59T); ++d)
     {
         calculatePaintColors59T(d,PATTERN_T, colors, possible_colors);
-            
-        block_error = 0;    
+
+        block_error = 0;
         pixel_colors = 0;
 
         // Loop block
-        for (size_t y = 0; y < BLOCKHEIGHT; ++y) 
+        for (size_t y = 0; y < BLOCKHEIGHT; ++y)
         {
-            for (size_t x = 0; x < BLOCKWIDTH; ++x) 
+            for (size_t x = 0; x < BLOCKWIDTH; ++x)
             {
                 best_pixel_error = MAXIMUM_ERROR;
                 pixel_colors <<=2; // Make room for next value
 
                 // Loop possible block colors
-                for (uint8 c = 0; c < 4; ++c) 
+                for (uint8 c = 0; c < 4; ++c)
                 {
                     diff[R] = srcimg[3*((starty+y)*width+startx+x)+R] - CLAMP(0,possible_colors[c][R],255);
                     diff[G] = srcimg[3*((starty+y)*width+startx+x)+G] - CLAMP(0,possible_colors[c][G],255);
@@ -6379,30 +6381,30 @@ double calculateError59TnoSwap(uint8* srcimg, int width, int startx, int starty,
                                                 weight[B]*SQUARE(diff[B]);
 
                     // Choose best error
-                    if (pixel_error < best_pixel_error) 
+                    if (pixel_error < best_pixel_error)
                     {
                         best_pixel_error = pixel_error;
                         pixel_colors ^= (pixel_colors & 3); // Reset the two first bits
                         pixel_colors |= c;
                         thebestintheworld = c;
-                    } 
+                    }
                 }
                 block_error += best_pixel_error;
             }
         }
-        if (block_error < best_block_error) 
+        if (block_error < best_block_error)
         {
             best_block_error = block_error;
             distance = d;
             pixel_indices = pixel_colors;
         }
     }
-        
+
     decompressColor(R_BITS59T, G_BITS59T, B_BITS59T, colorsRGB444, colors);
     return best_block_error;
 }
 
-// Put the compress params into the compression block 
+// Put the compress params into the compression block
 //
 //
 //|63 62 61 60 59|58 57 56 55|54 53 52 51|50 49 48 47|46 45 44 43|42 41 40 39|38 37 36 35|34 33 32|
@@ -6412,9 +6414,9 @@ double calculateError59TnoSwap(uint8* srcimg, int width, int startx, int starty,
 //|----------------------------------------index bits---------------------------------------------|
 //
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-void packBlock59T(uint8 (colors)[2][3], uint8 d, unsigned int pixel_indices, unsigned int &compressed1, unsigned int &compressed2) 
-{ 
-    
+void packBlock59T(uint8 (colors)[2][3], uint8 d, unsigned int pixel_indices, unsigned int &compressed1, unsigned int &compressed2)
+{
+
     compressed1 = 0;
 
     PUTBITSHIGH( compressed1, colors[0][R], 4, 58);
@@ -6422,7 +6424,7 @@ void packBlock59T(uint8 (colors)[2][3], uint8 d, unsigned int pixel_indices, uns
      PUTBITSHIGH( compressed1, colors[0][B], 4, 50);
      PUTBITSHIGH( compressed1, colors[1][R], 4, 46);
      PUTBITSHIGH( compressed1, colors[1][G], 4, 42);
-     PUTBITSHIGH( compressed1, colors[1][B], 4, 38);    
+     PUTBITSHIGH( compressed1, colors[1][B], 4, 38);
     PUTBITSHIGH( compressed1, d, TABLE_BITS_59T, 34);
     pixel_indices=indexConversion(pixel_indices);
     compressed2 = 0;
@@ -6440,7 +6442,7 @@ void copyColors(uint8 (source)[2][3], uint8 (dest)[2][3])
             dest[x][y] = source[x][y];
 }
 
-// The below code should compress the block to 59 bits. 
+// The below code should compress the block to 59 bits.
 //
 //|63 62 61 60 59|58 57 56 55|54 53 52 51|50 49 48 47|46 45 44 43|42 41 40 39|38 37 36 35|34 33 32|
 //|----empty-----|---red 0---|--green 0--|--blue 0---|---red 1---|--green 1--|--blue 1---|--dist--|
@@ -6470,7 +6472,7 @@ unsigned int compressBlockTHUMB59TFastestOnlyColorPerceptual1000(uint8 *img,int 
     compressColor(R_BITS59T, G_BITS59T, B_BITS59T, colors, colorsRGB444_no_i);
 
     // Determine the parameters for the lowest error
-    error_no_i = calculateError59Tperceptual1000(img, width, startx, starty, colorsRGB444_no_i, distance_no_i, pixel_indices_no_i);            
+    error_no_i = calculateError59Tperceptual1000(img, width, startx, starty, colorsRGB444_no_i, distance_no_i, pixel_indices_no_i);
 
     best_error = error_no_i;
     best_distance = distance_no_i;
@@ -6483,7 +6485,7 @@ unsigned int compressBlockTHUMB59TFastestOnlyColorPerceptual1000(uint8 *img,int 
 }
 
 
-// The below code should compress the block to 59 bits. 
+// The below code should compress the block to 59 bits.
 // This is supposed to match the first of the three modes in TWOTIMER.
 //
 //|63 62 61 60 59|58 57 56 55|54 53 52 51|50 49 48 47|46 45 44 43|42 41 40 39|38 37 36 35|34 33 32|
@@ -6514,7 +6516,7 @@ double compressBlockTHUMB59TFastestOnlyColor(uint8 *img,int width,int height,int
     compressColor(R_BITS59T, G_BITS59T, B_BITS59T, colors, colorsRGB444_no_i);
 
     // Determine the parameters for the lowest error
-    error_no_i = calculateError59T(img, width, startx, starty, colorsRGB444_no_i, distance_no_i, pixel_indices_no_i);            
+    error_no_i = calculateError59T(img, width, startx, starty, colorsRGB444_no_i, distance_no_i, pixel_indices_no_i);
 
     best_error = error_no_i;
     best_distance = distance_no_i;
@@ -6526,7 +6528,7 @@ double compressBlockTHUMB59TFastestOnlyColor(uint8 *img,int width,int height,int
     return best_error;
 }
 
-// The below code should compress the block to 59 bits. 
+// The below code should compress the block to 59 bits.
 // This is supposed to match the first of the three modes in TWOTIMER.
 //
 //|63 62 61 60 59|58 57 56 55|54 53 52 51|50 49 48 47|46 45 44 43|42 41 40 39|38 37 36 35|34 33 32|
@@ -6536,7 +6538,7 @@ double compressBlockTHUMB59TFastestOnlyColor(uint8 *img,int width,int height,int
 //|----------------------------------------index bits---------------------------------------------|
 //
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-double compressBlockTHUMB59TFastestPerceptual1000(uint8 *img,int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2) 
+double compressBlockTHUMB59TFastestPerceptual1000(uint8 *img,int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2)
 {
 
     UNREFERENCED_PARAMETER(height);
@@ -6557,20 +6559,20 @@ double compressBlockTHUMB59TFastestPerceptual1000(uint8 *img,int width,int heigh
     compressColor(R_BITS59T, G_BITS59T, B_BITS59T, colors, colorsRGB444_no_i);
 
     // Determine the parameters for the lowest error
-    error_no_i = calculateError59Tperceptual1000(img, width, startx, starty, colorsRGB444_no_i, distance_no_i, pixel_indices_no_i);            
+    error_no_i = calculateError59Tperceptual1000(img, width, startx, starty, colorsRGB444_no_i, distance_no_i, pixel_indices_no_i);
 
     //best_error = error_no_i;
     best_distance = distance_no_i;
     best_pixel_indices = pixel_indices_no_i;
     copyColors(colorsRGB444_no_i, best_colorsRGB444);
 
-    // Put the compress params into the compression block 
+    // Put the compress params into the compression block
     packBlock59T(best_colorsRGB444, best_distance, best_pixel_indices, compressed1, compressed2);
 
     return error_no_i;
 }
 
-// The below code should compress the block to 59 bits. 
+// The below code should compress the block to 59 bits.
 // This is supposed to match the first of the three modes in TWOTIMER.
 //
 //|63 62 61 60 59|58 57 56 55|54 53 52 51|50 49 48 47|46 45 44 43|42 41 40 39|38 37 36 35|34 33 32|
@@ -6580,7 +6582,7 @@ double compressBlockTHUMB59TFastestPerceptual1000(uint8 *img,int width,int heigh
 //|----------------------------------------index bits---------------------------------------------|
 //
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-double compressBlockTHUMB59TFastest(uint8 *img,int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2) 
+double compressBlockTHUMB59TFastest(uint8 *img,int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2)
 {
 
     UNREFERENCED_PARAMETER(height);
@@ -6602,20 +6604,20 @@ double compressBlockTHUMB59TFastest(uint8 *img,int width,int height,int startx,i
     compressColor(R_BITS59T, G_BITS59T, B_BITS59T, colors, colorsRGB444_no_i);
 
     // Determine the parameters for the lowest error
-    error_no_i = calculateError59T(img, width, startx, starty, colorsRGB444_no_i, distance_no_i, pixel_indices_no_i);            
+    error_no_i = calculateError59T(img, width, startx, starty, colorsRGB444_no_i, distance_no_i, pixel_indices_no_i);
 
     best_error = error_no_i;
     best_distance = distance_no_i;
     best_pixel_indices = pixel_indices_no_i;
     copyColors(colorsRGB444_no_i, best_colorsRGB444);
 
-    // Put the compress params into the compression block 
+    // Put the compress params into the compression block
     packBlock59T(best_colorsRGB444, best_distance, best_pixel_indices, compressed1, compressed2);
 
     return best_error;
 }
 
-// The below code should compress the block to 59 bits. 
+// The below code should compress the block to 59 bits.
 // This is supposed to match the first of the three modes in TWOTIMER.
 //
 //|63 62 61 60 59|58 57 56 55|54 53 52 51|50 49 48 47|46 45 44 43|42 41 40 39|38 37 36 35|34 33 32|
@@ -6624,7 +6626,7 @@ double compressBlockTHUMB59TFastest(uint8 *img,int width,int height,int startx,i
 //|31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10 09 08 07 06 05 04 03 02 01 00|
 //|----------------------------------------index bits---------------------------------------------|
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-double compressBlockTHUMB59TFast(uint8 *img,int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2) 
+double compressBlockTHUMB59TFast(uint8 *img,int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2)
 {
 
     UNREFERENCED_PARAMETER(height);
@@ -6643,7 +6645,7 @@ double compressBlockTHUMB59TFast(uint8 *img,int width,int height,int startx,int 
     uint8 colorsRGB444_half_i[2][3];
     unsigned int pixel_indices_half_i;
     uint8 distance_half_i;
-    
+
     double error;
     uint8 colorsRGB444[2][3];
     unsigned int pixel_indices;
@@ -6655,20 +6657,20 @@ double compressBlockTHUMB59TFast(uint8 *img,int width,int height,int startx,int 
     computeColorLBGNotIntensityFast(img,width,startx,starty, colors);
     compressColor(R_BITS59T, G_BITS59T, B_BITS59T, colors, colorsRGB444_no_i);
     // Determine the parameters for the lowest error
-    error_no_i = calculateError59T(img, width, startx, starty, colorsRGB444_no_i, distance_no_i, pixel_indices_no_i);            
+    error_no_i = calculateError59T(img, width, startx, starty, colorsRGB444_no_i, distance_no_i, pixel_indices_no_i);
 
     // Calculate average color using the LBG-algorithm
     computeColorLBGHalfIntensityFast(img,width,startx,starty, colors);
     compressColor(R_BITS59T, G_BITS59T, B_BITS59T, colors, colorsRGB444_half_i);
     // Determine the parameters for the lowest error
-    error_half_i = calculateError59T(img, width, startx, starty, colorsRGB444_half_i, distance_half_i, pixel_indices_half_i);            
+    error_half_i = calculateError59T(img, width, startx, starty, colorsRGB444_half_i, distance_half_i, pixel_indices_half_i);
 
     // Calculate average color using the LBG-algorithm
     computeColorLBGfast(img,width,startx,starty, colors);
     compressColor(R_BITS59T, G_BITS59T, B_BITS59T, colors, colorsRGB444);
     // Determine the parameters for the lowest error
-    error = calculateError59T(img, width, startx, starty, colorsRGB444, distance, pixel_indices);            
-    
+    error = calculateError59T(img, width, startx, starty, colorsRGB444, distance, pixel_indices);
+
     best_error = error_no_i;
     best_distance = distance_no_i;
     best_pixel_indices = pixel_indices_no_i;
@@ -6689,7 +6691,7 @@ double compressBlockTHUMB59TFast(uint8 *img,int width,int height,int startx,int 
         copyColors (colorsRGB444, best_colorsRGB444);
     }
 
-    // Put the compress params into the compression block 
+    // Put the compress params into the compression block
     packBlock59T(best_colorsRGB444, best_distance, best_pixel_indices, compressed1, compressed2);
 
     return best_error;
@@ -6697,14 +6699,14 @@ double compressBlockTHUMB59TFast(uint8 *img,int width,int height,int startx,int 
 
 // Calculate the error for the block at position (startx,starty)
 // The parameters needed for reconstruction is calculated as well
-// 
+//
 // In the 58H bit mode, we only have pattern H.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-unsigned int calculateErrorAndCompress58Hperceptual1000(uint8* srcimg, int width, int startx, int starty, uint8 (colorsRGB444)[2][3], uint8 &distance, unsigned int &pixel_indices) 
+unsigned int calculateErrorAndCompress58Hperceptual1000(uint8* srcimg, int width, int startx, int starty, uint8 (colorsRGB444)[2][3], uint8 &distance, unsigned int &pixel_indices)
 {
-    unsigned int block_error = 0, 
-                   best_block_error = MAXERR1000, 
-                             pixel_error, 
+    unsigned int block_error = 0,
+                   best_block_error = MAXERR1000,
+                             pixel_error,
                              best_pixel_error;
     int diff[3];
     unsigned int pixel_colors;
@@ -6714,23 +6716,23 @@ unsigned int calculateErrorAndCompress58Hperceptual1000(uint8* srcimg, int width
     decompressColor(R_BITS58H, G_BITS58H, B_BITS58H, colorsRGB444, colors);
 
     // Test all distances
-    for (uint8 d = 0; d < BINPOW(TABLE_BITS_58H); ++d) 
+    for (uint8 d = 0; d < BINPOW(TABLE_BITS_58H); ++d)
     {
         calculatePaintColors58H(d, PATTERN_H, colors, possible_colors);
 
-        block_error = 0;    
+        block_error = 0;
         pixel_colors = 0;
 
         // Loop block
-        for (size_t y = 0; y < BLOCKHEIGHT; ++y) 
+        for (size_t y = 0; y < BLOCKHEIGHT; ++y)
         {
-            for (size_t x = 0; x < BLOCKWIDTH; ++x) 
+            for (size_t x = 0; x < BLOCKWIDTH; ++x)
             {
                 best_pixel_error = MAXERR1000;
                 pixel_colors <<=2; // Make room for next value
 
                 // Loop possible block colors
-                for (uint8 c = 0; c < 4; ++c) 
+                for (uint8 c = 0; c < 4; ++c)
                 {
                     diff[R] = srcimg[3*((starty+y)*width+startx+x)+R] - CLAMP(0,possible_colors[c][R],255);
                     diff[G] = srcimg[3*((starty+y)*width+startx+x)+G] - CLAMP(0,possible_colors[c][G],255);
@@ -6741,18 +6743,18 @@ unsigned int calculateErrorAndCompress58Hperceptual1000(uint8* srcimg, int width
                                     PERCEPTUAL_WEIGHT_B_SQUARED_TIMES1000*SQUARE(diff[B]);
 
                     // Choose best error
-                    if (pixel_error < best_pixel_error) 
+                    if (pixel_error < best_pixel_error)
                     {
                         best_pixel_error = pixel_error;
                         pixel_colors ^= (pixel_colors & 3); // Reset the two first bits
                         pixel_colors |= c;
-                    } 
+                    }
                 }
                 block_error += best_pixel_error;
             }
         }
-        
-        if (block_error < best_block_error) 
+
+        if (block_error < best_block_error)
         {
             best_block_error = block_error;
             distance = d;
@@ -6764,11 +6766,11 @@ unsigned int calculateErrorAndCompress58Hperceptual1000(uint8* srcimg, int width
 
 // The H-mode but with punchthrough alpha
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-double calculateErrorAndCompress58HAlpha(uint8* srcimg, uint8* alphaimg,int width, int startx, int starty, uint8 (colorsRGB444)[2][3], uint8 &distance, unsigned int &pixel_indices) 
+double calculateErrorAndCompress58HAlpha(uint8* srcimg, uint8* alphaimg,int width, int startx, int starty, uint8 (colorsRGB444)[2][3], uint8 &distance, unsigned int &pixel_indices)
 {
-    double block_error = 0, 
-           best_block_error = MAXIMUM_ERROR, 
-           pixel_error, 
+    double block_error = 0,
+           best_block_error = MAXIMUM_ERROR,
+           pixel_error,
            best_pixel_error;
     int diff[3];
     unsigned int pixel_colors;
@@ -6778,11 +6780,11 @@ double calculateErrorAndCompress58HAlpha(uint8* srcimg, uint8* alphaimg,int widt
     int colorsRGB444_packed[2];
     colorsRGB444_packed[0] = (colorsRGB444[0][R] << 8) + (colorsRGB444[0][G] << 4) + colorsRGB444[0][B];
     colorsRGB444_packed[1] = (colorsRGB444[1][R] << 8) + (colorsRGB444[1][G] << 4) + colorsRGB444[1][B];
-    
+
     decompressColor(R_BITS58H, G_BITS58H, B_BITS58H, colorsRGB444, colors);
-    
+
     // Test all distances
-    for (uint8 d = 0; d < BINPOW(TABLE_BITS_58H); ++d) 
+    for (uint8 d = 0; d < BINPOW(TABLE_BITS_58H); ++d)
     {
         alphaindex=2;
         if( (colorsRGB444_packed[0] >= colorsRGB444_packed[1]) ^ ((d & 1)==1) )
@@ -6794,13 +6796,13 @@ double calculateErrorAndCompress58HAlpha(uint8* srcimg, uint8* alphaimg,int widt
 
         calculatePaintColors58H(d, PATTERN_H, colors, possible_colors);
 
-        block_error = 0;    
+        block_error = 0;
         pixel_colors = 0;
 
         // Loop block
-        for (size_t y = 0; y < BLOCKHEIGHT; ++y) 
+        for (size_t y = 0; y < BLOCKHEIGHT; ++y)
         {
-            for (size_t x = 0; x < BLOCKWIDTH; ++x) 
+            for (size_t x = 0; x < BLOCKWIDTH; ++x)
             {
                 int alpha=0;
                 if(alphaimg[((starty+y)*width+startx+x)]>0)
@@ -6811,17 +6813,17 @@ double calculateErrorAndCompress58HAlpha(uint8* srcimg, uint8* alphaimg,int widt
                 pixel_colors <<=2; // Make room for next value
 
                 // Loop possible block colors
-                for (uint8 c = 0; c < 4; ++c) 
+                for (uint8 c = 0; c < 4; ++c)
                 {
-                    if(c==alphaindex&&alpha) 
+                    if(c==alphaindex&&alpha)
                     {
                         pixel_error=0;
                     }
-                    else if(c==alphaindex||alpha) 
+                    else if(c==alphaindex||alpha)
                     {
                         pixel_error=MAXIMUM_ERROR;
                     }
-                    else 
+                    else
                     {
                         diff[R] = srcimg[3*((starty+y)*width+startx+x)+R] - CLAMP(0,possible_colors[c][R],255);
                         diff[G] = srcimg[3*((starty+y)*width+startx+x)+G] - CLAMP(0,possible_colors[c][G],255);
@@ -6833,17 +6835,17 @@ double calculateErrorAndCompress58HAlpha(uint8* srcimg, uint8* alphaimg,int widt
                     }
 
                     // Choose best error
-                    if (pixel_error < best_pixel_error) 
+                    if (pixel_error < best_pixel_error)
                     {
                         best_pixel_error = pixel_error;
                         pixel_colors ^= (pixel_colors & 3); // Reset the two first bits
                         pixel_colors |= c;
-                    } 
+                    }
                 }
                 block_error += best_pixel_error;
             }
         }
-        if (block_error < best_block_error) 
+        if (block_error < best_block_error)
         {
             best_block_error = block_error;
             distance = d;
@@ -6855,42 +6857,42 @@ double calculateErrorAndCompress58HAlpha(uint8* srcimg, uint8* alphaimg,int widt
 
 // Calculate the error for the block at position (startx,starty)
 // The parameters needed for reconstruction is calculated as well
-// 
+//
 // In the 58H bit mode, we only have pattern H.
 //
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-double calculateErrorAndCompress58H(uint8* srcimg, int width, int startx, int starty, uint8 (colorsRGB444)[2][3], uint8 &distance, unsigned int &pixel_indices) 
+double calculateErrorAndCompress58H(uint8* srcimg, int width, int startx, int starty, uint8 (colorsRGB444)[2][3], uint8 &distance, unsigned int &pixel_indices)
 {
-    double block_error = 0, 
-           best_block_error = MAXIMUM_ERROR, 
-                 pixel_error, 
+    double block_error = 0,
+           best_block_error = MAXIMUM_ERROR,
+                 pixel_error,
                  best_pixel_error;
     int diff[3];
     unsigned int pixel_colors;
     uint8 possible_colors[4][3];
     uint8 colors[2][3];
 
-    
+
     decompressColor(R_BITS58H, G_BITS58H, B_BITS58H, colorsRGB444, colors);
 
     // Test all distances
-    for (uint8 d = 0; d < BINPOW(TABLE_BITS_58H); ++d) 
+    for (uint8 d = 0; d < BINPOW(TABLE_BITS_58H); ++d)
     {
         calculatePaintColors58H(d, PATTERN_H, colors, possible_colors);
 
-        block_error = 0;    
+        block_error = 0;
         pixel_colors = 0;
 
         // Loop block
-        for (size_t y = 0; y < BLOCKHEIGHT; ++y) 
+        for (size_t y = 0; y < BLOCKHEIGHT; ++y)
         {
-            for (size_t x = 0; x < BLOCKWIDTH; ++x) 
+            for (size_t x = 0; x < BLOCKWIDTH; ++x)
             {
                 best_pixel_error = MAXIMUM_ERROR;
                 pixel_colors <<=2; // Make room for next value
 
                 // Loop possible block colors
-                for (uint8 c = 0; c < 4; ++c) 
+                for (uint8 c = 0; c < 4; ++c)
                 {
                     diff[R] = srcimg[3*((starty+y)*width+startx+x)+R] - CLAMP(0,possible_colors[c][R],255);
                     diff[G] = srcimg[3*((starty+y)*width+startx+x)+G] - CLAMP(0,possible_colors[c][G],255);
@@ -6901,25 +6903,25 @@ double calculateErrorAndCompress58H(uint8* srcimg, int width, int startx, int st
                                     weight[B]*SQUARE(diff[B]);
 
                     // Choose best error
-                    if (pixel_error < best_pixel_error) 
+                    if (pixel_error < best_pixel_error)
                     {
                         best_pixel_error = pixel_error;
                         pixel_colors ^= (pixel_colors & 3); // Reset the two first bits
                         pixel_colors |= c;
-                    } 
+                    }
                 }
                 block_error += best_pixel_error;
             }
         }
-        
-        if (block_error < best_block_error) 
+
+        if (block_error < best_block_error)
         {
             best_block_error = block_error;
             distance = d;
             pixel_indices = pixel_colors;
         }
     }
-        
+
     return best_block_error;
 }
 
@@ -6943,7 +6945,7 @@ void sortColorsRGB444(uint8 (colorsRGB444)[2][3])
     else
     {
         if(col0 == col1)
-        {    
+        {
             // Both colors are the same. That is useless. If they are both black,
             // col1 can just as well be (0,0,1). Else, col0 can be col1 - 1.
             if(col0 == 0)
@@ -6952,7 +6954,7 @@ void sortColorsRGB444(uint8 (colorsRGB444)[2][3])
                 col0 = col1-1;
         }
     }
-    
+
     colorsRGB444[0][R] = GETBITS(col0, 4, 11);
     colorsRGB444[0][G] = GETBITS(col0, 4, 7);
     colorsRGB444[0][B] = GETBITS(col0, 4, 3);
@@ -6961,7 +6963,7 @@ void sortColorsRGB444(uint8 (colorsRGB444)[2][3])
     colorsRGB444[1][B] = GETBITS(col1, 4, 3);
 }
 
-// The below code should compress the block to 58 bits. 
+// The below code should compress the block to 58 bits.
 // The bit layout is thought to be:
 //
 //|63 62 61 60 59 58|57 56 55 54|53 52 51 50|49 48 47 46|45 44 43 42|41 40 39 38|37 36 35 34|33 32|
@@ -6970,12 +6972,12 @@ void sortColorsRGB444(uint8 (colorsRGB444)[2][3])
 //|31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10 09 08 07 06 05 04 03 02 01 00|
 //|----------------------------------------index bits---------------------------------------------|
 //
-// The distance d is three bits, d2 (MSB), d1 and d0 (LSB). d0 is not stored explicitly. 
+// The distance d is three bits, d2 (MSB), d1 and d0 (LSB). d0 is not stored explicitly.
 // Instead if the 12-bit word red0,green0,blue0 < red1,green1,blue1, d0 is assumed to be 0.
 // Else, it is assumed to be 1.
 //
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-unsigned int compressBlockTHUMB58HFastestPerceptual1000(uint8 *img,int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2) 
+unsigned int compressBlockTHUMB58HFastestPerceptual1000(uint8 *img,int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2)
 {
 
     UNREFERENCED_PARAMETER(height);
@@ -6990,7 +6992,7 @@ unsigned int compressBlockTHUMB58HFastestPerceptual1000(uint8 *img,int width,int
     unsigned int pixel_indices_no_i;
     uint8 distance_no_i;
     uint8 colors[2][3];
-    
+
     // Calculate average color using the LBG-algorithm but discarding the intensity in the error function
     computeColorLBGHalfIntensityFast(img, width, startx, starty, colors);
     compressColor(R_BITS58H, G_BITS58H, B_BITS58H, colors, colorsRGB444_no_i);
@@ -6998,8 +7000,8 @@ unsigned int compressBlockTHUMB58HFastestPerceptual1000(uint8 *img,int width,int
 
     error_no_i = calculateErrorAndCompress58Hperceptual1000(img, width, startx, starty, colorsRGB444_no_i, distance_no_i, pixel_indices_no_i);
 
-    best_error = error_no_i;    
-    best_distance = distance_no_i; 
+    best_error = error_no_i;
+    best_distance = distance_no_i;
     best_pixel_indices = pixel_indices_no_i;
     copyColors(colorsRGB444_no_i, best_colorsRGB444);
 
@@ -7021,8 +7023,8 @@ unsigned int compressBlockTHUMB58HFastestPerceptual1000(uint8 *img,int width,int
         // Reshuffle pixel indices to to exchange C1 with C3, and C2 with C4
         best_pixel_indices = (0x55555555 & best_pixel_indices) | (0xaaaaaaaa & (~best_pixel_indices));
     }
-    
-    // Put the compress params into the compression block 
+
+    // Put the compress params into the compression block
 
     compressed1 = 0;
 
@@ -7041,7 +7043,7 @@ unsigned int compressBlockTHUMB58HFastestPerceptual1000(uint8 *img,int width,int
     return best_error;
 }
 
-// The below code should compress the block to 58 bits. 
+// The below code should compress the block to 58 bits.
 // This is supposed to match the first of the three modes in TWOTIMER.
 // The bit layout is thought to be:
 //
@@ -7051,12 +7053,12 @@ unsigned int compressBlockTHUMB58HFastestPerceptual1000(uint8 *img,int width,int
 //|31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10 09 08 07 06 05 04 03 02 01 00|
 //|----------------------------------------index bits---------------------------------------------|
 //
-// The distance d is three bits, d2 (MSB), d1 and d0 (LSB). d0 is not stored explicitly. 
+// The distance d is three bits, d2 (MSB), d1 and d0 (LSB). d0 is not stored explicitly.
 // Instead if the 12-bit word red0,green0,blue0 < red1,green1,blue1, d0 is assumed to be 0.
 // Else, it is assumed to be 1.
 //
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-double compressBlockTHUMB58HFastest(uint8 *img,int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2) 
+double compressBlockTHUMB58HFastest(uint8 *img,int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2)
 {
 
     UNREFERENCED_PARAMETER(height);
@@ -7071,7 +7073,7 @@ double compressBlockTHUMB58HFastest(uint8 *img,int width,int height,int startx,i
     unsigned int pixel_indices_no_i;
     uint8 distance_no_i;
     uint8 colors[2][3];
-    
+
     // Calculate average color using the LBG-algorithm but discarding the intensity in the error function
     computeColorLBGHalfIntensityFast(img, width, startx, starty, colors);
     compressColor(R_BITS58H, G_BITS58H, B_BITS58H, colors, colorsRGB444_no_i);
@@ -7079,8 +7081,8 @@ double compressBlockTHUMB58HFastest(uint8 *img,int width,int height,int startx,i
 
     error_no_i = calculateErrorAndCompress58H(img, width, startx, starty, colorsRGB444_no_i, distance_no_i, pixel_indices_no_i);
 
-    best_error = error_no_i;    
-    best_distance = distance_no_i; 
+    best_error = error_no_i;
+    best_distance = distance_no_i;
     best_pixel_indices = pixel_indices_no_i;
     copyColors(colorsRGB444_no_i, best_colorsRGB444);
 
@@ -7103,7 +7105,7 @@ double compressBlockTHUMB58HFastest(uint8 *img,int width,int height,int startx,i
         best_pixel_indices = (0x55555555 & best_pixel_indices) | (0xaaaaaaaa & (~best_pixel_indices));
     }
 
-    // Put the compress params into the compression block 
+    // Put the compress params into the compression block
 
     compressed1 = 0;
 
@@ -7123,7 +7125,7 @@ double compressBlockTHUMB58HFastest(uint8 *img,int width,int height,int startx,i
 
 //same as above, but with 1-bit alpha
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-double compressBlockTHUMB58HAlpha(uint8 *img, uint8* alphaimg, int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2) 
+double compressBlockTHUMB58HAlpha(uint8 *img, uint8* alphaimg, int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2)
 {
 
     UNREFERENCED_PARAMETER(height);
@@ -7138,7 +7140,7 @@ double compressBlockTHUMB58HAlpha(uint8 *img, uint8* alphaimg, int width,int hei
     unsigned int pixel_indices_no_i;
     uint8 distance_no_i;
     uint8 colors[2][3];
-    
+
     // Calculate average color using the LBG-algorithm but discarding the intensity in the error function
     computeColorLBGHalfIntensityFast(img, width, startx, starty, colors);
     compressColor(R_BITS58H, G_BITS58H, B_BITS58H, colors, colorsRGB444_no_i);
@@ -7146,8 +7148,8 @@ double compressBlockTHUMB58HAlpha(uint8 *img, uint8* alphaimg, int width,int hei
 
     error_no_i = calculateErrorAndCompress58HAlpha(img, alphaimg,width, startx, starty, colorsRGB444_no_i, distance_no_i, pixel_indices_no_i);
 
-    best_error = error_no_i;    
-    best_distance = distance_no_i; 
+    best_error = error_no_i;
+    best_distance = distance_no_i;
     best_pixel_indices = pixel_indices_no_i;
     copyColors(colorsRGB444_no_i, best_colorsRGB444);
 
@@ -7170,7 +7172,7 @@ double compressBlockTHUMB58HAlpha(uint8 *img, uint8* alphaimg, int width,int hei
         best_pixel_indices = (0x55555555 & best_pixel_indices) | (0xaaaaaaaa & (~best_pixel_indices));
     }
 
-    // Put the compress params into the compression block 
+    // Put the compress params into the compression block
 
     compressed1 = 0;
 
@@ -7188,7 +7190,7 @@ double compressBlockTHUMB58HAlpha(uint8 *img, uint8* alphaimg, int width,int hei
     return best_error;
 }
 
-// The below code should compress the block to 58 bits. 
+// The below code should compress the block to 58 bits.
 // This is supposed to match the first of the three modes in TWOTIMER.
 // The bit layout is thought to be:
 //
@@ -7198,12 +7200,12 @@ double compressBlockTHUMB58HAlpha(uint8 *img, uint8* alphaimg, int width,int hei
 //|31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10 09 08 07 06 05 04 03 02 01 00|
 //|----------------------------------------index bits---------------------------------------------|
 //
-// The distance d is three bits, d2 (MSB), d1 and d0 (LSB). d0 is not stored explicitly. 
+// The distance d is three bits, d2 (MSB), d1 and d0 (LSB). d0 is not stored explicitly.
 // Instead if the 12-bit word red0,green0,blue0 < red1,green1,blue1, d0 is assumed to be 0.
 // Else, it is assumed to be 1.
 //
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-double compressBlockTHUMB58HFast(uint8 *img,int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2) 
+double compressBlockTHUMB58HFast(uint8 *img,int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2)
 {
 
     UNREFERENCED_PARAMETER(height);
@@ -7229,7 +7231,7 @@ double compressBlockTHUMB58HFast(uint8 *img,int width,int height,int startx,int 
     uint8 distance;
 
     uint8 colors[2][3];
-    
+
     // Calculate average color using the LBG-algorithm but discarding the intensity in the error function
     computeColorLBGNotIntensity(img, width, startx, starty, colors);
     compressColor(R_BITS58H, G_BITS58H, B_BITS58H, colors, colorsRGB444_no_i);
@@ -7248,8 +7250,8 @@ double compressBlockTHUMB58HFast(uint8 *img,int width,int height,int startx,int 
     sortColorsRGB444(colorsRGB444);
     error = calculateErrorAndCompress58H(img, width, startx, starty, colorsRGB444, distance, pixel_indices);
 
-    best_error = error_no_i;    
-    best_distance = distance_no_i; 
+    best_error = error_no_i;
+    best_distance = distance_no_i;
     best_pixel_indices = pixel_indices_no_i;
     copyColors(colorsRGB444_no_i, best_colorsRGB444);
 
@@ -7263,8 +7265,8 @@ double compressBlockTHUMB58HFast(uint8 *img,int width,int height,int startx,int 
 
     if(error < best_error)
     {
-        best_error = error;    
-        best_distance = distance; 
+        best_error = error;
+        best_distance = distance;
         best_pixel_indices = pixel_indices;
         copyColors(colorsRGB444, best_colorsRGB444);
     }
@@ -7288,7 +7290,7 @@ double compressBlockTHUMB58HFast(uint8 *img,int width,int height,int startx,int 
         best_pixel_indices = (0x55555555 & best_pixel_indices) | (0xaaaaaaaa & (~best_pixel_indices));
     }
 
-    // Put the compress params into the compression block 
+    // Put the compress params into the compression block
     compressed1 = 0;
 
     PUTBITSHIGH( compressed1, best_colorsRGB444[0][R], 4, 57);
@@ -7334,7 +7336,7 @@ void compressBlockDiffFlipCombinedPerceptual(uint8 *img,int width,int height,int
     computeAverageColor2x4noQuantFloat(img,width,height,startx+2,starty,avg_color_float2);
 
     // First test if avg_color1 is similar enough to avg_color2 so that
-    // we can use differential coding of colors. 
+    // we can use differential coding of colors.
 
     float eps;
 
@@ -7343,8 +7345,8 @@ void compressBlockDiffFlipCombinedPerceptual(uint8 *img,int width,int height,int
     quantize555ColorCombinedPerceptual(avg_color_float1, enc_color1, dummy);
     quantize555ColorCombinedPerceptual(avg_color_float2, enc_color2, dummy);
 
-    diff[0] = enc_color2[0]-enc_color1[0];    
-    diff[1] = enc_color2[1]-enc_color1[1];    
+    diff[0] = enc_color2[0]-enc_color1[0];
+    diff[1] = enc_color2[1]-enc_color1[1];
     diff[2] = enc_color2[2]-enc_color1[2];
 
     if( (diff[0] >= -4) && (diff[0] <= 3) && (diff[1] >= -4) && (diff[1] <= 3) && (diff[2] >= -4) && (diff[2] <= 3) )
@@ -7353,8 +7355,8 @@ void compressBlockDiffFlipCombinedPerceptual(uint8 *img,int width,int height,int
 
         // The difference to be coded:
 
-        diff[0] = enc_color2[0]-enc_color1[0];    
-        diff[1] = enc_color2[1]-enc_color1[1];    
+        diff[0] = enc_color2[0]-enc_color1[0];
+        diff[1] = enc_color2[1]-enc_color1[1];
         diff[2] = enc_color2[2]-enc_color1[2];
 
         avg_color_quant1[0] = enc_color1[0] << 3 | (enc_color1[0] >> 2);
@@ -7364,33 +7366,33 @@ void compressBlockDiffFlipCombinedPerceptual(uint8 *img,int width,int height,int
         avg_color_quant2[1] = enc_color2[1] << 3 | (enc_color2[1] >> 2);
         avg_color_quant2[2] = enc_color2[2] << 3 | (enc_color2[2] >> 2);
 
-        // Pack bits into the first word. 
+        // Pack bits into the first word.
 
         //     ETC1_RGB8_OES:
-        // 
+        //
         //     a) bit layout in bits 63 through 32 if diffbit = 0
-        // 
-        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+        //
+        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
         //      ---------------------------------------------------------------------------------------------------
         //     | base col1 | base col2 | base col1 | base col2 | base col1 | base col2 | table  | table  |diff|flip|
         //     | R1 (4bits)| R2 (4bits)| G1 (4bits)| G2 (4bits)| B1 (4bits)| B2 (4bits)| cw 1   | cw 2   |bit |bit |
         //      ---------------------------------------------------------------------------------------------------
-        //     
+        //
         //     b) bit layout in bits 63 through 32 if diffbit = 1
-        // 
-        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+        //
+        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
         //      ---------------------------------------------------------------------------------------------------
         //     | base col1    | dcol 2 | base col1    | dcol 2 | base col 1   | dcol 2 | table  | table  |diff|flip|
         //     | R1' (5 bits) | dR2    | G1' (5 bits) | dG2    | B1' (5 bits) | dB2    | cw 1   | cw 2   |bit |bit |
         //      ---------------------------------------------------------------------------------------------------
-        // 
+        //
         //     c) bit layout in bits 31 through 0 (in both cases)
-        // 
+        //
         //      31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10  9  8  7  6  5  4  3   2   1  0
         //      --------------------------------------------------------------------------------------------------
-        //     |       most significant pixel index bits       |         least significant pixel index bits       |  
+        //     |       most significant pixel index bits       |         least significant pixel index bits       |
         //     | p| o| n| m| l| k| j| i| h| g| f| e| d| c| b| a| p| o| n| m| l| k| j| i| h| g| f| e| d| c | b | a |
-        //      --------------------------------------------------------------------------------------------------      
+        //      --------------------------------------------------------------------------------------------------
 
         compressed1_norm = 0;
         PUTBITSHIGH( compressed1_norm, diffbit,       1, 33);
@@ -7435,16 +7437,16 @@ void compressBlockDiffFlipCombinedPerceptual(uint8 *img,int width,int height,int
         quantize444ColorCombinedPerceptual(avg_color_float1, enc_color1, dummy);
         quantize444ColorCombinedPerceptual(avg_color_float2, enc_color2, dummy);
 
-        avg_color_quant1[0] = enc_color1[0] << 4 | enc_color1[0]; 
-        avg_color_quant1[1] = enc_color1[1] << 4 | enc_color1[1]; 
+        avg_color_quant1[0] = enc_color1[0] << 4 | enc_color1[0];
+        avg_color_quant1[1] = enc_color1[1] << 4 | enc_color1[1];
         avg_color_quant1[2] = enc_color1[2] << 4 | enc_color1[2];
-        avg_color_quant2[0] = enc_color2[0] << 4 | enc_color2[0]; 
-        avg_color_quant2[1] = enc_color2[1] << 4 | enc_color2[1]; 
+        avg_color_quant2[0] = enc_color2[0] << 4 | enc_color2[0];
+        avg_color_quant2[1] = enc_color2[1] << 4 | enc_color2[1];
         avg_color_quant2[2] = enc_color2[2] << 4 | enc_color2[2];
 
-        // Pack bits into the first word. 
+        // Pack bits into the first word.
 
-        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
         //      ---------------------------------------------------------------------------------------------------
         //     | base col1 | base col2 | base col1 | base col2 | base col1 | base col2 | table  | table  |diff|flip|
         //     | R1 (4bits)| R2 (4bits)| G1 (4bits)| G2 (4bits)| B1 (4bits)| B2 (4bits)| cw 1   | cw 2   |bit |bit |
@@ -7463,7 +7465,7 @@ void compressBlockDiffFlipCombinedPerceptual(uint8 *img,int width,int height,int
         unsigned int best_pixel_indices1_LSB;
         unsigned int best_pixel_indices2_MSB;
         unsigned int best_pixel_indices2_LSB;
-        
+
         // left part of block
         norm_err = tryalltables_3bittable2x4percep(img,width,height,startx,starty,avg_color_quant1,best_table1,best_pixel_indices1_MSB, best_pixel_indices1_LSB);
 
@@ -7486,12 +7488,12 @@ void compressBlockDiffFlipCombinedPerceptual(uint8 *img,int width,int height,int
     computeAverageColor4x2noQuantFloat(img,width,height,startx,starty+2,avg_color_float2);
 
     // First test if avg_color1 is similar enough to avg_color2 so that
-    // we can use differential coding of colors. 
+    // we can use differential coding of colors.
     quantize555ColorCombinedPerceptual(avg_color_float1, enc_color1, dummy);
     quantize555ColorCombinedPerceptual(avg_color_float2, enc_color2, dummy);
 
-    diff[0] = enc_color2[0]-enc_color1[0];    
-    diff[1] = enc_color2[1]-enc_color1[1];    
+    diff[0] = enc_color2[0]-enc_color1[0];
+    diff[1] = enc_color2[1]-enc_color1[1];
     diff[2] = enc_color2[2]-enc_color1[2];
 
     if( (diff[0] >= -4) && (diff[0] <= 3) && (diff[1] >= -4) && (diff[1] <= 3) && (diff[2] >= -4) && (diff[2] <= 3) )
@@ -7499,8 +7501,8 @@ void compressBlockDiffFlipCombinedPerceptual(uint8 *img,int width,int height,int
         diffbit = 1;
 
         // The difference to be coded:
-        diff[0] = enc_color2[0]-enc_color1[0];    
-        diff[1] = enc_color2[1]-enc_color1[1];    
+        diff[0] = enc_color2[0]-enc_color1[0];
+        diff[1] = enc_color2[1]-enc_color1[1];
         diff[2] = enc_color2[2]-enc_color1[2];
 
         avg_color_quant1[0] = enc_color1[0] << 3 | (enc_color1[0] >> 2);
@@ -7510,7 +7512,7 @@ void compressBlockDiffFlipCombinedPerceptual(uint8 *img,int width,int height,int
         avg_color_quant2[1] = enc_color2[1] << 3 | (enc_color2[1] >> 2);
         avg_color_quant2[2] = enc_color2[2] << 3 | (enc_color2[2] >> 2);
 
-        // Pack bits into the first word. 
+        // Pack bits into the first word.
         compressed1_flip = 0;
         PUTBITSHIGH( compressed1_flip, diffbit,       1, 33);
          PUTBITSHIGH( compressed1_flip, enc_color1[0], 5, 63);
@@ -7536,7 +7538,7 @@ void compressBlockDiffFlipCombinedPerceptual(uint8 *img,int width,int height,int
 
         best_pixel_indices1_MSB |= (best_pixel_indices2_MSB << 2);
         best_pixel_indices1_LSB |= (best_pixel_indices2_LSB << 2);
-        
+
         compressed2_flip = ((best_pixel_indices1_MSB & 0xffff) << 16) | (best_pixel_indices1_LSB & 0xffff);
     }
     else
@@ -7549,20 +7551,20 @@ void compressBlockDiffFlipCombinedPerceptual(uint8 *img,int width,int height,int
         quantize444ColorCombinedPerceptual(avg_color_float1, enc_color1, dummy);
         quantize444ColorCombinedPerceptual(avg_color_float2, enc_color2, dummy);
 
-        avg_color_quant1[0] = enc_color1[0] << 4 | enc_color1[0]; 
-        avg_color_quant1[1] = enc_color1[1] << 4 | enc_color1[1]; 
+        avg_color_quant1[0] = enc_color1[0] << 4 | enc_color1[0];
+        avg_color_quant1[1] = enc_color1[1] << 4 | enc_color1[1];
         avg_color_quant1[2] = enc_color1[2] << 4 | enc_color1[2];
-        avg_color_quant2[0] = enc_color2[0] << 4 | enc_color2[0]; 
-        avg_color_quant2[1] = enc_color2[1] << 4 | enc_color2[1]; 
+        avg_color_quant2[0] = enc_color2[0] << 4 | enc_color2[0];
+        avg_color_quant2[1] = enc_color2[1] << 4 | enc_color2[1];
         avg_color_quant2[2] = enc_color2[2] << 4 | enc_color2[2];
 
-        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+        //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
         //      ---------------------------------------------------------------------------------------------------
         //     | base col1 | base col2 | base col1 | base col2 | base col1 | base col2 | table  | table  |diff|flip|
         //     | R1 (4bits)| R2 (4bits)| G1 (4bits)| G2 (4bits)| B1 (4bits)| B2 (4bits)| cw 1   | cw 2   |bit |bit |
         //      ---------------------------------------------------------------------------------------------------
 
-        // Pack bits into the first word. 
+        // Pack bits into the first word.
         compressed1_flip = 0;
         PUTBITSHIGH( compressed1_flip, diffbit,       1, 33);
          PUTBITSHIGH( compressed1_flip, enc_color1[0], 4, 63);
@@ -7588,11 +7590,11 @@ void compressBlockDiffFlipCombinedPerceptual(uint8 *img,int width,int height,int
 
         best_pixel_indices1_MSB |= (best_pixel_indices2_MSB << 2);
         best_pixel_indices1_LSB |= (best_pixel_indices2_LSB << 2);
-        
+
         compressed2_flip = ((best_pixel_indices1_MSB & 0xffff) << 16) | (best_pixel_indices1_LSB & 0xffff);
     }
 
-    // Now lets see which is the best table to use. Only 8 tables are possible. 
+    // Now lets see which is the best table to use. Only 8 tables are possible.
     if(norm_err <= flip_err)
     {
         compressed1 = compressed1_norm | 0;
@@ -7711,7 +7713,7 @@ void compressBlockDiffFlipFastPerceptual(uint8 *img, uint8 *imgdec,int width,int
     decompressBlockDiffFlip(average_block1, average_block2, imgdec, width, height, startx, starty);
     error_average = calcBlockPerceptualErrorRGB(img, imgdec, width, height, startx, starty);
 
-    // Then quantize the average color taking into consideration that intensity can change 
+    // Then quantize the average color taking into consideration that intensity can change
     compressBlockDiffFlipCombinedPerceptual(img, width, height, startx, starty, combined_block1, combined_block2);
     decompressBlockDiffFlip(combined_block1, combined_block2, imgdec, width, height, startx, starty);
     error_combined = calcBlockPerceptualErrorRGB(img, imgdec, width, height, startx, starty);
@@ -7730,7 +7732,7 @@ void compressBlockDiffFlipFastPerceptual(uint8 *img, uint8 *imgdec,int width,int
 
 // Compresses the differential mode of an ETC2 block with punchthrough alpha
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-int compressBlockDifferentialWithAlpha(bool isTransparent, uint8* img, uint8* alphaimg, uint8* imgdec, int width, int height, int startx, int starty, unsigned int &etc1_word1, unsigned int &etc1_word2) 
+int compressBlockDifferentialWithAlpha(bool isTransparent, uint8* img, uint8* alphaimg, uint8* imgdec, int width, int height, int startx, int starty, unsigned int &etc1_word1, unsigned int &etc1_word2)
 {
     UNREFERENCED_PARAMETER(imgdec);
     UNREFERENCED_PARAMETER(height);
@@ -7743,22 +7745,22 @@ int compressBlockDifferentialWithAlpha(bool isTransparent, uint8* img, uint8* al
     float avg_color_float1[3],avg_color_float2[3];
     int enc_color1[3], enc_color2[3], diff[3];
     //int min_error=255*255*8*3;
-    
+
     int norm_err=0;
     int flip_err=0;
     int temp_err=0;
-    for(int flipbit=0; flipbit<2; flipbit++) 
+    for(int flipbit=0; flipbit<2; flipbit++)
     {
         //compute average color for each half.
-        for(int c=0; c<3; c++) 
+        for(int c=0; c<3; c++)
         {
             avg_color_float1[c]=0;
             avg_color_float2[c]=0;
             float sum1=0;
             float sum2=0;
-            for(int x=0; x<4; x++) 
+            for(int x=0; x<4; x++)
             {
-                for(int y=0; y<4; y++) 
+                for(int y=0; y<4; y++)
                 {
                     float fac=1;
                     int index = x+startx+(y+starty)*width;
@@ -7767,12 +7769,12 @@ int compressBlockDifferentialWithAlpha(bool isTransparent, uint8* img, uint8* al
                     if(alphaimg[index]<128)
                         fac=0.0001f;
                     float col = fac*img[index*3+c];
-                    if( (flipbit==0&&x<2) || (flipbit==1&&y<2) ) 
+                    if( (flipbit==0&&x<2) || (flipbit==1&&y<2) )
                     {
                         sum1+=fac;
                         avg_color_float1[c]+=col;
                     }
-                    else 
+                    else
                     {
                         sum2+=fac;
                         avg_color_float2[c]+=col;
@@ -7786,12 +7788,12 @@ int compressBlockDifferentialWithAlpha(bool isTransparent, uint8* img, uint8* al
         quantize555ColorCombined(avg_color_float1, enc_color1, dummy);
         quantize555ColorCombined(avg_color_float2, enc_color2, dummy);
 
-        diff[0] = enc_color2[0]-enc_color1[0];    
-        diff[1] = enc_color2[1]-enc_color1[1];    
+        diff[0] = enc_color2[0]-enc_color1[0];
+        diff[1] = enc_color2[1]-enc_color1[1];
         diff[2] = enc_color2[2]-enc_color1[2];
 
         //make sure diff is small enough for diff-coding
-        for(int c=0; c<3; c++) 
+        for(int c=0; c<3; c++)
         {
                 if(diff[c]<-4)
                     diff[c]=-4;
@@ -7807,7 +7809,7 @@ int compressBlockDifferentialWithAlpha(bool isTransparent, uint8* img, uint8* al
         avg_color_quant2[1] = enc_color2[1] << 3 | (enc_color2[1] >> 2);
         avg_color_quant2[2] = enc_color2[2] << 3 | (enc_color2[2] >> 2);
 
-        // Pack bits into the first word. 
+        // Pack bits into the first word.
         // see regular compressblockdiffflipfast for details
 
         compressed1_temp = 0;
@@ -7820,7 +7822,7 @@ int compressBlockDifferentialWithAlpha(bool isTransparent, uint8* img, uint8* al
         PUTBITSHIGH( compressed1_temp, diff[2],       3, 42);
 
         temp_err = 0;
-        
+
         int besterror[2];
         besterror[0]=255*255*3*16;
         besterror[1]=255*255*3*16;
@@ -7829,32 +7831,32 @@ int compressBlockDifferentialWithAlpha(bool isTransparent, uint8* img, uint8* al
         int    best_indices_MSB[16];
         //for each table, we're going to compute the indices required to get minimum error in each half.
         //then we'll check if this was the best table for either half, and set besterror/besttable accordingly.
-        for(int table=0; table<8; table++) 
+        for(int table=0; table<8; table++)
         {
             int taberror[2];//count will be sort of an index of each pixel within a half, determining where the index will be placed in the bitstream.
-            
+
             int pixel_indices_LSB[16],pixel_indices_MSB[16];
-            
-            for(int i=0; i<2; i++) 
+
+            for(int i=0; i<2; i++)
             {
                 taberror[i]=0;
             }
-            for(int x=0; x<4; x++) 
+            for(int x=0; x<4; x++)
             {
-                for(int y=0; y<4; y++) 
+                for(int y=0; y<4; y++)
                 {
                     int index = x+startx+(y+starty)*width;
                     uint8 basecol[3];
                     bool transparentPixel=alphaimg[index]<128;
                     //determine which half of the block this pixel is in, based on the flipbit.
                     int half=0;
-                    if( (flipbit==0&&x<2) || (flipbit&&y<2) ) 
+                    if( (flipbit==0&&x<2) || (flipbit&&y<2) )
                     {
                         basecol[0]=avg_color_quant1[0];
                         basecol[1]=avg_color_quant1[1];
                         basecol[2]=avg_color_quant1[2];
                     }
-                    else 
+                    else
                     {
                         half=1;
                         basecol[0]=avg_color_quant2[0];
@@ -7864,28 +7866,28 @@ int compressBlockDifferentialWithAlpha(bool isTransparent, uint8* img, uint8* al
                     int besterri=255*255*3*2;
                     int besti=0;
                     int erri;
-                    for(int i=0; i<4; i++) 
+                    for(int i=0; i<4; i++)
                     {
                         if(i==1&&isTransparent)
                             continue;
                         erri=0;
-                        for(int c=0; c<3; c++) 
+                        for(int c=0; c<3; c++)
                         {
                             int col=CLAMP(0,((int)basecol[c])+compressParams[table*2][i],255);
-                            if(i==2&&isTransparent) 
+                            if(i==2&&isTransparent)
                             {
                                  col=(int)basecol[c];
                             }
                             int errcol=col-((int)(img[index*3+c]));
                             erri=erri+(errcol*errcol);
                         }
-                        if(erri<besterri) 
+                        if(erri<besterri)
                         {
                             besterri=erri;
                             besti=i;
                         }
                     }
-                    if(transparentPixel) 
+                    if(transparentPixel)
                     {
                         besterri=0;
                         besti=1;
@@ -7901,13 +7903,13 @@ int compressBlockDifferentialWithAlpha(bool isTransparent, uint8* img, uint8* al
                     pixel_indices_LSB[x*4+y]=(pixel_index & 1);
                 }
             }
-            for(int half=0; half<2; half++) 
+            for(int half=0; half<2; half++)
             {
-                if(taberror[half]<besterror[half]) 
+                if(taberror[half]<besterror[half])
                 {
                     besterror[half]=taberror[half];
                     besttable[half]=table;
-                    for(int i=0; i<16; i++) 
+                    for(int i=0; i<16; i++)
                     {
                         int thishalf=0;
                         int y=i%4;
@@ -7927,19 +7929,19 @@ int compressBlockDifferentialWithAlpha(bool isTransparent, uint8* img, uint8* al
         PUTBITSHIGH( compressed1_temp,      0,   1, 32);
 
         compressed2_temp = 0;
-        for(int i=0; i<16; i++) 
+        for(int i=0; i<16; i++)
         {
             PUTBITS( compressed2_temp, (best_indices_MSB[i]  ), 1, 16+i);
             PUTBITS( compressed2_temp, (best_indices_LSB[i]  ), 1, i);
         }
-        
-        if(flipbit) 
+
+        if(flipbit)
         {
             flip_err=besterror[0]+besterror[1];
             compressed1_flip=compressed1_temp;
             compressed2_flip=compressed2_temp;
         }
-        else 
+        else
         {
             norm_err=besterror[0]+besterror[1];
             compressed1_norm=compressed1_temp;
@@ -7980,7 +7982,7 @@ double calcBlockErrorRGBA(uint8 *img, uint8 *imgdec, uint8* alpha, int width, in
         for(yy = starty; yy<starty+4; yy++)
         {
             //only count non-transparent pixels.
-            if(alpha[yy*width+xx]>128)    
+            if(alpha[yy*width+xx]>128)
             {
                  err += SQUARE(1.0*RED(img,width,xx,yy)  - 1.0*RED(imgdec, width, xx,yy));
                  err += SQUARE(1.0*GREEN(img,width,xx,yy)- 1.0*GREEN(imgdec, width, xx,yy));
@@ -7993,12 +7995,12 @@ double calcBlockErrorRGBA(uint8 *img, uint8 *imgdec, uint8* alpha, int width, in
 
 //calculates the error for a block using the given colors, and the paremeters required to obtain the error. This version uses 1-bit punch-through alpha.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-double calculateError59TAlpha(uint8* srcimg, uint8* alpha,int width, int startx, int starty, uint8 (colorsRGB444)[2][3], uint8 &distance, unsigned int &pixel_indices) 
+double calculateError59TAlpha(uint8* srcimg, uint8* alpha,int width, int startx, int starty, uint8 (colorsRGB444)[2][3], uint8 &distance, unsigned int &pixel_indices)
 {
 
-    double block_error = 0, 
-           best_block_error = MAXIMUM_ERROR, 
-           pixel_error, 
+    double block_error = 0,
+           best_block_error = MAXIMUM_ERROR,
+           pixel_error,
            best_pixel_error;
     int diff[3];
     uint8 best_sw;
@@ -8007,43 +8009,43 @@ double calculateError59TAlpha(uint8* srcimg, uint8* alpha,int width, int startx,
     uint8 possible_colors[4][3];
 
     // First use the colors as they are, then swap them
-    for (uint8 sw = 0; sw <2; ++sw) 
-    { 
-        if (sw == 1) 
+    for (uint8 sw = 0; sw <2; ++sw)
+    {
+        if (sw == 1)
         {
             swapColors(colorsRGB444);
         }
         decompressColor(R_BITS59T, G_BITS59T, B_BITS59T, colorsRGB444, colors);
 
         // Test all distances
-        for (uint8 d = 0; d < BINPOW(TABLE_BITS_59T); ++d) 
+        for (uint8 d = 0; d < BINPOW(TABLE_BITS_59T); ++d)
         {
             calculatePaintColors59T(d,PATTERN_T, colors, possible_colors);
-            
-            block_error = 0;    
+
+            block_error = 0;
             pixel_colors = 0;
 
             // Loop block
-            for (size_t y = 0; y < BLOCKHEIGHT; ++y) 
+            for (size_t y = 0; y < BLOCKHEIGHT; ++y)
             {
-                for (size_t x = 0; x < BLOCKWIDTH; ++x) 
+                for (size_t x = 0; x < BLOCKWIDTH; ++x)
                 {
                     best_pixel_error = MAXIMUM_ERROR;
                     pixel_colors <<=2; // Make room for next value
 
                     // Loop possible block colors
-                    if(alpha[x+startx+(y+starty)*width]==0) 
+                    if(alpha[x+startx+(y+starty)*width]==0)
                     {
                         best_pixel_error=0;
                         pixel_colors ^= (pixel_colors & 3); // Reset the two first bits
                         pixel_colors |= 2; //insert the index for this pixel, two meaning transparent.
                     }
-                    else 
+                    else
                     {
-                        for (uint8 c = 0; c < 4; ++c) 
+                        for (uint8 c = 0; c < 4; ++c)
                         {
-                            
-                            if(c==2) 
+
+                            if(c==2)
                                 continue; //don't use this, because we don't have alpha here and index 2 means transparent.
                             diff[R] = srcimg[3*((starty+y)*width+startx+x)+R] - CLAMP(0,possible_colors[c][R],255);
                             diff[G] = srcimg[3*((starty+y)*width+startx+x)+G] - CLAMP(0,possible_colors[c][G],255);
@@ -8054,18 +8056,18 @@ double calculateError59TAlpha(uint8* srcimg, uint8* alpha,int width, int startx,
                                             weight[B]*SQUARE(diff[B]);
 
                             // Choose best error
-                            if (pixel_error < best_pixel_error) 
+                            if (pixel_error < best_pixel_error)
                             {
                                 best_pixel_error = pixel_error;
                                 pixel_colors ^= (pixel_colors & 3); // Reset the two first bits
                                 pixel_colors |= c; //insert the index for this pixel
-                            } 
+                            }
                         }
                     }
                     block_error += best_pixel_error;
                 }
             }
-            if (block_error < best_block_error) 
+            if (block_error < best_block_error)
             {
                 best_block_error = block_error;
                 distance = d;
@@ -8073,8 +8075,8 @@ double calculateError59TAlpha(uint8* srcimg, uint8* alpha,int width, int startx,
                 best_sw = sw;
             }
         }
-        
-        if (sw == 1 && best_sw == 0) 
+
+        if (sw == 1 && best_sw == 0)
         {
             swapColors(colorsRGB444);
         }
@@ -8086,7 +8088,7 @@ double calculateError59TAlpha(uint8* srcimg, uint8* alpha,int width, int startx,
 // same as fastest t-mode compressor above, but here one of the colors (the central one in the T) is used to also signal that the pixel is transparent.
 // the only difference is that calculateError has been swapped out to one that considers alpha.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-double compressBlockTHUMB59TAlpha(uint8 *img, uint8* alpha, int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2) 
+double compressBlockTHUMB59TAlpha(uint8 *img, uint8* alpha, int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2)
 {
 
     UNREFERENCED_PARAMETER(height);
@@ -8108,14 +8110,14 @@ double compressBlockTHUMB59TAlpha(uint8 *img, uint8* alpha, int width,int height
     compressColor(R_BITS59T, G_BITS59T, B_BITS59T, colors, colorsRGB444_no_i);
 
     // Determine the parameters for the lowest error
-    error_no_i = calculateError59TAlpha(img, alpha, width, startx, starty, colorsRGB444_no_i, distance_no_i, pixel_indices_no_i);            
+    error_no_i = calculateError59TAlpha(img, alpha, width, startx, starty, colorsRGB444_no_i, distance_no_i, pixel_indices_no_i);
 
     best_error = error_no_i;
     best_distance = distance_no_i;
     best_pixel_indices = pixel_indices_no_i;
     copyColors(colorsRGB444_no_i, best_colorsRGB444);
 
-    // Put the compress params into the compression block 
+    // Put the compress params into the compression block
     packBlock59T(best_colorsRGB444, best_distance, best_pixel_indices, compressed1, compressed2);
 
     return best_error;
@@ -8126,7 +8128,7 @@ double compressBlockTHUMB59TAlpha(uint8 *img, uint8* alpha, int width,int height
 void stuff59bitsDiffFalse(unsigned int thumbT59_word1, unsigned int thumbT59_word2, unsigned int &thumbT_word1, unsigned int &thumbT_word2)
 {
     // Put bits in twotimer configuration for 59 (red overflows)
-    // 
+    //
     // Go from this bit layout:
     //
     //     |63 62 61 60 59|58 57 56 55|54 53 52 51|50 49 48 47|46 45 44 43|42 41 40 39|38 37 36 35|34 33 32|
@@ -8137,8 +8139,8 @@ void stuff59bitsDiffFalse(unsigned int thumbT59_word1, unsigned int thumbT59_wor
     //
     //
     //  To this:
-    // 
-    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33 32 
+    //
+    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33 32
     //      -----------------------------------------------------------------------------------------------
     //     |// // //|R0a  |//|R0b  |G0         |B0         |R1         |G1         |B1          |da  |df|db|
     //      -----------------------------------------------------------------------------------------------
@@ -8146,7 +8148,7 @@ void stuff59bitsDiffFalse(unsigned int thumbT59_word1, unsigned int thumbT59_wor
     //     |31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10 09 08 07 06 05 04 03 02 01 00|
     //     |----------------------------------------index bits---------------------------------------------|
     //
-    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33 32 
+    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33 32
     //      -----------------------------------------------------------------------------------------------
     //     | base col1    | dcol 2 | base col1    | dcol 2 | base col 1   | dcol 2 | table  | table  |df|fp|
     //     | R1' (5 bits) | dR2    | G1' (5 bits) | dG2    | B1' (5 bits) | dB2    | cw 1   | cw 2   |bt|bt|
@@ -8163,7 +8165,7 @@ void stuff59bitsDiffFalse(unsigned int thumbT59_word1, unsigned int thumbT59_wor
     PUTBITSHIGH( thumbT_word1, R0a,  2, 60);
     // Fix db (lowest bit of d)
     PUTBITSHIGH( thumbT_word1, thumbT59_word1,  1, 32);
-    // 
+    //
     // Make sure that red overflows:
     a = GETBITSHIGH( thumbT_word1, 1, 60);
     b = GETBITSHIGH( thumbT_word1, 1, 59);
@@ -8183,14 +8185,14 @@ void stuff59bitsDiffFalse(unsigned int thumbT59_word1, unsigned int thumbT59_wor
 
 // Tests if there is at least one pixel in the image which would get alpha = 0 in punchtrough mode.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-bool hasAlpha(uint8* alphaimg, int ix, int iy, int width) 
+bool hasAlpha(uint8* alphaimg, int ix, int iy, int width)
 {
-    for(int x=ix; x<ix+4; x++) 
+    for(int x=ix; x<ix+4; x++)
     {
-        for(int y=iy; y<iy+4; y++) 
+        for(int y=iy; y<iy+4; y++)
         {
             int index = x+y*width;
-            if(alphaimg[index]<128) 
+            if(alphaimg[index]<128)
             {
                 return true;
             }
@@ -8218,7 +8220,7 @@ void compressBlockETC2Fast(uint8 *img, uint8* alphaimg, uint8 *imgdec,int width,
     unsigned int thumbT_word1;
     unsigned int thumbT_word2;
     double error_thumbT;
-    
+
     unsigned int thumbH58_word1;
     unsigned int thumbH58_word2;
     unsigned int thumbH_word1;
@@ -8228,7 +8230,7 @@ void compressBlockETC2Fast(uint8 *img, uint8* alphaimg, uint8 *imgdec,int width,
     double error_best;
     signed char best_char;
     int best_mode;
-    
+
     if(format==ETC2PACKAGE_RGBA1_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA1_NO_MIPMAPS)
     {
         /*                if we have one-bit alpha, we never use the individual mode,
@@ -8254,7 +8256,7 @@ void compressBlockETC2Fast(uint8 *img, uint8* alphaimg, uint8 *imgdec,int width,
         uint8* alphadec = new uint8[width*height];
         decompressBlockDifferentialWithAlpha(etc1_word1, etc1_word2, imgdec, alphadec,width, height, startx, starty);
         error_etc1 = calcBlockErrorRGBA(img, imgdec, alphaimg,width, height, startx, starty);
-        if(error_etc1!=testerr) 
+        if(error_etc1!=testerr)
         {
             printf("testerr: %d, etcerr: %lf\n",testerr,error_etc1);
         }
@@ -8263,7 +8265,7 @@ void compressBlockETC2Fast(uint8 *img, uint8* alphaimg, uint8 *imgdec,int width,
         compressBlockTHUMB59TAlpha(img,alphaimg,width,height,startx,starty,tempword1,tempword2);
         decompressBlockTHUMB59TAlpha(tempword1,tempword2,imgdec, alphadec, width,height,startx,starty);
         temperror=calcBlockErrorRGBA(img, imgdec, alphaimg, width, height, startx, starty);
-        if(temperror<error_etc1) 
+        if(temperror<error_etc1)
         {
             error_etc1=temperror;
             stuff59bitsDiffFalse(tempword1,tempword2,etc1_word1,etc1_word2);
@@ -8271,13 +8273,13 @@ void compressBlockETC2Fast(uint8 *img, uint8* alphaimg, uint8 *imgdec,int width,
         compressBlockTHUMB58HAlpha(img,alphaimg,width,height,startx,starty,tempword1,tempword2);
         decompressBlockTHUMB58HAlpha(tempword1,tempword2,imgdec, alphadec, width,height,startx,starty);
         temperror=calcBlockErrorRGBA(img, imgdec, alphaimg, width, height, startx, starty);
-        if(temperror<error_etc1) 
+        if(temperror<error_etc1)
         {
             error_etc1=temperror;
             stuff58bitsDiffFalse(tempword1,tempword2,etc1_word1,etc1_word2);
         }
         //if we have transparency in this pixel, we know that one of these two modes was best..
-        if(hasAlpha(alphaimg,startx,starty,width)) 
+        if(hasAlpha(alphaimg,startx,starty,width))
         {
             compressed1=etc1_word1;
             compressed2=etc1_word2;
@@ -8286,12 +8288,12 @@ void compressBlockETC2Fast(uint8 *img, uint8* alphaimg, uint8 *imgdec,int width,
         }
         //error_etc1=255*255*1000;
         //otherwise, they MIGHT have been the best, although that's unlikely.. anyway, try old differential mode now
-        
+
         compressBlockDifferentialWithAlpha(false,img,alphaimg,imgdec,width,height,startx,starty,tempword1,tempword2);
         decompressBlockDiffFlip(tempword1, tempword2, imgdec, width, height, startx, starty);
         temperror = calcBlockErrorRGB(img, imgdec, width, height, startx, starty);
         decompressBlockDifferentialWithAlpha(tempword1,tempword2,imgdec,alphadec,width,height,startx,starty);
-        if(temperror<error_etc1) 
+        if(temperror<error_etc1)
         {
             error_etc1=temperror;
             etc1_word1=tempword1;
@@ -8300,7 +8302,7 @@ void compressBlockETC2Fast(uint8 *img, uint8* alphaimg, uint8 *imgdec,int width,
         delete alphadec;
         //drop out of this if, and test old T, H and planar modes (we have already returned if there are transparent pixels in this block)
     }
-    else 
+    else
     {
         //this includes individual mode, and therefore doesn't apply in case of punch-through alpha.
         compressBlockDiffFlipFast(img, imgdec, width, height, startx, starty, etc1_word1, etc1_word2);
@@ -8315,12 +8317,12 @@ void compressBlockETC2Fast(uint8 *img, uint8* alphaimg, uint8 *imgdec,int width,
     stuff57bits(planar57_word1, planar57_word2, planar_word1, planar_word2);
 
     compressBlockTHUMB59TFastest(img,width, height, startx, starty, thumbT59_word1, thumbT59_word2);
-    decompressBlockTHUMB59T(thumbT59_word1, thumbT59_word2, imgdec, width, height, startx, starty);            
+    decompressBlockTHUMB59T(thumbT59_word1, thumbT59_word2, imgdec, width, height, startx, starty);
     error_thumbT = calcBlockErrorRGB(img, imgdec, width, height, startx, starty);
     stuff59bits(thumbT59_word1, thumbT59_word2, thumbT_word1, thumbT_word2);
 
     compressBlockTHUMB58HFastest(img,width,height,startx, starty, thumbH58_word1, thumbH58_word2);
-    decompressBlockTHUMB58H(thumbH58_word1, thumbH58_word2, imgdec, width, height, startx, starty);            
+    decompressBlockTHUMB58H(thumbH58_word1, thumbH58_word2, imgdec, width, height, startx, starty);
     error_thumbH = calcBlockErrorRGB(img, imgdec, width, height, startx, starty);
     stuff58bits(thumbH58_word1, thumbH58_word2, thumbH_word1, thumbH_word2);
 
@@ -8335,7 +8337,7 @@ void compressBlockETC2Fast(uint8 *img, uint8* alphaimg, uint8 *imgdec,int width,
         compressed1 = planar_word1;
         compressed2 = planar_word2;
         best_char = 'p';
-        error_best = error_planar;    
+        error_best = error_planar;
         best_mode = MODE_PLANAR;
     }
     if(error_thumbT < error_best)
@@ -8354,13 +8356,13 @@ void compressBlockETC2Fast(uint8 *img, uint8* alphaimg, uint8 *imgdec,int width,
         error_best = error_thumbH;
         best_mode = MODE_THUMB_H;
     }
-    
+
     switch(best_mode)
     {
         // Now see which mode won and compress that a little bit harder
     case MODE_THUMB_T:
         compressBlockTHUMB59TFast(img,width, height, startx, starty, thumbT59_word1, thumbT59_word2);
-        decompressBlockTHUMB59T(thumbT59_word1, thumbT59_word2, imgdec, width, height, startx, starty);            
+        decompressBlockTHUMB59T(thumbT59_word1, thumbT59_word2, imgdec, width, height, startx, starty);
         error_thumbT = calcBlockErrorRGB(img, imgdec, width, height, startx, starty);
         stuff59bits(thumbT59_word1, thumbT59_word2, thumbT_word1, thumbT_word2);
         if(error_thumbT < error_best)
@@ -8371,7 +8373,7 @@ void compressBlockETC2Fast(uint8 *img, uint8* alphaimg, uint8 *imgdec,int width,
         break;
     case MODE_THUMB_H:
         compressBlockTHUMB58HFast(img,width,height,startx, starty, thumbH58_word1, thumbH58_word2);
-        decompressBlockTHUMB58H(thumbH58_word1, thumbH58_word2, imgdec, width, height, startx, starty);            
+        decompressBlockTHUMB58H(thumbH58_word1, thumbH58_word2, imgdec, width, height, startx, starty);
         error_thumbH = calcBlockErrorRGB(img, imgdec, width, height, startx, starty);
         stuff58bits(thumbH58_word1, thumbH58_word2, thumbH_word1, thumbH_word2);
         if(error_thumbH < error_best)
@@ -8404,7 +8406,7 @@ void compressBlockETC2FastPerceptual(uint8 *img, uint8 *imgdec,int width,int hei
     unsigned int thumbT_word1;
     unsigned int thumbT_word2;
     double error_thumbT;
-    
+
     unsigned int thumbH58_word1;
     unsigned int thumbH58_word2;
     unsigned int thumbH_word1;
@@ -8425,12 +8427,12 @@ void compressBlockETC2FastPerceptual(uint8 *img, uint8 *imgdec,int width,int hei
     stuff57bits(planar57_word1, planar57_word2, planar_word1, planar_word2);
 
     compressBlockTHUMB59TFastestPerceptual1000(img,width, height, startx, starty, thumbT59_word1, thumbT59_word2);
-    decompressBlockTHUMB59T(thumbT59_word1, thumbT59_word2, imgdec, width, height, startx, starty);            
+    decompressBlockTHUMB59T(thumbT59_word1, thumbT59_word2, imgdec, width, height, startx, starty);
     error_thumbT = 1000*calcBlockPerceptualErrorRGB(img, imgdec, width, height, startx, starty);
     stuff59bits(thumbT59_word1, thumbT59_word2, thumbT_word1, thumbT_word2);
 
     compressBlockTHUMB58HFastestPerceptual1000(img,width,height,startx, starty, thumbH58_word1, thumbH58_word2);
-    decompressBlockTHUMB58H(thumbH58_word1, thumbH58_word2, imgdec, width, height, startx, starty);            
+    decompressBlockTHUMB58H(thumbH58_word1, thumbH58_word2, imgdec, width, height, startx, starty);
     error_thumbH = 1000*calcBlockPerceptualErrorRGB(img, imgdec, width, height, startx, starty);
     stuff58bits(thumbH58_word1, thumbH58_word2, thumbH_word1, thumbH_word2);
 
@@ -8445,7 +8447,7 @@ void compressBlockETC2FastPerceptual(uint8 *img, uint8 *imgdec,int width,int hei
         compressed1 = planar_word1;
         compressed2 = planar_word2;
         best_char = 'p';
-        error_best = error_planar;    
+        error_best = error_planar;
         best_mode = MODE_PLANAR;
     }
     if(error_thumbT < error_best)
@@ -8464,13 +8466,13 @@ void compressBlockETC2FastPerceptual(uint8 *img, uint8 *imgdec,int width,int hei
         error_best = error_thumbH;
         best_mode = MODE_THUMB_H;
     }
-    
+
     switch(best_mode)
     {
         // Now see which mode won and compress that a little bit harder
     case MODE_THUMB_T:
         compressBlockTHUMB59TFast(img,width, height, startx, starty, thumbT59_word1, thumbT59_word2);
-        decompressBlockTHUMB59T(thumbT59_word1, thumbT59_word2, imgdec, width, height, startx, starty);            
+        decompressBlockTHUMB59T(thumbT59_word1, thumbT59_word2, imgdec, width, height, startx, starty);
         error_thumbT = calcBlockErrorRGB(img, imgdec, width, height, startx, starty);
         stuff59bits(thumbT59_word1, thumbT59_word2, thumbT_word1, thumbT_word2);
         if(error_thumbT < error_best)
@@ -8481,7 +8483,7 @@ void compressBlockETC2FastPerceptual(uint8 *img, uint8 *imgdec,int width,int hei
         break;
     case MODE_THUMB_H:
         compressBlockTHUMB58HFast(img,width,height,startx, starty, thumbH58_word1, thumbH58_word2);
-        decompressBlockTHUMB58H(thumbH58_word1, thumbH58_word2, imgdec, width, height, startx, starty);            
+        decompressBlockTHUMB58H(thumbH58_word1, thumbH58_word2, imgdec, width, height, startx, starty);
         error_thumbH = calcBlockErrorRGB(img, imgdec, width, height, startx, starty);
         stuff58bits(thumbH58_word1, thumbH58_word2, thumbH_word1, thumbH_word2);
         if(error_thumbH < error_best)
@@ -8549,13 +8551,13 @@ void setupAlphaTableAndValtab()
     valtab = new int[1024*512];
     int16 val16;
     int count=0;
-    for(int base=0; base<256; base++) 
+    for(int base=0; base<256; base++)
     {
-        for(int tab=0; tab<16; tab++) 
+        for(int tab=0; tab<16; tab++)
         {
-            for(int mul=0; mul<16; mul++) 
+            for(int mul=0; mul<16; mul++)
             {
-                for(int index=0; index<8; index++) 
+                for(int index=0; index<8; index++)
                 {
                     if(formatSigned)
                     {
@@ -8573,20 +8575,20 @@ void setupAlphaTableAndValtab()
 
 // Reads alpha data
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-void readAlpha(uint8* &data, int &width, int &height, int &extendedwidth, int &extendedheight) 
+void readAlpha(uint8* &data, int &width, int &height, int &extendedwidth, int &extendedheight)
 {
     //width and height are already known..?
     uint8* tempdata;
     int wantedBitDepth;
-    if(format==ETC2PACKAGE_RGBA_NO_MIPMAPS||format==ETC2PACKAGE_RGBA1_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA1_NO_MIPMAPS) 
+    if(format==ETC2PACKAGE_RGBA_NO_MIPMAPS||format==ETC2PACKAGE_RGBA1_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA1_NO_MIPMAPS)
     {
         wantedBitDepth=8;
     }
-    else if(format==ETC2PACKAGE_R_NO_MIPMAPS) 
+    else if(format==ETC2PACKAGE_R_NO_MIPMAPS)
     {
         wantedBitDepth=16;
     }
-    else 
+    else
     {
         printf("invalid format for alpha reading!\n");
         exit(1);
@@ -8595,33 +8597,33 @@ void readAlpha(uint8* &data, int &width, int &height, int &extendedwidth, int &e
     extendedwidth=4*((width+3)/4);
     extendedheight=4*((height+3)/4);
 
-    if(width==extendedwidth&&height==extendedheight) 
+    if(width==extendedwidth&&height==extendedheight)
     {
         data=tempdata;
     }
-    else 
+    else
     {
         data = (uint8*)malloc(extendedwidth*extendedheight*wantedBitDepth/8);
         uint8 last=0;
         uint8 lastlast=0;
-        for(int x=0; x<extendedwidth; x++) 
+        for(int x=0; x<extendedwidth; x++)
         {
-            for(int y=0; y<extendedheight; y++) 
+            for(int y=0; y<extendedheight; y++)
             {
-                if(wantedBitDepth==8) 
+                if(wantedBitDepth==8)
                 {
-                    if(x<width&&y<height) 
+                    if(x<width&&y<height)
                     {
                         last = tempdata[x+y*width];
                     }
                     data[x+y*extendedwidth]=last;
                 }
-                else 
+                else
                 {
-                    if(x<width&&y<height) 
+                    if(x<width&&y<height)
                     {
                         last = tempdata[(x+y*width)*2];
-                        lastlast = tempdata[(x+y*width)*2+1];                        
+                        lastlast = tempdata[(x+y*width)*2+1];
                     }
                     data[(x+y*extendedwidth)*2]=last;
                     data[(x+y*extendedwidth)*2+1]=lastlast;
@@ -8629,11 +8631,11 @@ void readAlpha(uint8* &data, int &width, int &height, int &extendedwidth, int &e
             }
         }
     }
-    if(format==ETC2PACKAGE_RGBA1_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA1_NO_MIPMAPS) 
+    if(format==ETC2PACKAGE_RGBA1_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA1_NO_MIPMAPS)
     {
-        for(int x=0; x<extendedwidth; x++) 
+        for(int x=0; x<extendedwidth; x++)
         {
-            for(int y=0; y<extendedheight; y++) 
+            for(int y=0; y<extendedheight; y++)
             {
                 if(data[x+y*extendedwidth]<128)
                     data[x+y*extendedwidth]=0;
@@ -8647,24 +8649,24 @@ void readAlpha(uint8* &data, int &width, int &height, int &extendedwidth, int &e
 
 // Compresses the alpha part of a GL_COMPRESSED_RGBA8_ETC2_EAC block.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-void compressBlockAlphaFast(uint8 * data, int ix, int iy, int width, int height, uint8* returnData) 
+void compressBlockAlphaFast(uint8 * data, int ix, int iy, int width, int height, uint8* returnData)
 {
 
     UNREFERENCED_PARAMETER(height);
 
     int alphasum=0;
     int maxdist=-2;
-    for(int x=0; x<4; x++) 
+    for(int x=0; x<4; x++)
     {
-        for(int y=0; y<4; y++) 
+        for(int y=0; y<4; y++)
         {
             alphasum+=data[ix+x+(iy+y)*width];
         }
     }
     int alpha = (int)( ((float)alphasum)/16.0f+0.5f); //average pixel value, used as guess for base value.
-    for(int x=0; x<4; x++) 
+    for(int x=0; x<4; x++)
     {
-        for(int y=0; y<4; y++) 
+        for(int y=0; y<4; y++)
         {
             if(abs(alpha-data[ix+x+(iy+y)*width])>maxdist)
                 maxdist=abs(alpha-data[ix+x+(iy+y)*width]); //maximum distance from average
@@ -8679,7 +8681,7 @@ void compressBlockAlphaFast(uint8 * data, int ix, int iy, int width, int height,
     int endTable=clamp(approxPos+15);  //last table to be tested
 
     int bestsum=1000000000;
-    int besttable=-3; 
+    int besttable=-3;
     int bestalpha=128;
     int prevalpha=alpha;
 
@@ -8689,41 +8691,41 @@ void compressBlockAlphaFast(uint8 * data, int ix, int iy, int width, int height,
     {
         int tablealpha=prevalpha;
         int tablebestsum=1000000000;
-        //test some different alpha values, trying to find the best one for the given table.    
-        for(int alphascale=16; alphascale>0; alphascale/=4) 
+        //test some different alpha values, trying to find the best one for the given table.
+        for(int alphascale=16; alphascale>0; alphascale/=4)
         {
             int startalpha;
             int endalpha;
-            if(alphascale==16) 
+            if(alphascale==16)
             {
                 startalpha = clamp(tablealpha-alphascale*4);
                 endalpha = clamp(tablealpha+alphascale*4);
             }
-            else 
+            else
             {
                 startalpha = clamp(tablealpha-alphascale*2);
                 endalpha = clamp(tablealpha+alphascale*2);
             }
-            for(alpha=startalpha; alpha<=endalpha; alpha+=alphascale) 
+            for(alpha=startalpha; alpha<=endalpha; alpha+=alphascale)
             {
                 int sum=0;
                 int val,diff,bestdiff=10000000,index;
-                for(int x=0; x<4; x++) 
+                for(int x=0; x<4; x++)
                 {
-                    for(int y=0; y<4; y++) 
+                    for(int y=0; y<4; y++)
                     {
                         //compute best offset here, add square difference to sum..
                         val=data[ix+x+(iy+y)*width];
                         bestdiff=1000000000;
                         //the values are always ordered from small to large, with the first 4 being negative and the last 4 positive
                         //search is therefore made in the order 0-1-2-3 or 7-6-5-4, stopping when error increases compared to the previous entry tested.
-                        if(val>alpha) 
-                        { 
-                            for(index=7; index>3; index--) 
+                        if(val>alpha)
+                        {
+                            for(index=7; index>3; index--)
                             {
                                 diff=clamp_table[alpha+(int)(alphaTable[table][index])+255]-val;
                                 diff*=diff;
-                                if(diff<=bestdiff) 
+                                if(diff<=bestdiff)
                                 {
                                     bestdiff=diff;
                                 }
@@ -8731,13 +8733,13 @@ void compressBlockAlphaFast(uint8 * data, int ix, int iy, int width, int height,
                                     break;
                             }
                         }
-                        else 
+                        else
                         {
-                            for(index=0; index<4; index++) 
+                            for(index=0; index<4; index++)
                             {
                                 diff=clamp_table[alpha+(int)(alphaTable[table][index])+255]-val;
                                 diff*=diff;
-                                if(diff<bestdiff) 
+                                if(diff<bestdiff)
                                 {
                                     bestdiff=diff;
                                 }
@@ -8750,19 +8752,19 @@ void compressBlockAlphaFast(uint8 * data, int ix, int iy, int width, int height,
                         sum+=bestdiff;
                         //if the sum here is worse than previously best already, there's no use in continuing the count..
                         //note that tablebestsum could be used for more precise estimation, but the speedup gained here is deemed more important.
-                        if(sum>bestsum) 
-                        { 
+                        if(sum>bestsum)
+                        {
                             x=9999; //just to make it large and get out of the x<4 loop
                             break;
                         }
                     }
                 }
-                if(sum<tablebestsum) 
+                if(sum<tablebestsum)
                 {
                     tablebestsum=sum;
                     tablealpha=alpha;
                 }
-                if(sum<bestsum) 
+                if(sum<bestsum)
                 {
                     bestsum=sum;
                     besttable=table;
@@ -8774,30 +8776,30 @@ void compressBlockAlphaFast(uint8 * data, int ix, int iy, int width, int height,
         }
     }
 
-    alpha=bestalpha;    
+    alpha=bestalpha;
 
     //"good" alpha value and table are known!
     //store them, then loop through the pixels again and print indices.
 
     returnData[0]=alpha;
     returnData[1]=besttable;
-    for(int pos=2; pos<8; pos++) 
+    for(int pos=2; pos<8; pos++)
     {
         returnData[pos]=0;
     }
     int byte=2;
     int bit=0;
-    for(int x=0; x<4; x++) 
+    for(int x=0; x<4; x++)
     {
-        for(int y=0; y<4; y++) 
+        for(int y=0; y<4; y++)
         {
             //find correct index
             int besterror=1000000;
             int bestindex=99;
             for(int index=0; index<8; index++) //no clever ordering this time, as this loop is only run once per block anyway
-            { 
+            {
                 int error= (clamp(alpha +(int)(alphaTable[besttable][index]))-data[ix+x+(iy+y)*width])*(clamp(alpha +(int)(alphaTable[besttable][index]))-data[ix+x+(iy+y)*width]);
-                if(error<besterror) 
+                if(error<besterror)
                 {
                     besterror=error;
                     bestindex=index;
@@ -8805,12 +8807,12 @@ void compressBlockAlphaFast(uint8 * data, int ix, int iy, int width, int height,
             }
             //best table index has been determined.
             //pack 3-bit index into compressed data, one bit at a time
-            for(int numbit=0; numbit<3; numbit++) 
+            for(int numbit=0; numbit<3; numbit++)
             {
                 returnData[byte]|=getbit(bestindex,2-numbit,7-bit);
 
                 bit++;
-                if(bit>7) 
+                if(bit>7)
                 {
                     bit=0;
                     byte++;
@@ -8822,30 +8824,30 @@ void compressBlockAlphaFast(uint8 * data, int ix, int iy, int width, int height,
 
 // Helper function for the below function
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-int getPremulIndex(int base, int tab, int mul, int index) 
+int getPremulIndex(int base, int tab, int mul, int index)
 {
     return (base<<11)+(tab<<7)+(mul<<3)+index;
 }
 
 // Calculates the error used in compressBlockAlpha16()
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-double calcError(uint8* data, int ix, int iy, int width, int height, int base, int tab, int mul, double prevbest) 
+double calcError(uint8* data, int ix, int iy, int width, int height, int base, int tab, int mul, double prevbest)
 {
 
     UNREFERENCED_PARAMETER(height);
 
     int offset = getPremulIndex(base,tab,mul,0);
     double error=0;
-    for (int y=0; y<4; y++) 
+    for (int y=0; y<4; y++)
     {
-        for(int x=0; x<4; x++) 
+        for(int x=0; x<4; x++)
         {
             double besthere = (1<<20);
             besthere*=besthere;
             uint8 byte1 = data[2*(x+ix+(y+iy)*width)];
             uint8 byte2 = data[2*(x+ix+(y+iy)*width)+1];
             int alpha = (byte1<<8)+byte2;
-            for(int index=0; index<8; index++) 
+            for(int index=0; index<8; index++)
             {
                 double indexError;
                 indexError = alpha-valtab[offset+index];
@@ -8862,41 +8864,41 @@ double calcError(uint8* data, int ix, int iy, int width, int height, int base, i
 }
 
 // compressBlockAlpha16
-// 
+//
 // Compresses a block using the 11-bit EAC formats.
 // Depends on the global variable formatSigned.
-// 
+//
 // COMPRESSED_R11_EAC (if formatSigned = 0)
 // This is an 11-bit unsigned format. Since we do not have a good 11-bit file format, we use 16-bit pgm instead.
-// Here we assume that, in the input 16-bit pgm file, 0 represents 0.0 and 65535 represents 1.0. The function compressBlockAlpha16 
-// will find the compressed block which best matches the data. In detail, it will find the compressed block, which 
-// if decompressed, will generate an 11-bit block that after bit replication to 16-bits will generate the closest 
+// Here we assume that, in the input 16-bit pgm file, 0 represents 0.0 and 65535 represents 1.0. The function compressBlockAlpha16
+// will find the compressed block which best matches the data. In detail, it will find the compressed block, which
+// if decompressed, will generate an 11-bit block that after bit replication to 16-bits will generate the closest
 // block to the original 16-bit pgm block.
-// 
+//
 // COMPRESSED_SIGNED_R11_EAC (if formatSigned = 1)
 // This is an 11-bit signed format. Since we do not have any signed file formats, we use unsigned 16-bit pgm instead.
-// Hence we assume that, in the input 16-bit pgm file, 1 represents -1.0, 32768 represents 0.0 and 65535 represents 1.0. 
+// Hence we assume that, in the input 16-bit pgm file, 1 represents -1.0, 32768 represents 0.0 and 65535 represents 1.0.
 // The function compresseBlockAlpha16 will find the compressed block, which if decompressed, will generate a signed
-// 11-bit block that after bit replication to 16-bits and conversion to unsigned (1 equals -1.0, 32768 equals 0.0 and 
-// 65535 equals 1.0) will generate the closest block to the original 16-bit pgm block. 
+// 11-bit block that after bit replication to 16-bits and conversion to unsigned (1 equals -1.0, 32768 equals 0.0 and
+// 65535 equals 1.0) will generate the closest block to the original 16-bit pgm block.
 //
 // COMPRESSED_RG11_EAC is compressed by calling the function twice, dito for COMPRESSED_SIGNED_RG11_EAC.
-// 
+//
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-void compressBlockAlpha16(uint8* data, int ix, int iy, int width, int height, uint8* returnData) 
+void compressBlockAlpha16(uint8* data, int ix, int iy, int width, int height, uint8* returnData)
 {
     unsigned int bestbase = 0, besttable = 0, bestmul = 0;
     double besterror;
     besterror=1<<20;
     besterror*=besterror;
-    for(int base=0; base<256; base++) 
+    for(int base=0; base<256; base++)
     {
-        for(int table=0; table<16; table++) 
+        for(int table=0; table<16; table++)
         {
-            for(int mul=0; mul<16; mul++) 
+            for(int mul=0; mul<16; mul++)
             {
                 double e = calcError(data, ix, iy, width, height,base,table,mul,besterror);
-                if(e<besterror) 
+                if(e<besterror)
                 {
                     bestbase=base;
                     besttable=table;
@@ -8908,23 +8910,23 @@ void compressBlockAlpha16(uint8* data, int ix, int iy, int width, int height, ui
     }
     returnData[0]=bestbase;
     returnData[1]=(bestmul<<4)+besttable;
-    if(formatSigned) 
+    if(formatSigned)
     {
-        //if we have a signed format, the base value should be given as a signed byte. 
+        //if we have a signed format, the base value should be given as a signed byte.
         signed char signedbase = bestbase-128;
         returnData[0]=*((uint8*)(&signedbase));
     }
-    
-    for(int i=2; i<8; i++) 
+
+    for(int i=2; i<8; i++)
     {
         returnData[i]=0;
     }
 
     int byte=2;
     int bit=0;
-    for (int x=0; x<4; x++) 
+    for (int x=0; x<4; x++)
     {
-        for(int y=0; y<4; y++) 
+        for(int y=0; y<4; y++)
         {
             double besterror1=255*255;
             besterror1*=besterror1;
@@ -8932,7 +8934,7 @@ void compressBlockAlpha16(uint8* data, int ix, int iy, int width, int height, ui
             uint8 byte1 = data[2*(x+ix+(y+iy)*width)];
             uint8 byte2 = data[2*(x+ix+(y+iy)*width)+1];
             int alpha = (byte1<<8)+byte2;
-            for(unsigned int index=0; index<8; index++) 
+            for(unsigned int index=0; index<8; index++)
             {
                 double indexError;
                 if(formatSigned)
@@ -8947,18 +8949,18 @@ void compressBlockAlpha16(uint8* data, int ix, int iy, int width, int height, ui
                     indexError = alpha-get16bits11bits(bestbase,besttable,bestmul,index);
 
                 indexError*=indexError;
-                if(indexError<besterror1) 
+                if(indexError<besterror1)
                 {
                     besterror1=indexError;
                     bestindex=index;
                 }
             }
-            
-            for(int numbit=0; numbit<3; numbit++) 
+
+            for(int numbit=0; numbit<3; numbit++)
             {
                 returnData[byte]|=getbit(bestindex,2-numbit,7-bit);
                 bit++;
-                if(bit>7) 
+                if(bit>7)
                 {
                     bit=0;
                     byte++;
@@ -8970,7 +8972,7 @@ void compressBlockAlpha16(uint8* data, int ix, int iy, int width, int height, ui
 
 // Exhaustive compression of alpha compression in a GL_COMPRESSED_RGB8_ETC2 block
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-void compressBlockAlphaSlow(uint8* data, int ix, int iy, int width, int height, uint8* returnData) 
+void compressBlockAlphaSlow(uint8* data, int ix, int iy, int width, int height, uint8* returnData)
 {
 
     UNREFERENCED_PARAMETER(height);
@@ -8978,9 +8980,9 @@ void compressBlockAlphaSlow(uint8* data, int ix, int iy, int width, int height, 
     //determine the best table and base alpha value for this block using MSE
     int alphasum=0;
     //int maxdist=-2;
-    for(int x=0; x<4; x++) 
+    for(int x=0; x<4; x++)
     {
-        for(int y=0; y<4; y++) 
+        for(int y=0; y<4; y++)
         {
             alphasum+=data[ix+x+(iy+y)*width];
         }
@@ -8988,7 +8990,7 @@ void compressBlockAlphaSlow(uint8* data, int ix, int iy, int width, int height, 
     int alpha = (int)( ((float)alphasum)/16.0f+0.5f); //average pixel value, used as guess for base value.
 
     int bestsum=1000000000;
-    int besttable=-3; 
+    int besttable=-3;
     int bestalpha=128;
     int prevalpha=alpha;
 
@@ -8999,31 +9001,31 @@ void compressBlockAlphaSlow(uint8* data, int ix, int iy, int width, int height, 
         int tablealpha=prevalpha;
         int tablebestsum=1000000000;
         //test some different alpha values, trying to find the best one for the given table.
-        for(int alphascale=32; alphascale>0; alphascale/=8) 
+        for(int alphascale=32; alphascale>0; alphascale/=8)
         {
-            
+
             int startalpha = clamp(tablealpha-alphascale*4);
             int endalpha = clamp(tablealpha+alphascale*4);
-            
+
             for(alpha=startalpha; alpha<=endalpha; alpha+=alphascale) {
                 int sum=0;
                 int val,diff,bestdiff=10000000,index;
-                for(int x=0; x<4; x++) 
+                for(int x=0; x<4; x++)
                 {
-                    for(int y=0; y<4; y++) 
+                    for(int y=0; y<4; y++)
                     {
                         //compute best offset here, add square difference to sum..
                         val=data[ix+x+(iy+y)*width];
                         bestdiff=1000000000;
                         //the values are always ordered from small to large, with the first 4 being negative and the last 4 positive
                         //search is therefore made in the order 0-1-2-3 or 7-6-5-4, stopping when error increases compared to the previous entry tested.
-                        if(val>alpha) 
-                        { 
-                            for(index=7; index>3; index--) 
+                        if(val>alpha)
+                        {
+                            for(index=7; index>3; index--)
                             {
                                 diff=clamp_table[alpha+(alphaTable[table][index])+255]-val;
                                 diff*=diff;
-                                if(diff<=bestdiff) 
+                                if(diff<=bestdiff)
                                 {
                                     bestdiff=diff;
                                 }
@@ -9031,13 +9033,13 @@ void compressBlockAlphaSlow(uint8* data, int ix, int iy, int width, int height, 
                                     break;
                             }
                         }
-                        else 
+                        else
                         {
-                            for(index=0; index<5; index++) 
+                            for(index=0; index<5; index++)
                             {
                                 diff=clamp_table[alpha+(alphaTable[table][index])+255]-val;
                                 diff*=diff;
-                                if(diff<bestdiff) 
+                                if(diff<bestdiff)
                                 {
                                     bestdiff=diff;
                                 }
@@ -9049,19 +9051,19 @@ void compressBlockAlphaSlow(uint8* data, int ix, int iy, int width, int height, 
                         //best diff here is bestdiff, add it to sum!
                         sum+=bestdiff;
                         //if the sum here is worse than previously best already, there's no use in continuing the count..
-                        if(sum>tablebestsum) 
-                        { 
+                        if(sum>tablebestsum)
+                        {
                             x=9999; //just to make it large and get out of the x<4 loop
                             break;
                         }
                     }
                 }
-                if(sum<tablebestsum) 
+                if(sum<tablebestsum)
                 {
                     tablebestsum=sum;
                     tablealpha=alpha;
                 }
-                if(sum<bestsum) 
+                if(sum<bestsum)
                 {
                     bestsum=sum;
                     besttable=table;
@@ -9073,28 +9075,28 @@ void compressBlockAlphaSlow(uint8* data, int ix, int iy, int width, int height, 
         }
     }
 
-    alpha=bestalpha;    
+    alpha=bestalpha;
     //the best alpha value and table are known!
     //store them, then loop through the pixels again and print indices.
     returnData[0]=alpha;
     returnData[1]=besttable;
-    for(int pos=2; pos<8; pos++) 
+    for(int pos=2; pos<8; pos++)
     {
         returnData[pos]=0;
     }
     int byte=2;
     int bit=0;
-    for(int x=0; x<4; x++) 
+    for(int x=0; x<4; x++)
     {
-        for(int y=0; y<4; y++) 
+        for(int y=0; y<4; y++)
         {
             //find correct index
             int besterror=1000000;
             int bestindex=99;
             for(int index=0; index<8; index++) //no clever ordering this time, as this loop is only run once per block anyway
-            { 
+            {
                 int error= (clamp(alpha +(int)(alphaTable[besttable][index]))-data[ix+x+(iy+y)*width])*(clamp(alpha +(int)(alphaTable[besttable][index]))-data[ix+x+(iy+y)*width]);
-                if(error<besterror) 
+                if(error<besterror)
                 {
                     besterror=error;
                     bestindex=index;
@@ -9102,12 +9104,12 @@ void compressBlockAlphaSlow(uint8* data, int ix, int iy, int width, int height, 
             }
             //best table index has been determined.
             //pack 3-bit index into compressed data, one bit at a time
-            for(int numbit=0; numbit<3; numbit++) 
+            for(int numbit=0; numbit<3; numbit++)
             {
                 returnData[byte]|=getbit(bestindex,2-numbit,7-bit);
 
                 bit++;
-                if(bit>7) 
+                if(bit>7)
                 {
                     bit=0;
                     byte++;
@@ -9123,11 +9125,11 @@ double calculateWeightedPSNR(uint8 *lossyimg, uint8 *origimg, int width, int hei
 {
     // Note: This calculation of PSNR uses the formula
     //
-    // PSNR = 10 * log_10 ( 255^2 / wMSE ) 
-    // 
+    // PSNR = 10 * log_10 ( 255^2 / wMSE )
+    //
     // where the wMSE is calculated as
     //
-    // 1/(N*M) * sum ( ( w1*(R' - R)^2 + w2*(G' - G)^2 + w3*(B' - B)^2) ) 
+    // 1/(N*M) * sum ( ( w1*(R' - R)^2 + w2*(G' - G)^2 + w3*(B' - B)^2) )
     //
     // typical weights are  0.299,   0.587,   0.114  for perceptually weighted PSNR and
   //                     1.0/3.0, 1.0/3.0, 1.0/3.0 for nonweighted PSNR
@@ -9167,20 +9169,20 @@ double calculatePSNR(uint8 *lossyimg, uint8 *origimg, int width, int height)
 {
     // Note: This calculation of PSNR uses the formula
     //
-    // PSNR = 10 * log_10 ( 255^2 / MSE ) 
-    // 
+    // PSNR = 10 * log_10 ( 255^2 / MSE )
+    //
     // where the MSE is calculated as
     //
-    // 1/(N*M) * sum ( 1/3 * ((R' - R)^2 + (G' - G)^2 + (B' - B)^2) ) 
+    // 1/(N*M) * sum ( 1/3 * ((R' - R)^2 + (G' - G)^2 + (B' - B)^2) )
     //
     // The reason for having the 1/3 factor is the following:
-    // Presume we have a grayscale image, that is acutally just the red component 
+    // Presume we have a grayscale image, that is acutally just the red component
     // of a color image.. The squared error is then (R' - R)^2.
     // Assume that we have a certain signal to noise ratio, say 30 dB. If we add
-    // another two components (say green and blue) with the same signal to noise 
+    // another two components (say green and blue) with the same signal to noise
     // ratio, we want the total signal to noise ratio be the same. For the
     // squared error to remain constant we must divide by three after adding
-    // together the squared errors of the components. 
+    // together the squared errors of the components.
 
   return calculateWeightedPSNR(lossyimg, origimg, width, height, (1.0/3.0), (1.0/3.0), (1.0/3.0));
 }
@@ -9203,7 +9205,7 @@ void uncompressFile(char *srcfile, uint8* &img, uint8 *&alphaimg, int& active_wi
     {
         // Load table
         readCompressParams();
-        if(ktxFile) 
+        if(ktxFile)
         {
             //read ktx header..
             KTX_header header;
@@ -9211,7 +9213,7 @@ void uncompressFile(char *srcfile, uint8* &img, uint8 *&alphaimg, int& active_wi
             //read size parameter, which we don't actually need..
             unsigned int bitsize;
             fread(&bitsize,sizeof(unsigned int),1,f);
-    
+
             active_width=header.pixelWidth;
             active_height = header.pixelHeight;
             w = ((active_width+3)/4)*4;
@@ -9219,60 +9221,60 @@ void uncompressFile(char *srcfile, uint8* &img, uint8 *&alphaimg, int& active_wi
             width=w;
             height=h;
 
-            if(header.glInternalFormat==GL_COMPRESSED_SIGNED_R11_EAC) 
+            if(header.glInternalFormat==GL_COMPRESSED_SIGNED_R11_EAC)
             {
                 format=ETC2PACKAGE_R_NO_MIPMAPS;
                 formatSigned=1;
             }
-            else if(header.glInternalFormat==GL_COMPRESSED_R11_EAC) 
+            else if(header.glInternalFormat==GL_COMPRESSED_R11_EAC)
             {
                 format=ETC2PACKAGE_R_NO_MIPMAPS;
             }
-            else if(header.glInternalFormat==GL_COMPRESSED_SIGNED_RG11_EAC) 
+            else if(header.glInternalFormat==GL_COMPRESSED_SIGNED_RG11_EAC)
             {
                 format=ETC2PACKAGE_RG_NO_MIPMAPS;
                 formatSigned=1;
             }
-            else if(header.glInternalFormat==GL_COMPRESSED_RG11_EAC) 
+            else if(header.glInternalFormat==GL_COMPRESSED_RG11_EAC)
             {
                 format=ETC2PACKAGE_RG_NO_MIPMAPS;
             }
-            else if(header.glInternalFormat==GL_COMPRESSED_RGB8_ETC2) 
+            else if(header.glInternalFormat==GL_COMPRESSED_RGB8_ETC2)
             {
                 format=ETC2PACKAGE_RGB_NO_MIPMAPS;
             }
-            else if(header.glInternalFormat==GL_COMPRESSED_SRGB8_ETC2) 
+            else if(header.glInternalFormat==GL_COMPRESSED_SRGB8_ETC2)
             {
                 format=ETC2PACKAGE_sRGB_NO_MIPMAPS;
             }
-            else if(header.glInternalFormat==GL_COMPRESSED_RGBA8_ETC2_EAC) 
+            else if(header.glInternalFormat==GL_COMPRESSED_RGBA8_ETC2_EAC)
             {
                 format=ETC2PACKAGE_RGBA_NO_MIPMAPS;
             }
-            else if(header.glInternalFormat==GL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC) 
+            else if(header.glInternalFormat==GL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC)
             {
                 format=ETC2PACKAGE_sRGBA_NO_MIPMAPS;
             }
-            else if(header.glInternalFormat==GL_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2) 
+            else if(header.glInternalFormat==GL_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2)
             {
                 format=ETC2PACKAGE_RGBA1_NO_MIPMAPS;
             }
-            else if(header.glInternalFormat==GL_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2) 
+            else if(header.glInternalFormat==GL_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2)
             {
                 format=ETC2PACKAGE_sRGBA1_NO_MIPMAPS;
             }
-            else if(header.glInternalFormat==GL_ETC1_RGB8_OES) 
+            else if(header.glInternalFormat==GL_ETC1_RGB8_OES)
             {
                 format=ETC1_RGB_NO_MIPMAPS;
                 codec=CODEC_ETC;
             }
-            else 
+            else
             {
                 printf("ktx file has unknown glInternalFormat (not etc compressed)!\n");
                 exit(1);
             }
         }
-        else 
+        else
         {
             // Read magic nunmber
             fread(&magic[0], sizeof(unsigned char), 1, f);
@@ -9284,7 +9286,7 @@ void uncompressFile(char *srcfile, uint8* &img, uint8 *&alphaimg, int& active_wi
                 printf("\n\n The file %s is not a .pkm file.\n",srcfile);
                 exit(1);
             }
-        
+
             // Read version
             fread(&version[0], sizeof(unsigned char), 1, f);
             fread(&version[1], sizeof(unsigned char), 1, f);
@@ -9304,13 +9306,13 @@ void uncompressFile(char *srcfile, uint8* &img, uint8 *&alphaimg, int& active_wi
             {
                 // Read texture type
                 read_big_endian_2byte_word(&texture_type, f);
-                if(texture_type==ETC2PACKAGE_RG_SIGNED_NO_MIPMAPS) 
+                if(texture_type==ETC2PACKAGE_RG_SIGNED_NO_MIPMAPS)
                 {
                     texture_type=ETC2PACKAGE_RG_NO_MIPMAPS;
                     formatSigned=1;
                     //printf("Decompressing 2-channel signed data\n");
                 }
-                if(texture_type==ETC2PACKAGE_R_SIGNED_NO_MIPMAPS) 
+                if(texture_type==ETC2PACKAGE_R_SIGNED_NO_MIPMAPS)
                 {
                     texture_type=ETC2PACKAGE_R_NO_MIPMAPS;
                     formatSigned=1;
@@ -9331,7 +9333,7 @@ void uncompressFile(char *srcfile, uint8* &img, uint8 *&alphaimg, int& active_wi
           // The SRGB formats are decoded just as RGB formats -- use RGB format for decompression.
           texture_type=ETC2PACKAGE_sRGBA1_NO_MIPMAPS;
         }
-                if(texture_type==ETC2PACKAGE_RGBA_NO_MIPMAPS_OLD) 
+                if(texture_type==ETC2PACKAGE_RGBA_NO_MIPMAPS_OLD)
                 {
                     printf("\n\nThe file %s contains a compressed texture created using an old version of ETCPACK.\n",srcfile);
                     printf("decompression is not supported in this version.\n");
@@ -9353,7 +9355,7 @@ void uncompressFile(char *srcfile, uint8* &img, uint8 *&alphaimg, int& active_wi
             format=texture_type;
             printf("textype: %d\n",texture_type);
             // ETC2 is backwards compatible, which means that an ETC2-capable decompressor can also handle
-            // old ETC1 textures without any problems. Thus a version 1.0 file with ETC1_RGB_NO_MIPMAPS and a 
+            // old ETC1 textures without any problems. Thus a version 1.0 file with ETC1_RGB_NO_MIPMAPS and a
             // version 2.0 file with ETC2PACKAGE_RGB_NO_MIPMAPS can be handled by the same ETC2-capable decompressor
 
             // Read how many pixels the blocks make up
@@ -9394,7 +9396,7 @@ void uncompressFile(char *srcfile, uint8* &img, uint8 *&alphaimg, int& active_wi
                 exit(0);
             }
         }
-        if(format==ETC2PACKAGE_RG_NO_MIPMAPS) 
+        if(format==ETC2PACKAGE_RG_NO_MIPMAPS)
         {
             alphaimg2=(uint8*)malloc(width*height*2);
             if(!alphaimg2)
@@ -9409,14 +9411,14 @@ void uncompressFile(char *srcfile, uint8* &img, uint8 *&alphaimg, int& active_wi
             for(int x=0;x<width/4;x++)
             {
                 //decode alpha channel for RGBA
-                if(format==ETC2PACKAGE_RGBA_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA_NO_MIPMAPS) 
+                if(format==ETC2PACKAGE_RGBA_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA_NO_MIPMAPS)
                 {
                     uint8 alphablock[8];
                     fread(alphablock,1,8,f);
                     decompressBlockAlpha(alphablock,alphaimg,width,height,4*x,4*y);
                 }
                 //color channels for most normal modes
-                if(format!=ETC2PACKAGE_R_NO_MIPMAPS&&format!=ETC2PACKAGE_RG_NO_MIPMAPS) 
+                if(format!=ETC2PACKAGE_R_NO_MIPMAPS&&format!=ETC2PACKAGE_RG_NO_MIPMAPS)
                 {
                     //we have normal ETC2 color channels, decompress these
                     read_big_endian_4byte_word(&block_part1,f);
@@ -9424,16 +9426,16 @@ void uncompressFile(char *srcfile, uint8* &img, uint8 *&alphaimg, int& active_wi
                     if(format==ETC2PACKAGE_RGBA1_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA1_NO_MIPMAPS)
                         decompressBlockETC21BitAlpha(block_part1, block_part2,img,alphaimg,width,height,4*x,4*y);
                     else
-                        decompressBlockETC2(block_part1, block_part2,img,width,height,4*x,4*y);        
+                        decompressBlockETC2(block_part1, block_part2,img,width,height,4*x,4*y);
                 }
                 //one or two 11-bit alpha channels for R or RG.
-                if(format==ETC2PACKAGE_R_NO_MIPMAPS||format==ETC2PACKAGE_RG_NO_MIPMAPS) 
+                if(format==ETC2PACKAGE_R_NO_MIPMAPS||format==ETC2PACKAGE_RG_NO_MIPMAPS)
                 {
                     uint8 alphablock[8];
                     fread(alphablock,1,8,f);
                     decompressBlockAlpha16bit(alphablock,alphaimg,width,height,4*x,4*y);
                 }
-                if(format==ETC2PACKAGE_RG_NO_MIPMAPS) 
+                if(format==ETC2PACKAGE_RG_NO_MIPMAPS)
                 {
                     uint8 alphablock[8];
                     fread(alphablock,1,8,f);
@@ -9441,7 +9443,7 @@ void uncompressFile(char *srcfile, uint8* &img, uint8 *&alphaimg, int& active_wi
                 }
             }
         }
-        if(format==ETC2PACKAGE_RG_NO_MIPMAPS) 
+        if(format==ETC2PACKAGE_RG_NO_MIPMAPS)
         {
             for(int y=0;y<height;y++)
             {
@@ -9466,7 +9468,7 @@ void uncompressFile(char *srcfile, uint8* &img, uint8 *&alphaimg, int& active_wi
                 newimg=(uint8*)malloc(3*active_width*active_height*2);
             else
                 newimg=(uint8*)malloc(3*active_width*active_height);
-            
+
             if(format==ETC2PACKAGE_RGBA_NO_MIPMAPS||format==ETC2PACKAGE_RGBA1_NO_MIPMAPS||format==ETC2PACKAGE_R_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA1_NO_MIPMAPS)
             {
                 newalphaimg = (uint8*)malloc(active_width*active_height*2);
@@ -9477,20 +9479,20 @@ void uncompressFile(char *srcfile, uint8* &img, uint8 *&alphaimg, int& active_wi
                 printf("Error: could not allocate memory\n");
                 exit(0);
             }
-            
+
             // Convert from total area to active area:
 
             for(yy = 0; yy<active_height; yy++)
             {
                 for(xx = 0; xx< active_width; xx++)
                 {
-                    if(format!=ETC2PACKAGE_R_NO_MIPMAPS&&format!=ETC2PACKAGE_RG_NO_MIPMAPS) 
+                    if(format!=ETC2PACKAGE_R_NO_MIPMAPS&&format!=ETC2PACKAGE_RG_NO_MIPMAPS)
                     {
                         newimg[ (yy*active_width)*3 + xx*3 + 0 ] = img[ (yy*width)*3 + xx*3 + 0];
                         newimg[ (yy*active_width)*3 + xx*3 + 1 ] = img[ (yy*width)*3 + xx*3 + 1];
                         newimg[ (yy*active_width)*3 + xx*3 + 2 ] = img[ (yy*width)*3 + xx*3 + 2];
                     }
-                    else if(format==ETC2PACKAGE_RG_NO_MIPMAPS) 
+                    else if(format==ETC2PACKAGE_RG_NO_MIPMAPS)
                     {
                         newimg[ (yy*active_width)*6 + xx*6 + 0 ] = img[ (yy*width)*6 + xx*6 + 0];
                         newimg[ (yy*active_width)*6 + xx*6 + 1 ] = img[ (yy*width)*6 + xx*6 + 1];
@@ -9499,12 +9501,12 @@ void uncompressFile(char *srcfile, uint8* &img, uint8 *&alphaimg, int& active_wi
                         newimg[ (yy*active_width)*6 + xx*6 + 4 ] = img[ (yy*width)*6 + xx*6 + 4];
                         newimg[ (yy*active_width)*6 + xx*6 + 5 ] = img[ (yy*width)*6 + xx*6 + 5];
                     }
-                    if(format==ETC2PACKAGE_R_NO_MIPMAPS) 
+                    if(format==ETC2PACKAGE_R_NO_MIPMAPS)
                     {
                         newalphaimg[ ((yy*active_width) + xx)*2]   = alphaimg[2*((yy*width) + xx)];
                         newalphaimg[ ((yy*active_width) + xx)*2+1] = alphaimg[2*((yy*width) + xx)+1];
                     }
-                    if(format==ETC2PACKAGE_RGBA_NO_MIPMAPS||format==ETC2PACKAGE_RGBA1_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA1_NO_MIPMAPS) 
+                    if(format==ETC2PACKAGE_RGBA_NO_MIPMAPS||format==ETC2PACKAGE_RGBA1_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA1_NO_MIPMAPS)
                     {
                         newalphaimg[ ((yy*active_width) + xx)]   = alphaimg[((yy*width) + xx)];
                     }
@@ -9518,7 +9520,7 @@ void uncompressFile(char *srcfile, uint8* &img, uint8 *&alphaimg, int& active_wi
                 free(alphaimg);
                 alphaimg=newalphaimg;
             }
-            if(format==ETC2PACKAGE_RG_NO_MIPMAPS) 
+            if(format==ETC2PACKAGE_RG_NO_MIPMAPS)
             {
                 free(alphaimg);
                 free(alphaimg2);
@@ -9537,18 +9539,18 @@ void uncompressFile(char *srcfile, uint8* &img, uint8 *&alphaimg, int& active_wi
     fclose(f);
 }
 
-// Writes output file 
+// Writes output file
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-void writeOutputFile(char *dstfile, uint8* img, uint8* alphaimg, int width, int height) 
+void writeOutputFile(char *dstfile, uint8* img, uint8* alphaimg, int width, int height)
 {
     char str[300];
 
-    if(format!=ETC2PACKAGE_R_NO_MIPMAPS&&format!=ETC2PACKAGE_RG_NO_MIPMAPS) 
+    if(format!=ETC2PACKAGE_R_NO_MIPMAPS&&format!=ETC2PACKAGE_RG_NO_MIPMAPS)
     {
         fWritePPM("tmp.ppm",width,height,img,8,false);
         printf("Saved file tmp.ppm \n\n");
     }
-    else if(format==ETC2PACKAGE_RG_NO_MIPMAPS) 
+    else if(format==ETC2PACKAGE_RG_NO_MIPMAPS)
     {
         fWritePPM("tmp.ppm",width,height,img,16,false);
     }
@@ -9560,30 +9562,30 @@ void writeOutputFile(char *dstfile, uint8* img, uint8* alphaimg, int width, int 
     // Delete destination file if it exists
     if(fileExist(dstfile))
     {
-        sprintf(str, "del %s\n",dstfile);    
+        sprintf(str, "del %s\n",dstfile);
         system(str);
     }
 
     int q = find_pos_of_extension(dstfile);
-    if(!strcmp(&dstfile[q],".ppm")&&format!=ETC2PACKAGE_R_NO_MIPMAPS) 
+    if(!strcmp(&dstfile[q],".ppm")&&format!=ETC2PACKAGE_R_NO_MIPMAPS)
     {
-        // Already a .ppm file. Just rename. 
+        // Already a .ppm file. Just rename.
         sprintf(str,"move tmp.ppm %s\n",dstfile);
         printf("Renaming destination file to %s\n",dstfile);
     }
     else
     {
         // Converting from .ppm to other file format
-        // 
+        //
         // Use your favorite command line image converter program,
         // for instance Image Magick. Just make sure the syntax can
         // be written as below:
-        // 
+        //
         // C:\imconv source.ppm dest.jpg
         //
-        if(format==ETC2PACKAGE_RGBA_NO_MIPMAPS||format==ETC2PACKAGE_RGBA1_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA1_NO_MIPMAPS) 
+        if(format==ETC2PACKAGE_RGBA_NO_MIPMAPS||format==ETC2PACKAGE_RGBA1_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA1_NO_MIPMAPS)
         {
-            // Somewhere after version 6.7.1-2 of ImageMagick the following command gives the wrong result due to a bug. 
+            // Somewhere after version 6.7.1-2 of ImageMagick the following command gives the wrong result due to a bug.
             // sprintf(str,"composite -compose CopyOpacity alphaout.pgm tmp.ppm %s\n",dstfile);
             // Instead we read the file and write a tga.
 
@@ -9598,12 +9600,12 @@ void writeOutputFile(char *dstfile, uint8* img, uint8* alphaimg, int width, int 
             free(pixelsA);
             sprintf(str,""); // Nothing to execute.
         }
-        else if(format==ETC2PACKAGE_R_NO_MIPMAPS) 
+        else if(format==ETC2PACKAGE_R_NO_MIPMAPS)
         {
             sprintf(str,"imconv alphaout.pgm %s\n",dstfile);
             printf("Converting destination file from .pgm to %s\n",dstfile);
         }
-        else 
+        else
         {
             sprintf(str,"imconv tmp.ppm %s\n",dstfile);
             printf("Converting destination file from .ppm to %s\n",dstfile);
@@ -9611,7 +9613,7 @@ void writeOutputFile(char *dstfile, uint8* img, uint8* alphaimg, int width, int 
     }
     // Execute system call
     system(str);
-    
+
     free(img);
     if(alphaimg!=NULL)
         free(alphaimg);
@@ -9644,7 +9646,7 @@ double calculatePSNRfile(char *srcfile, uint8 *origimg, uint8* origalpha)
     {
         for(int x=0;x<active_width;x++)
         {
-            if(format!=ETC2PACKAGE_R_NO_MIPMAPS&&format!=ETC2PACKAGE_RG_NO_MIPMAPS) 
+            if(format!=ETC2PACKAGE_R_NO_MIPMAPS&&format!=ETC2PACKAGE_RG_NO_MIPMAPS)
             {
                 //we have regular color channels..
                 if((format != ETC2PACKAGE_RGBA1_NO_MIPMAPS && format != ETC2PACKAGE_sRGBA1_NO_MIPMAPS) || alphaimg[y*width + x] > 0)
@@ -9661,7 +9663,7 @@ double calculatePSNRfile(char *srcfile, uint8 *origimg, uint8* origalpha)
                     numpixels++;
                 }
             }
-            else if(format==ETC2PACKAGE_RG_NO_MIPMAPS) 
+            else if(format==ETC2PACKAGE_RG_NO_MIPMAPS)
             {
                 int rorig = (origimg[6*(y*width+x)+0]<<8)+origimg[6*(y*width+x)+1];
                 int rnew =  (    img[6*(y*active_width+x)+0]<<8)+    img[6*(y*active_width+x)+1];
@@ -9672,7 +9674,7 @@ double calculatePSNRfile(char *srcfile, uint8 *origimg, uint8* origalpha)
                 err=gorig-gnew;
                 MSEG+=(err*err);
             }
-            else if(format==ETC2PACKAGE_R_NO_MIPMAPS) 
+            else if(format==ETC2PACKAGE_R_NO_MIPMAPS)
             {
                 int aorig = (((int)origalpha[2*(y*width+x)+0])<<8)+origalpha[2*(y*width+x)+1];
                 int anew =  (((int)alphaimg[2*(y*active_width+x)+0])<<8)+alphaimg[2*(y*active_width+x)+1];
@@ -9690,7 +9692,7 @@ double calculatePSNRfile(char *srcfile, uint8 *origimg, uint8* origalpha)
         printf("PSNR only calculated on pixels where compressed alpha > 0\n");
         printf("color PSNR: %lf\nweighted PSNR: %lf\n",PSNR,wPSNR);
     }
-    else if(format!=ETC2PACKAGE_R_NO_MIPMAPS&&format!=ETC2PACKAGE_RG_NO_MIPMAPS) 
+    else if(format!=ETC2PACKAGE_R_NO_MIPMAPS&&format!=ETC2PACKAGE_RG_NO_MIPMAPS)
     {
         MSE = MSE / (active_width * active_height);
         wMSE = wMSE / (active_width * active_height);
@@ -9700,7 +9702,7 @@ double calculatePSNRfile(char *srcfile, uint8 *origimg, uint8* origalpha)
             printf("PSNR only calculated on RGB, not on alpha\n");
         printf("color PSNR: %lf\nweighted PSNR: %lf\n",PSNR,wPSNR);
     }
-    else if(format==ETC2PACKAGE_RG_NO_MIPMAPS) 
+    else if(format==ETC2PACKAGE_RG_NO_MIPMAPS)
     {
         MSER = MSER / (active_width * active_height);
         MSEG = MSEG / (active_width * active_height);
@@ -9708,7 +9710,7 @@ double calculatePSNRfile(char *srcfile, uint8 *origimg, uint8* origalpha)
         PSNRG = 10*log((1.0*65535*65535)/MSEG)/log(10.0);
         printf("red PSNR: %lf\ngreen PSNR: %lf\n",PSNRR,PSNRG);
     }
-    else if(format==ETC2PACKAGE_R_NO_MIPMAPS) 
+    else if(format==ETC2PACKAGE_R_NO_MIPMAPS)
     {
         MSEA = MSEA / (active_width * active_height);
         PSNRA = 10*log((1.0*65535.0*65535.0)/MSEA)/log(10.0);
@@ -9739,13 +9741,13 @@ inline unsigned int precompute_3bittable_all_subblocksRG_withtest_perceptual1000
     unsigned int err_this_table_left;
     unsigned int err_this_table_right;
 
-    // If the error in the red and green component is already larger than best_err for all 8 tables in 
-    // all of upper, lower, left and right, this combination of red and green will never be used in 
-    // the optimal color configuration. Therefore we can avoid testing all the blue colors for this 
-    // combination. 
-    good_enough_to_test = false;    
+    // If the error in the red and green component is already larger than best_err for all 8 tables in
+    // all of upper, lower, left and right, this combination of red and green will never be used in
+    // the optimal color configuration. Therefore we can avoid testing all the blue colors for this
+    // combination.
+    good_enough_to_test = false;
 
-    for(table=0;table<8;table++)        // try all the 8 tables. 
+    for(table=0;table<8;table++)        // try all the 8 tables.
     {
         table_indices = &compressParamsFast[table*4];
 
@@ -9769,7 +9771,7 @@ inline unsigned int precompute_3bittable_all_subblocksRG_withtest_perceptual1000
             orig[2]=block[x*4+2];
             for(index=0;index<4;index++)
             {
-                err[index] = precalc_err_UL_R[table*4*4+x*4+index] 
+                err[index] = precalc_err_UL_R[table*4*4+x*4+index]
                     + PERCEPTUAL_WEIGHT_G_SQUARED_TIMES1000 * SQUARE(approx[1][index]-orig[1]);
                 precalc_err_UL_RG[table*4*4+x*4+index] = err[index];
             }
@@ -9789,7 +9791,7 @@ inline unsigned int precompute_3bittable_all_subblocksRG_withtest_perceptual1000
             orig[2]=block[x*4+2];
             for(index=0;index<4;index++)
             {
-                err[index] = precalc_err_UR_R[table*4*4+(x-4)*4+index] 
+                err[index] = precalc_err_UR_R[table*4*4+(x-4)*4+index]
                   + PERCEPTUAL_WEIGHT_G_SQUARED_TIMES1000 * SQUARE(approx[1][index]-orig[1]);
                 precalc_err_UR_RG[table*4*4+(x-4)*4+index] = err[index];
             }
@@ -9854,7 +9856,7 @@ inline unsigned int precompute_3bittable_all_subblocksRG_withtest_perceptual1000
             good_enough_to_test = true;
     }
     return good_enough_to_test;
-} 
+}
 #endif
 
 #if EXHAUSTIVE_CODE_ACTIVE
@@ -9876,13 +9878,13 @@ inline int precompute_3bittable_all_subblocksRG_withtest(uint8 *block,uint8 *avg
     unsigned int err_this_table_left;
     unsigned int err_this_table_right;
 
-    // If the error in the red and green component is already larger than best_err for all 8 tables in 
-    // all of upper, lower, left and right, this combination of red and green will never be used in 
-    // the optimal color configuration. Therefore we can avoid testing all the blue colors for this 
-    // combination. 
-    good_enough_to_test = false;    
+    // If the error in the red and green component is already larger than best_err for all 8 tables in
+    // all of upper, lower, left and right, this combination of red and green will never be used in
+    // the optimal color configuration. Therefore we can avoid testing all the blue colors for this
+    // combination.
+    good_enough_to_test = false;
 
-    for(table=0;table<8;table++)        // try all the 8 tables. 
+    for(table=0;table<8;table++)        // try all the 8 tables.
     {
         table_indices = &compressParamsFast[table*4];
 
@@ -9987,7 +9989,7 @@ inline int precompute_3bittable_all_subblocksRG_withtest(uint8 *block,uint8 *avg
             good_enough_to_test = true;
     }
     return good_enough_to_test;
-} 
+}
 #endif
 
 #if EXHAUSTIVE_CODE_ACTIVE
@@ -10012,7 +10014,7 @@ inline unsigned int precompute_3bittable_all_subblocksR_with_test_perceptual1000
 
     good_enough_to_test = false;
 
-    for(table=0;table<8;table++)        // try all the 8 tables. 
+    for(table=0;table<8;table++)        // try all the 8 tables.
     {
         err_this_table_upper = 0;
         err_this_table_lower = 0;
@@ -10087,7 +10089,7 @@ inline unsigned int precompute_3bittable_all_subblocksR_with_test_perceptual1000
                 err[0] = err[2];
             err_this_table_lower+=err[0];
             err_this_table_left+=err[0];
-             
+
         }
         for(x=12; x<16; x++)
         {
@@ -10119,7 +10121,7 @@ inline unsigned int precompute_3bittable_all_subblocksR_with_test_perceptual1000
             good_enough_to_test = true;
     }
     return good_enough_to_test;
-} 
+}
 #endif
 
 #if EXHAUSTIVE_CODE_ACTIVE
@@ -10144,7 +10146,7 @@ inline int precompute_3bittable_all_subblocksR_with_test(uint8 *block,uint8 *avg
 
     good_enough_to_test = false;
 
-    for(table=0;table<8;table++)        // try all the 8 tables. 
+    for(table=0;table<8;table++)        // try all the 8 tables.
     {
         err_this_table_upper = 0;
         err_this_table_lower = 0;
@@ -10219,7 +10221,7 @@ inline int precompute_3bittable_all_subblocksR_with_test(uint8 *block,uint8 *avg
                 err[0] = err[2];
             err_this_table_lower+=err[0];
             err_this_table_left+=err[0];
-             
+
         }
         for(x=12; x<16; x++)
         {
@@ -10251,7 +10253,7 @@ inline int precompute_3bittable_all_subblocksR_with_test(uint8 *block,uint8 *avg
             good_enough_to_test = true;
     }
     return good_enough_to_test;
-} 
+}
 #endif
 
 #if EXHAUSTIVE_CODE_ACTIVE
@@ -10265,10 +10267,10 @@ inline void tryalltables_3bittable_all_subblocks_using_precalc(uint8 *block_2x2,
     unsigned int err_this_table_right;
     int orig[3],approx[4];
     int err[4];
-    err_upper = 3*255*255*16;    
-    err_lower = 3*255*255*16;    
-    err_left = 3*255*255*16;    
-    err_right = 3*255*255*16;    
+    err_upper = 3*255*255*16;
+    err_lower = 3*255*255*16;
+    err_left = 3*255*255*16;
+    err_right = 3*255*255*16;
 
 #define ONE_PIXEL_UL(table_nbr,xx)\
             orig[0]=block_2x2[xx*4];\
@@ -10405,7 +10407,7 @@ inline void tryalltables_3bittable_all_subblocks_using_precalc(uint8 *block_2x2,
         ONE_TABLE_3(6);
         ONE_TABLE_3(7);
     /*end unroll loop*/
-} 
+}
 #endif
 
 #if EXHAUSTIVE_CODE_ACTIVE
@@ -10419,10 +10421,10 @@ inline void tryalltables_3bittable_all_subblocks_using_precalc_perceptual1000(ui
     unsigned int err_this_table_right;
     int orig[3],approx[4];
     int err[4];
-    err_upper = MAXERR1000;    
-    err_lower = MAXERR1000;    
-    err_left = MAXERR1000;    
-    err_right =MAXERR1000;    
+    err_upper = MAXERR1000;
+    err_lower = MAXERR1000;
+    err_left = MAXERR1000;
+    err_right =MAXERR1000;
 
 #define ONE_PIXEL_UL_PERCEP(table_nbr,xx)\
             orig[0]=block_2x2[xx*4];\
@@ -10559,7 +10561,7 @@ inline void tryalltables_3bittable_all_subblocks_using_precalc_perceptual1000(ui
         ONE_TABLE_3_PERCEP(6);
         ONE_TABLE_3_PERCEP(7);
     /*end unroll loop*/
-} 
+}
 #endif
 
 #if EXHAUSTIVE_CODE_ACTIVE
@@ -10567,16 +10569,16 @@ inline void tryalltables_3bittable_all_subblocks_using_precalc_perceptual1000(ui
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 unsigned int compressBlockIndividualExhaustivePerceptual(uint8 *img,int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2, unsigned int total_best_err)
 {
-    //unsigned int best_err_norm_diff = MAXERR1000; 
-    //unsigned int best_err_norm_444 = MAXERR1000; 
-    //unsigned int best_err_flip_diff = MAXERR1000; 
-    //unsigned int best_err_flip_444 = MAXERR1000; 
+    //unsigned int best_err_norm_diff = MAXERR1000;
+    //unsigned int best_err_norm_444 = MAXERR1000;
+    //unsigned int best_err_flip_diff = MAXERR1000;
+    //unsigned int best_err_flip_444 = MAXERR1000;
     uint8 color_quant1[3], color_quant2[3];
 
     int enc_color1[3];
     int best_enc_color1[3], best_enc_color2[3];
-    
-    //int min_error=MAXERR1000; 
+
+    //int min_error=MAXERR1000;
     unsigned int best_pixel_indices1_MSB=0;
     unsigned int best_pixel_indices1_LSB=0;
     unsigned int best_pixel_indices2_MSB=0;
@@ -10590,10 +10592,10 @@ unsigned int compressBlockIndividualExhaustivePerceptual(uint8 *img,int width,in
 
     //unsigned int pixel_indices2_LSB=0;
 
-    unsigned int best_err_upper = MAXERR1000; 
-    unsigned int best_err_lower = MAXERR1000; 
-    unsigned int best_err_left = MAXERR1000; 
-    unsigned int best_err_right = MAXERR1000; 
+    unsigned int best_err_upper = MAXERR1000;
+    unsigned int best_err_lower = MAXERR1000;
+    unsigned int best_err_left = MAXERR1000;
+    unsigned int best_err_right = MAXERR1000;
 
     int best_upper_col[3];
     int best_lower_col[3];
@@ -10744,7 +10746,7 @@ unsigned int compressBlockIndividualExhaustivePerceptual(uint8 *img,int width,in
             }
         }
     }
-    
+
     if(best_err_upper+best_err_lower < best_err_left+best_err_right)
     {
         best_flip = 1;
@@ -10789,30 +10791,30 @@ unsigned int compressBlockIndividualExhaustivePerceptual(uint8 *img,int width,in
         tryalltables_3bittable4x2percep1000(img,width,height,startx,starty+2,color_quant2,best_table2,best_pixel_indices2_MSB, best_pixel_indices2_LSB);
 
     //     ETC1_RGB8_OES:
-    // 
+    //
     //     a) bit layout in bits 63 through 32 if diffbit = 0
-    // 
-    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+    //
+    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
     //      ---------------------------------------------------------------------------------------------------
     //     | base col1 | base col2 | base col1 | base col2 | base col1 | base col2 | table  | table  |diff|flip|
     //     | R1 (4bits)| R2 (4bits)| G1 (4bits)| G2 (4bits)| B1 (4bits)| B2 (4bits)| cw 1   | cw 2   |bit |bit |
     //      ---------------------------------------------------------------------------------------------------
-    //     
+    //
     //     b) bit layout in bits 63 through 32 if diffbit = 1
-    // 
-    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+    //
+    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
     //      ---------------------------------------------------------------------------------------------------
     //     | base col1    | dcol 2 | base col1    | dcol 2 | base col 1   | dcol 2 | table  | table  |diff|flip|
     //     | R1' (5 bits) | dR2    | G1' (5 bits) | dG2    | B1' (5 bits) | dB2    | cw 1   | cw 2   |bit |bit |
     //      ---------------------------------------------------------------------------------------------------
-    // 
+    //
     //     c) bit layout in bits 31 through 0 (in both cases)
-    // 
+    //
     //      31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10  9  8  7  6  5  4  3   2   1  0
     //      --------------------------------------------------------------------------------------------------
-    //     |       most significant pixel index bits       |         least significant pixel index bits       |  
+    //     |       most significant pixel index bits       |         least significant pixel index bits       |
     //     | p| o| n| m| l| k| j| i| h| g| f| e| d| c| b| a| p| o| n| m| l| k| j| i| h| g| f| e| d| c | b | a |
-    //      --------------------------------------------------------------------------------------------------      
+    //      --------------------------------------------------------------------------------------------------
 
 
     diffbit = 1;
@@ -10839,7 +10841,7 @@ unsigned int compressBlockIndividualExhaustivePerceptual(uint8 *img,int width,in
     else
     {
         best_pixel_indices1_MSB |= (best_pixel_indices2_MSB << 2);
-        best_pixel_indices1_LSB |= (best_pixel_indices2_LSB << 2);        
+        best_pixel_indices1_LSB |= (best_pixel_indices2_LSB << 2);
         compressed2 = ((best_pixel_indices1_MSB & 0xffff) << 16) | (best_pixel_indices1_LSB & 0xffff);
     }
 
@@ -10860,7 +10862,7 @@ unsigned int compressBlockIndividualExhaustive(uint8 *img,int width,int height,i
 
     int enc_color1[3];
     int best_enc_color1[3], best_enc_color2[3];
-    
+
     //int min_error=255*255*8*3;
     unsigned int best_pixel_indices1_MSB=0;
     unsigned int best_pixel_indices1_LSB=0;
@@ -11073,30 +11075,30 @@ unsigned int compressBlockIndividualExhaustive(uint8 *img,int width,int height,i
         tryalltables_3bittable4x2(img,width,height,startx,starty+2,color_quant2,best_table2,best_pixel_indices2_MSB, best_pixel_indices2_LSB);
 
     //     ETC1_RGB8_OES:
-    // 
+    //
     //     a) bit layout in bits 63 through 32 if diffbit = 0
-    // 
-    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+    //
+    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
     //      ---------------------------------------------------------------------------------------------------
     //     | base col1 | base col2 | base col1 | base col2 | base col1 | base col2 | table  | table  |diff|flip|
     //     | R1 (4bits)| R2 (4bits)| G1 (4bits)| G2 (4bits)| B1 (4bits)| B2 (4bits)| cw 1   | cw 2   |bit |bit |
     //      ---------------------------------------------------------------------------------------------------
-    //     
+    //
     //     b) bit layout in bits 63 through 32 if diffbit = 1
-    // 
-    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+    //
+    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
     //      ---------------------------------------------------------------------------------------------------
     //     | base col1    | dcol 2 | base col1    | dcol 2 | base col 1   | dcol 2 | table  | table  |diff|flip|
     //     | R1' (5 bits) | dR2    | G1' (5 bits) | dG2    | B1' (5 bits) | dB2    | cw 1   | cw 2   |bit |bit |
     //      ---------------------------------------------------------------------------------------------------
-    // 
+    //
     //     c) bit layout in bits 31 through 0 (in both cases)
-    // 
+    //
     //      31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10  9  8  7  6  5  4  3   2   1  0
     //      --------------------------------------------------------------------------------------------------
-    //     |       most significant pixel index bits       |         least significant pixel index bits       |  
+    //     |       most significant pixel index bits       |         least significant pixel index bits       |
     //     | p| o| n| m| l| k| j| i| h| g| f| e| d| c| b| a| p| o| n| m| l| k| j| i| h| g| f| e| d| c | b | a |
-    //      --------------------------------------------------------------------------------------------------      
+    //      --------------------------------------------------------------------------------------------------
 
     diffbit = 1;
     compressed1 = 0;
@@ -11122,14 +11124,14 @@ unsigned int compressBlockIndividualExhaustive(uint8 *img,int width,int height,i
     else
     {
         best_pixel_indices1_MSB |= (best_pixel_indices2_MSB << 2);
-        best_pixel_indices1_LSB |= (best_pixel_indices2_LSB << 2);        
+        best_pixel_indices1_LSB |= (best_pixel_indices2_LSB << 2);
         compressed2 = ((best_pixel_indices1_MSB & 0xffff) << 16) | (best_pixel_indices1_LSB & 0xffff);
     }
 
     return best_err;
 }
 #endif
- 
+
 #if EXHAUSTIVE_CODE_ACTIVE
 // Compresses the differential mode exhaustively (perecptual error metric).
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
@@ -11144,7 +11146,7 @@ unsigned int compressBlockDifferentialExhaustivePerceptual(uint8 *img,int width,
     int enc_color1[3], enc_color2[3], diff[3];
     int best_enc_color1[3], best_enc_color2[3];
     signed char bytediff[3];
-    
+
     unsigned int best_pixel_indices1_MSB=0;
     unsigned int best_pixel_indices1_LSB=0;
     unsigned int best_pixel_indices2_MSB=0;
@@ -11364,7 +11366,7 @@ unsigned int compressBlockDifferentialExhaustivePerceptual(uint8 *img,int width,
                         {
                             err_lower_adr = &err_lower[32*32*enc_color2[0]+32*enc_color2[1]];
                             err_right_adr = &err_right[32*32*enc_color2[0]+32*enc_color2[1]];
-                            // since enc_color[2] is between 4 and 29 we do not need to clamp the loop on the next line 
+                            // since enc_color[2] is between 4 and 29 we do not need to clamp the loop on the next line
                             for(enc_color2[2]=enc_color1[2]-4; enc_color2[2]<enc_color1[2]+4; enc_color2[2]++)
                             {
                                 error = error_lying+err_lower_adr[enc_color2[2]];
@@ -11467,35 +11469,35 @@ unsigned int compressBlockDifferentialExhaustivePerceptual(uint8 *img,int width,
     else
         tryalltables_3bittable4x2percep1000(img,width,height,startx,starty+2,color_quant2,best_table2,best_pixel_indices2_MSB, best_pixel_indices2_LSB);
 
-    diff[0] = best_enc_color2[0]-best_enc_color1[0];    
-    diff[1] = best_enc_color2[1]-best_enc_color1[1];    
+    diff[0] = best_enc_color2[0]-best_enc_color1[0];
+    diff[1] = best_enc_color2[1]-best_enc_color1[1];
     diff[2] = best_enc_color2[2]-best_enc_color1[2];
 
     //     ETC1_RGB8_OES:
-    // 
+    //
     //     a) bit layout in bits 63 through 32 if diffbit = 0
-    // 
-    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+    //
+    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
     //      ---------------------------------------------------------------------------------------------------
     //     | base col1 | base col2 | base col1 | base col2 | base col1 | base col2 | table  | table  |diff|flip|
     //     | R1 (4bits)| R2 (4bits)| G1 (4bits)| G2 (4bits)| B1 (4bits)| B2 (4bits)| cw 1   | cw 2   |bit |bit |
     //      ---------------------------------------------------------------------------------------------------
-    //     
+    //
     //     b) bit layout in bits 63 through 32 if diffbit = 1
-    // 
-    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+    //
+    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
     //      ---------------------------------------------------------------------------------------------------
     //     | base col1    | dcol 2 | base col1    | dcol 2 | base col 1   | dcol 2 | table  | table  |diff|flip|
     //     | R1' (5 bits) | dR2    | G1' (5 bits) | dG2    | B1' (5 bits) | dB2    | cw 1   | cw 2   |bit |bit |
     //      ---------------------------------------------------------------------------------------------------
-    // 
+    //
     //     c) bit layout in bits 31 through 0 (in both cases)
-    // 
+    //
     //      31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10  9  8  7  6  5  4  3   2   1  0
     //      --------------------------------------------------------------------------------------------------
-    //     |       most significant pixel index bits       |         least significant pixel index bits       |  
+    //     |       most significant pixel index bits       |         least significant pixel index bits       |
     //     | p| o| n| m| l| k| j| i| h| g| f| e| d| c| b| a| p| o| n| m| l| k| j| i| h| g| f| e| d| c | b | a |
-    //      --------------------------------------------------------------------------------------------------      
+    //      --------------------------------------------------------------------------------------------------
 
     diffbit = 1;
     compressed1 = 0;
@@ -11521,7 +11523,7 @@ unsigned int compressBlockDifferentialExhaustivePerceptual(uint8 *img,int width,
     else
     {
         best_pixel_indices1_MSB |= (best_pixel_indices2_MSB << 2);
-        best_pixel_indices1_LSB |= (best_pixel_indices2_LSB << 2);        
+        best_pixel_indices1_LSB |= (best_pixel_indices2_LSB << 2);
         compressed2 = ((best_pixel_indices1_MSB & 0xffff) << 16) | (best_pixel_indices1_LSB & 0xffff);
     }
     return best_error_using_diff_mode;
@@ -11541,7 +11543,7 @@ unsigned int compressBlockDifferentialExhaustive(uint8 *img,int width,int height
 
     int enc_color1[3], enc_color2[3], diff[3];
     int best_enc_color1[3], best_enc_color2[3];
-    
+
     //int min_error=255*255*8*3;
     unsigned int best_pixel_indices1_MSB=0;
     unsigned int best_pixel_indices1_LSB=0;
@@ -11746,7 +11748,7 @@ unsigned int compressBlockDifferentialExhaustive(uint8 *img,int width,int height
                         {
                             err_lower_adr = &err_lower[32*32*enc_color2[0]+32*enc_color2[1]];
                             err_right_adr = &err_right[32*32*enc_color2[0]+32*enc_color2[1]];
-                            // since enc_color[2] is between 4 and 29 we do not need to clamp the loop on the next line 
+                            // since enc_color[2] is between 4 and 29 we do not need to clamp the loop on the next line
                             for(enc_color2[2]=enc_color1[2]-4; enc_color2[2]<enc_color1[2]+4; enc_color2[2]++)
                             {
                                 error = error_lying+err_lower_adr[enc_color2[2]];
@@ -11851,35 +11853,35 @@ unsigned int compressBlockDifferentialExhaustive(uint8 *img,int width,int height
     else
         tryalltables_3bittable4x2(img,width,height,startx,starty+2,color_quant2,best_table2,best_pixel_indices2_MSB, best_pixel_indices2_LSB);
 
-    diff[0] = best_enc_color2[0]-best_enc_color1[0];    
-    diff[1] = best_enc_color2[1]-best_enc_color1[1];    
+    diff[0] = best_enc_color2[0]-best_enc_color1[0];
+    diff[1] = best_enc_color2[1]-best_enc_color1[1];
     diff[2] = best_enc_color2[2]-best_enc_color1[2];
 
     //     ETC1_RGB8_OES:
-    // 
+    //
     //     a) bit layout in bits 63 through 32 if diffbit = 0
-    // 
-    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+    //
+    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
     //      ---------------------------------------------------------------------------------------------------
     //     | base col1 | base col2 | base col1 | base col2 | base col1 | base col2 | table  | table  |diff|flip|
     //     | R1 (4bits)| R2 (4bits)| G1 (4bits)| G2 (4bits)| B1 (4bits)| B2 (4bits)| cw 1   | cw 2   |bit |bit |
     //      ---------------------------------------------------------------------------------------------------
-    //     
+    //
     //     b) bit layout in bits 63 through 32 if diffbit = 1
-    // 
-    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+    //
+    //      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32
     //      ---------------------------------------------------------------------------------------------------
     //     | base col1    | dcol 2 | base col1    | dcol 2 | base col 1   | dcol 2 | table  | table  |diff|flip|
     //     | R1' (5 bits) | dR2    | G1' (5 bits) | dG2    | B1' (5 bits) | dB2    | cw 1   | cw 2   |bit |bit |
     //      ---------------------------------------------------------------------------------------------------
-    // 
+    //
     //     c) bit layout in bits 31 through 0 (in both cases)
-    // 
+    //
     //      31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10  9  8  7  6  5  4  3   2   1  0
     //      --------------------------------------------------------------------------------------------------
-    //     |       most significant pixel index bits       |         least significant pixel index bits       |  
+    //     |       most significant pixel index bits       |         least significant pixel index bits       |
     //     | p| o| n| m| l| k| j| i| h| g| f| e| d| c| b| a| p| o| n| m| l| k| j| i| h| g| f| e| d| c | b | a |
-    //      --------------------------------------------------------------------------------------------------      
+    //      --------------------------------------------------------------------------------------------------
 
     diffbit = 1;
     compressed1 = 0;
@@ -11905,7 +11907,7 @@ unsigned int compressBlockDifferentialExhaustive(uint8 *img,int width,int height
     else
     {
         best_pixel_indices1_MSB |= (best_pixel_indices2_MSB << 2);
-        best_pixel_indices1_LSB |= (best_pixel_indices2_LSB << 2);        
+        best_pixel_indices1_LSB |= (best_pixel_indices2_LSB << 2);
         compressed2 = ((best_pixel_indices1_MSB & 0xffff) << 16) | (best_pixel_indices1_LSB & 0xffff);
     }
     return best_err;
@@ -11913,7 +11915,7 @@ unsigned int compressBlockDifferentialExhaustive(uint8 *img,int width,int height
 #endif
 
 #if EXHAUSTIVE_CODE_ACTIVE
-// This function uses real exhaustive search for the planar mode. 
+// This function uses real exhaustive search for the planar mode.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 void compressBlockPlanar57ExhaustivePerceptual(uint8 *img, int width,int height,int startx,int starty, unsigned int &compressed57_1, unsigned int &compressed57_2, unsigned int best_error_sofar, unsigned int best_error_planar_red, unsigned int best_error_planar_green, unsigned int best_error_planar_blue)
 {
@@ -11955,7 +11957,7 @@ void compressBlockPlanar57ExhaustivePerceptual(uint8 *img, int width,int height,
     //                                    B D D C
     //                                    B D C D
     //                                    B C D D
-    // where the error in 
+    // where the error in
     // O only depends on colorO
     // A only depends on colorO and colorH
     // B only depends on colorO and colorV
@@ -12029,7 +12031,7 @@ void compressBlockPlanar57ExhaustivePerceptual(uint8 *img, int width,int height,
     //                                    B D D C
     //                                    B D C D
     //                                    B C D D
-    // where the error in 
+    // where the error in
     // O only depends on colorO
     // A only depends on colorO and colorH
     // B only depends on colorO and colorV
@@ -12101,7 +12103,7 @@ void compressBlockPlanar57ExhaustivePerceptual(uint8 *img, int width,int height,
     //                                    B D D C
     //                                    B D C D
     //                                    B C D D
-    // where the error in 
+    // where the error in
     // O only depends on colorO
     // A only depends on colorO and colorH
     // B only depends on colorO and colorV
@@ -12168,12 +12170,12 @@ void compressBlockPlanar57ExhaustivePerceptual(uint8 *img, int width,int height,
     PUTBITS(     compressed57_2, best_colorV_enc[0], 6, 25);
     PUTBITS(     compressed57_2, best_colorV_enc[1], 7, 19);
     PUTBITS(     compressed57_2, best_colorV_enc[2], 6, 12);
-    
+
 }
 #endif
 
 #if EXHAUSTIVE_CODE_ACTIVE
-// This function uses real exhaustive search for the planar mode. 
+// This function uses real exhaustive search for the planar mode.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 void compressBlockPlanar57Exhaustive(uint8 *img, int width,int height,int startx,int starty, unsigned int &compressed57_1, unsigned int &compressed57_2, unsigned int best_error_sofar, unsigned int best_error_red, unsigned int best_error_green, unsigned int best_error_blue)
 {
@@ -12215,7 +12217,7 @@ void compressBlockPlanar57Exhaustive(uint8 *img, int width,int height,int startx
     //                                    B D D C
     //                                    B D C D
     //                                    B C D D
-    // where the error in 
+    // where the error in
     // O only depends on colorO
     // A only depends on colorO and colorH
     // B only depends on colorO and colorV
@@ -12274,7 +12276,7 @@ void compressBlockPlanar57Exhaustive(uint8 *img, int width,int height,int startx
     //                                    B D D C
     //                                    B D C D
     //                                    B C D D
-    // where the error in 
+    // where the error in
     // O only depends on colorO
     // A only depends on colorO and colorH
     // B only depends on colorO and colorV
@@ -12333,7 +12335,7 @@ void compressBlockPlanar57Exhaustive(uint8 *img, int width,int height,int startx
     //                                    B D D C
     //                                    B D C D
     //                                    B C D D
-    // where the error in 
+    // where the error in
     // O only depends on colorO
     // A only depends on colorO and colorH
     // B only depends on colorO and colorV
@@ -12397,7 +12399,7 @@ void compressBlockPlanar57Exhaustive(uint8 *img, int width,int height,int startx
     PUTBITS(     compressed57_2, best_colorV_enc[0], 6, 25);
     PUTBITS(     compressed57_2, best_colorV_enc[1], 7, 19);
     PUTBITS(     compressed57_2, best_colorV_enc[2], 6, 12);
-    
+
 }
 #endif
 
@@ -12406,9 +12408,9 @@ void compressBlockPlanar57Exhaustive(uint8 *img, int width,int height,int startx
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 void precalcError59T_col0_Rpercep1000(uint8* block, int colorRGB444_packed, unsigned int *precalc_err_col0_R)
 {
-    unsigned int //block_error = 0, 
+    unsigned int //block_error = 0,
                  //best_block_error = MAXERR1000,
-                 pixel_error, 
+                 pixel_error,
                  best_pixel_error;
     int diff;
     uint8 color;
@@ -12430,15 +12432,15 @@ void precalcError59T_col0_Rpercep1000(uint8* block, int colorRGB444_packed, unsi
             best_pixel_error = MAXERR1000;
 
             // Loop possible block colors
-            for (uint8 c = 0; c < 3; c++) 
+            for (uint8 c = 0; c < 3; c++)
             {
-            
+
                 diff = block[4*x + R] - CLAMP(0,possible_colors[c],255);
 
                 pixel_error = PERCEPTUAL_WEIGHT_R_SQUARED_TIMES1000*SQUARE(diff);
 
                 // Choose best error
-                if (pixel_error < best_pixel_error) 
+                if (pixel_error < best_pixel_error)
                     best_pixel_error = pixel_error;
             }
 
@@ -12446,7 +12448,7 @@ void precalcError59T_col0_Rpercep1000(uint8* block, int colorRGB444_packed, unsi
         }
 
     }
-        
+
 }
 #endif
 
@@ -12455,9 +12457,9 @@ void precalcError59T_col0_Rpercep1000(uint8* block, int colorRGB444_packed, unsi
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 void precalcError59T_col0_R(uint8* block, int colorRGB444_packed, unsigned int *precalc_err_col0_R)
 {
-    unsigned int //block_error = 0, 
-                 //     best_block_error = MAXIMUM_ERROR, 
-                             pixel_error, 
+    unsigned int //block_error = 0,
+                 //     best_block_error = MAXIMUM_ERROR,
+                             pixel_error,
                              best_pixel_error;
     int diff;
     uint8 color;
@@ -12479,15 +12481,15 @@ void precalcError59T_col0_R(uint8* block, int colorRGB444_packed, unsigned int *
             best_pixel_error = MAXIMUM_ERROR;
 
             // Loop possible block colors
-            for (uint8 c = 0; c < 3; c++) 
+            for (uint8 c = 0; c < 3; c++)
             {
-            
+
                 diff = block[4*x + R] - CLAMP(0,possible_colors[c],255);
 
                 pixel_error = SQUARE(diff);
 
                 // Choose best error
-                if (pixel_error < best_pixel_error) 
+                if (pixel_error < best_pixel_error)
                     best_pixel_error = pixel_error;
             }
             precalc_err_col0_R[((colorRGB444_packed>>8)*8 + d)*16 + x] = (unsigned int) best_pixel_error;
@@ -12501,9 +12503,9 @@ void precalcError59T_col0_R(uint8* block, int colorRGB444_packed, unsigned int *
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 void precalcError59T_col0_RGpercep1000(uint8* block, int colorRGB444_packed, unsigned int *precalc_err_col0_RG)
 {
-    unsigned int //block_error = 0, 
+    unsigned int //block_error = 0,
                  //   best_block_error = MAXERR1000,
-                 pixel_error, 
+                 pixel_error,
                  best_pixel_error;
     int diff[3];
     uint8 color[3];
@@ -12525,7 +12527,7 @@ void precalcError59T_col0_RGpercep1000(uint8* block, int colorRGB444_packed, uns
         possible_colors[2][R] = CLAMP(0,color[R] + table59T[d],255);
         possible_colors[2][G] = CLAMP(0,color[G] + table59T[d],255);
 
-        
+
 
         // Loop block
         for (int x = 0; x < 16; x++)
@@ -12533,16 +12535,16 @@ void precalcError59T_col0_RGpercep1000(uint8* block, int colorRGB444_packed, uns
             best_pixel_error = MAXERR1000;
 
             // Loop possible block colors
-            for (uint8 c = 0; c < 3; c++) 
+            for (uint8 c = 0; c < 3; c++)
             {
-            
+
                 diff[R] = block[4*x + R] - CLAMP(0,possible_colors[c][R],255);
                 diff[G] = block[4*x + G] - CLAMP(0,possible_colors[c][G],255);
 
                 pixel_error = PERCEPTUAL_WEIGHT_R_SQUARED_TIMES1000*SQUARE(diff[R]) + PERCEPTUAL_WEIGHT_G_SQUARED_TIMES1000*SQUARE(diff[G]);
 
                 // Choose best error
-                if (pixel_error < best_pixel_error) 
+                if (pixel_error < best_pixel_error)
                     best_pixel_error = pixel_error;
             }
             precalc_err_col0_RG[((colorRGB444_packed>>4)*8 + d)*16 + x] = (unsigned int) best_pixel_error;
@@ -12556,9 +12558,9 @@ void precalcError59T_col0_RGpercep1000(uint8* block, int colorRGB444_packed, uns
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 void precalcError59T_col0_RG(uint8* block, int colorRGB444_packed, unsigned int *precalc_err_col0_RG)
 {
-    unsigned int //block_error = 0, 
-                 //   best_block_error = MAXIMUM_ERROR, 
-                 pixel_error, 
+    unsigned int //block_error = 0,
+                 //   best_block_error = MAXIMUM_ERROR,
+                 pixel_error,
                  best_pixel_error;
     int diff[3];
     uint8 color[3];
@@ -12586,7 +12588,7 @@ void precalcError59T_col0_RG(uint8* block, int colorRGB444_packed, unsigned int 
             best_pixel_error = MAXIMUM_ERROR;
 
             // Loop possible block colors
-            for (uint8 c = 0; c < 3; c++) 
+            for (uint8 c = 0; c < 3; c++)
             {
                 diff[R] = block[4*x + R] - CLAMP(0,possible_colors[c][R],255);
                 diff[G] = block[4*x + G] - CLAMP(0,possible_colors[c][G],255);
@@ -12594,7 +12596,7 @@ void precalcError59T_col0_RG(uint8* block, int colorRGB444_packed, unsigned int 
                 pixel_error = SQUARE(diff[R]) + SQUARE(diff[G]);
 
                 // Choose best error
-                if (pixel_error < best_pixel_error) 
+                if (pixel_error < best_pixel_error)
                     best_pixel_error = pixel_error;
             }
             precalc_err_col0_RG[((colorRGB444_packed>>4)*8 + d)*16 + x] = (unsigned int) best_pixel_error;
@@ -12608,7 +12610,7 @@ void precalcError59T_col0_RG(uint8* block, int colorRGB444_packed, unsigned int 
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 void precalcError59T_col1_Rpercep1000(uint8* block, int colorRGB444_packed, unsigned int *precalc_err_col1_R)
 {
-    unsigned int pixel_error; 
+    unsigned int pixel_error;
     int diff;
     uint8 color;
 
@@ -12633,7 +12635,7 @@ void precalcError59T_col1_Rpercep1000(uint8* block, int colorRGB444_packed, unsi
  */
 void precalcError59T_col1_R(uint8* block, int colorRGB444_packed, unsigned int *precalc_err_col1_R)
 {
-    unsigned int pixel_error; 
+    unsigned int pixel_error;
     int diff;
     uint8 color;
 
@@ -12654,7 +12656,7 @@ void precalcError59T_col1_R(uint8* block, int colorRGB444_packed, unsigned int *
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 void precalcError59T_col1_RGpercep1000(uint8* block, int colorRGB444_packed, unsigned int *precalc_err_col1_RG)
 {
-    unsigned int pixel_error; 
+    unsigned int pixel_error;
     int diff[3];
     uint8 color[2];
 
@@ -12677,7 +12679,7 @@ void precalcError59T_col1_RGpercep1000(uint8* block, int colorRGB444_packed, uns
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 void precalcError59T_col1_RG(uint8* block, int colorRGB444_packed, unsigned int *precalc_err_col1_RG)
 {
-    unsigned int pixel_error; 
+    unsigned int pixel_error;
     int diff[3];
     uint8 color[2];
 
@@ -12700,9 +12702,9 @@ void precalcError59T_col1_RG(uint8* block, int colorRGB444_packed, unsigned int 
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 void precalcError59T_col0_RGBpercep1000(uint8* block, int colorRGB444_packed, unsigned int *precalc_err_col0_RGB)
 {
-    unsigned int // block_error = 0, 
+    unsigned int // block_error = 0,
                  // best_block_error = MAXERR1000,
-                 pixel_error, 
+                 pixel_error,
                  best_pixel_error;
     uint8 color[3];
     int possible_colors[3][3];
@@ -12763,7 +12765,7 @@ void precalcError59T_col0_RGBpercep1000(uint8* block, int colorRGB444_packed, un
     color[R] = (((colorRGB444_packed >> 8) ) << 4) | ((colorRGB444_packed >> 8) ) ;
     color[G] = (((colorRGB444_packed >> 4) & 0xf) << 4) | ((colorRGB444_packed >> 4) & 0xf) ;
     color[B] = (((colorRGB444_packed) & 0xf) << 4) | ((colorRGB444_packed) & 0xf) ;
-    
+
     /* Test all distances */
     /* unroll loop for (uint8 d = 0; d < 8; ++d) */
     {
@@ -12784,9 +12786,9 @@ void precalcError59T_col0_RGBpercep1000(uint8* block, int colorRGB444_packed, un
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
 void precalcError59T_col0_RGB(uint8* block, int colorRGB444_packed, unsigned int *precalc_err_col0_RGB)
 {
-    unsigned int // block_error = 0, 
-                 // best_block_error = MAXIMUM_ERROR, 
-                 pixel_error, 
+    unsigned int // block_error = 0,
+                 // best_block_error = MAXIMUM_ERROR,
+                 pixel_error,
                  best_pixel_error;
     uint8 color[3];
     int possible_colors[3][3];
@@ -12884,7 +12886,7 @@ void precalcError59T_col1_RGBpercep1000(uint8* block, int colorRGB444_packed, un
         diff[B] = block[4*x + B] - colorRGB[B];
 
         pixel_error = PERCEPTUAL_WEIGHT_R_SQUARED_TIMES1000*SQUARE(diff[R]) + PERCEPTUAL_WEIGHT_G_SQUARED_TIMES1000*SQUARE(diff[G]) + PERCEPTUAL_WEIGHT_B_SQUARED_TIMES1000*SQUARE(diff[B]);
-        
+
         precalc_err_col1_RGB[(colorRGB444_packed)*16 + x] = (unsigned int) pixel_error;
     }
 }
@@ -12919,9 +12921,9 @@ void precalcError59T_col1_RGB(uint8* block, int colorRGB444_packed, unsigned int
 #if EXHAUSTIVE_CODE_ACTIVE
 // Calculate a minimal error for the T-mode when compressing exhaustively.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-unsigned int calculateError59TusingPrecalcRperceptual1000(uint8* block, int *colorsRGB444_packed, unsigned int *precalc_err_col0_R, unsigned int *precalc_err_col1_R, unsigned int best_error_so_far) 
+unsigned int calculateError59TusingPrecalcRperceptual1000(uint8* block, int *colorsRGB444_packed, unsigned int *precalc_err_col0_R, unsigned int *precalc_err_col1_R, unsigned int best_error_so_far)
 {
-    unsigned int    block_error = 0, 
+    unsigned int    block_error = 0,
                     best_block_error = MAXERR1000;
 
     unsigned int *pixel_error_col0_base_adr;
@@ -12989,7 +12991,7 @@ unsigned int calculateError59TusingPrecalcRperceptual1000(uint8* block, int *col
         }\
         if (block_error < best_block_error)\
             best_block_error = block_error;\
-    
+
     pixel_error_col0_base_adr = &precalc_err_col0_R[((colorsRGB444_packed[0]>>8)*8)*16];
     pixel_error_col1_adr = &precalc_err_col1_R[((colorsRGB444_packed[1]>>8))*16];
 
@@ -13012,9 +13014,9 @@ unsigned int calculateError59TusingPrecalcRperceptual1000(uint8* block, int *col
 #if EXHAUSTIVE_CODE_ACTIVE
 // Calculate a minimal error for the T-mode when compressing exhaustively.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-unsigned int calculateError59TusingPrecalcR(uint8* block, int *colorsRGB444_packed, unsigned int *precalc_err_col0_R, unsigned int *precalc_err_col1_R, unsigned int best_error_so_far) 
+unsigned int calculateError59TusingPrecalcR(uint8* block, int *colorsRGB444_packed, unsigned int *precalc_err_col0_R, unsigned int *precalc_err_col1_R, unsigned int best_error_so_far)
 {
-    unsigned int    block_error = 0, 
+    unsigned int    block_error = 0,
                     best_block_error = MAXIMUM_ERROR;
 
     unsigned int *pixel_error_col0_base_adr;
@@ -13082,7 +13084,7 @@ unsigned int calculateError59TusingPrecalcR(uint8* block, int *colorsRGB444_pack
         }\
         if (block_error < best_block_error)\
             best_block_error = block_error;\
-    
+
     pixel_error_col0_base_adr = &precalc_err_col0_R[((colorsRGB444_packed[0]>>8)*8)*16];
     pixel_error_col1_adr = &precalc_err_col1_R[((colorsRGB444_packed[1]>>8))*16];
 
@@ -13099,7 +13101,7 @@ unsigned int calculateError59TusingPrecalcR(uint8* block, int *colorsRGB444_pack
         ONETABLE59R(6)
         ONETABLE59R(7)
     }
-    
+
     return best_block_error;
 }
 #endif
@@ -13107,9 +13109,9 @@ unsigned int calculateError59TusingPrecalcR(uint8* block, int *colorsRGB444_pack
 #if EXHAUSTIVE_CODE_ACTIVE
 // Calculate a minimal error for the T-mode when compressing exhaustively.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-unsigned int calculateError59TusingPrecalcRGperceptual1000(uint8* block, int *colorsRGB444_packed, unsigned int *precalc_err_col0_RG, unsigned int *precalc_err_col1_RG, unsigned int best_error_so_far) 
+unsigned int calculateError59TusingPrecalcRGperceptual1000(uint8* block, int *colorsRGB444_packed, unsigned int *precalc_err_col0_RG, unsigned int *precalc_err_col1_RG, unsigned int best_error_so_far)
 {
-    unsigned int    block_error = 0, 
+    unsigned int    block_error = 0,
                     best_block_error = MAXERR1000;
 
     unsigned int *pixel_error_col0_adr, *pixel_error_col1_adr;
@@ -13203,9 +13205,9 @@ unsigned int calculateError59TusingPrecalcRGperceptual1000(uint8* block, int *co
 #if EXHAUSTIVE_CODE_ACTIVE
 // Calculate a minimal error for the T-mode when compressing exhaustively.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-unsigned int calculateError59TusingPrecalcRG(uint8* block, int *colorsRGB444_packed, unsigned int *precalc_err_col0_RG, unsigned int *precalc_err_col1_RG, unsigned int best_error_so_far) 
+unsigned int calculateError59TusingPrecalcRG(uint8* block, int *colorsRGB444_packed, unsigned int *precalc_err_col0_RG, unsigned int *precalc_err_col1_RG, unsigned int best_error_so_far)
 {
-    unsigned int    block_error = 0, 
+    unsigned int    block_error = 0,
                     best_block_error = MAXIMUM_ERROR;
 
     unsigned int *pixel_error_col0_adr, *pixel_error_col1_adr;
@@ -13295,9 +13297,9 @@ unsigned int calculateError59TusingPrecalcRG(uint8* block, int *colorsRGB444_pac
 #if EXHAUSTIVE_CODE_ACTIVE
 // Calculate a minimal error for the T-mode when compressing exhaustively.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-unsigned int calculateError59TusingPrecalcRGBperceptual1000(uint8* block, int *colorsRGB444_packed, unsigned int *precalc_err_col0_RGB, unsigned int *precalc_err_col1_RGB, unsigned int best_error_so_far) 
+unsigned int calculateError59TusingPrecalcRGBperceptual1000(uint8* block, int *colorsRGB444_packed, unsigned int *precalc_err_col0_RGB, unsigned int *precalc_err_col1_RGB, unsigned int best_error_so_far)
 {
-    unsigned int    block_error = 0, 
+    unsigned int    block_error = 0,
                           best_block_error = MAXERR1000;
     unsigned int *pixel_error_col0_adr, *pixel_error_col1_adr;
     unsigned int *pixel_error_col0_base_adr;
@@ -13386,9 +13388,9 @@ unsigned int calculateError59TusingPrecalcRGBperceptual1000(uint8* block, int *c
 #if EXHAUSTIVE_CODE_ACTIVE
 // Calculate a minimal error for the T-mode when compressing exhaustively.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-unsigned int calculateError59TusingPrecalcRGB(uint8* block, int *colorsRGB444_packed, unsigned int *precalc_err_col0_RGB, unsigned int *precalc_err_col1_RGB, unsigned int best_error_so_far) 
+unsigned int calculateError59TusingPrecalcRGB(uint8* block, int *colorsRGB444_packed, unsigned int *precalc_err_col0_RGB, unsigned int *precalc_err_col1_RGB, unsigned int best_error_so_far)
 {
-    unsigned int    block_error = 0, 
+    unsigned int    block_error = 0,
                           best_block_error = MAXIMUM_ERROR;
     unsigned int *pixel_error_col0_adr, *pixel_error_col1_adr;
     unsigned int *pixel_error_col0_base_adr;
@@ -13475,7 +13477,7 @@ unsigned int calculateError59TusingPrecalcRGB(uint8* block, int *colorsRGB444_pa
 #endif
 
 #if EXHAUSTIVE_CODE_ACTIVE
-// The below code should compress the block to 59 bits. 
+// The below code should compress the block to 59 bits.
 // This is supposed to match the first of the three modes in TWOTIMER.
 //
 //|63 62 61 60 59|58 57 56 55|54 53 52 51|50 49 48 47|46 45 44 43|42 41 40 39|38 37 36 35|34 33 32|
@@ -13486,9 +13488,9 @@ unsigned int calculateError59TusingPrecalcRGB(uint8* block, int *colorsRGB444_pa
 //
 // Note that this method might not return the best possible compression for the T-mode. It will only do so if the best possible T-representation
 // is less than best_error_so_far. To guarantee that the best possible T-representation is found, the function should be called using
-// best_error_so_far = 255*255*3*16, which is the maximum error for a block. 
+// best_error_so_far = 255*255*3*16, which is the maximum error for a block.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-unsigned int compressBlockTHUMB59TExhaustivePerceptual(uint8 *img,int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2, unsigned int best_error_so_far) 
+unsigned int compressBlockTHUMB59TExhaustivePerceptual(uint8 *img,int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2, unsigned int best_error_so_far)
 {
     uint8 colorsRGB444[2][3];
     unsigned int pixel_indices;
@@ -13511,7 +13513,7 @@ unsigned int compressBlockTHUMB59TExhaustivePerceptual(uint8 *img,int width,int 
     unsigned int best_error_using_Tmode;
 
     // First compress block quickly to a resonable quality so that we can
-    // rule out all blocks that are of worse quality than that. 
+    // rule out all blocks that are of worse quality than that.
     best_error_using_Tmode = (unsigned int) compressBlockTHUMB59TFastestOnlyColorPerceptual1000(img, width, height, startx, starty, best_colorsRGB444_packed);
     if(best_error_using_Tmode < best_error_so_far)
         best_error_so_far = best_error_using_Tmode;
@@ -13640,20 +13642,20 @@ unsigned int compressBlockTHUMB59TExhaustivePerceptual(uint8 *img,int width,int 
     free(precalc_err_col0_R);
     free(precalc_err_col1_R);
 
-    // We have got the two best colors. Now find the best distance and pixel indices. 
+    // We have got the two best colors. Now find the best distance and pixel indices.
 
     // Color numbering are reversed between precalc and noSwap
     colorsRGB444[0][0] = (best_colorsRGB444_packed[1] >> 8) & 0xf;
     colorsRGB444[0][1] = (best_colorsRGB444_packed[1] >> 4) & 0xf;
     colorsRGB444[0][2] = (best_colorsRGB444_packed[1] >> 0) & 0xf;
-    
+
     colorsRGB444[1][0] = (best_colorsRGB444_packed[0] >> 8) & 0xf;
     colorsRGB444[1][1] = (best_colorsRGB444_packed[0] >> 4) & 0xf;
     colorsRGB444[1][2] = (best_colorsRGB444_packed[0] >> 0) & 0xf;
 
-    calculateError59TnoSwapPerceptual1000(img, width, startx, starty, colorsRGB444, distance, pixel_indices);            
+    calculateError59TnoSwapPerceptual1000(img, width, startx, starty, colorsRGB444, distance, pixel_indices);
 
-    // Put the compress params into the compression block 
+    // Put the compress params into the compression block
     packBlock59T(colorsRGB444, distance, pixel_indices, compressed1, compressed2);
 
     return best_error_using_Tmode;
@@ -13661,7 +13663,7 @@ unsigned int compressBlockTHUMB59TExhaustivePerceptual(uint8 *img,int width,int 
 #endif
 
 #if EXHAUSTIVE_CODE_ACTIVE
-// The below code should compress the block to 59 bits. 
+// The below code should compress the block to 59 bits.
 // This is supposed to match the first of the three modes in TWOTIMER.
 //
 //|63 62 61 60 59|58 57 56 55|54 53 52 51|50 49 48 47|46 45 44 43|42 41 40 39|38 37 36 35|34 33 32|
@@ -13672,9 +13674,9 @@ unsigned int compressBlockTHUMB59TExhaustivePerceptual(uint8 *img,int width,int 
 //
 // Note that this method might not return the best possible compression for the T-mode. It will only do so if the best possible T-representation
 // is less than best_error_so_far. To guarantee that the best possible T-representation is found, the function should be called using
-// best_error_so_far = 255*255*3*16, which is the maximum error for a block. 
+// best_error_so_far = 255*255*3*16, which is the maximum error for a block.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-unsigned int compressBlockTHUMB59TExhaustive(uint8 *img,int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2, unsigned int best_error_so_far) 
+unsigned int compressBlockTHUMB59TExhaustive(uint8 *img,int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2, unsigned int best_error_so_far)
 {
     uint8 colorsRGB444[2][3];
     unsigned int pixel_indices;
@@ -13697,7 +13699,7 @@ unsigned int compressBlockTHUMB59TExhaustive(uint8 *img,int width,int height,int
     unsigned int best_error_using_Tmode;
 
     // First compress block quickly to a resonable quality so that we can
-    // rule out all blocks that are of worse quality than that. 
+    // rule out all blocks that are of worse quality than that.
     best_error_using_Tmode = (unsigned int) compressBlockTHUMB59TFastestOnlyColor(img, width, height, startx, starty, best_colorsRGB444_packed);
     if(best_error_using_Tmode < best_error_so_far)
         best_error_so_far = best_error_using_Tmode;
@@ -13827,20 +13829,20 @@ unsigned int compressBlockTHUMB59TExhaustive(uint8 *img,int width,int height,int
     free(precalc_err_col0_R);
     free(precalc_err_col1_R);
 
-    // We have got the two best colors. Now find the best distance and pixel indices. 
+    // We have got the two best colors. Now find the best distance and pixel indices.
 
     // Color numbering are reversed between precalc and noSwap
     colorsRGB444[0][0] = (best_colorsRGB444_packed[1] >> 8) & 0xf;
     colorsRGB444[0][1] = (best_colorsRGB444_packed[1] >> 4) & 0xf;
     colorsRGB444[0][2] = (best_colorsRGB444_packed[1] >> 0) & 0xf;
-    
+
     colorsRGB444[1][0] = (best_colorsRGB444_packed[0] >> 8) & 0xf;
     colorsRGB444[1][1] = (best_colorsRGB444_packed[0] >> 4) & 0xf;
     colorsRGB444[1][2] = (best_colorsRGB444_packed[0] >> 0) & 0xf;
 
-    calculateError59TnoSwap(img, width, startx, starty, colorsRGB444, distance, pixel_indices);            
+    calculateError59TnoSwap(img, width, startx, starty, colorsRGB444, distance, pixel_indices);
 
-    // Put the compress params into the compression block 
+    // Put the compress params into the compression block
     packBlock59T(colorsRGB444, distance, pixel_indices, compressed1, compressed2);
 
     return best_error_using_Tmode;
@@ -13850,47 +13852,47 @@ unsigned int compressBlockTHUMB59TExhaustive(uint8 *img,int width,int height,int
 #if EXHAUSTIVE_CODE_ACTIVE
 // Precalculates tables used in the exhaustive compression of the H-mode.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-void precalcErrorR_58Hperceptual1000(uint8* srcimg, int width, int startx, int starty, uint8 (colorsRGB444)[2][3],int colorRGB444_packed, unsigned int *precalc_errR) 
+void precalcErrorR_58Hperceptual1000(uint8* srcimg, int width, int startx, int starty, uint8 (colorsRGB444)[2][3],int colorRGB444_packed, unsigned int *precalc_errR)
 {
-    unsigned int block_error = 0, 
-           //best_block_error = MAXERR1000, 
-           pixel_error, 
+    unsigned int block_error = 0,
+           //best_block_error = MAXERR1000,
+           pixel_error,
            best_pixel_error;
     int diff[3];
     unsigned int pixel_colors;
     uint8 possible_colors[2][3];
     uint8 colors[2][3];
-    
+
     decompressColor(R_BITS58H, G_BITS58H, B_BITS58H, colorsRGB444, colors);
 
     // Test all distances
-    for (uint8 d = 0; d < BINPOW(TABLE_BITS_58H); ++d) 
+    for (uint8 d = 0; d < BINPOW(TABLE_BITS_58H); ++d)
     {
         possible_colors[0][R] = CLAMP(0,colors[0][R] - table58H[d],255);
         possible_colors[1][R] = CLAMP(0,colors[0][R] + table58H[d],255);
 
-        block_error = 0;    
+        block_error = 0;
         pixel_colors = 0;
 
         // Loop block
-        for (size_t y = 0; y < BLOCKHEIGHT; ++y) 
+        for (size_t y = 0; y < BLOCKHEIGHT; ++y)
         {
-            for (size_t x = 0; x < BLOCKWIDTH; ++x) 
+            for (size_t x = 0; x < BLOCKWIDTH; ++x)
             {
                 best_pixel_error = MAXERR1000;
 
                 // Loop possible block colors
-                for (uint8 c = 0; c < 2; ++c) 
+                for (uint8 c = 0; c < 2; ++c)
                 {
                     diff[R] = srcimg[3*((starty+y)*width+startx+x)+R] - CLAMP(0,possible_colors[c][R],255);
 
                     pixel_error =    PERCEPTUAL_WEIGHT_R_SQUARED_TIMES1000*SQUARE(diff[R]);
 
                     // Choose best error
-                    if (pixel_error < best_pixel_error) 
+                    if (pixel_error < best_pixel_error)
                     {
                         best_pixel_error = pixel_error;
-                    } 
+                    }
                 }
                 precalc_errR[((colorRGB444_packed>>8)*8 + d)*16 + (y*4)+x] = (unsigned int) best_pixel_error;
             }
@@ -13902,47 +13904,47 @@ void precalcErrorR_58Hperceptual1000(uint8* srcimg, int width, int startx, int s
 #if EXHAUSTIVE_CODE_ACTIVE
 // Precalculates tables used in the exhaustive compression of the H-mode.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-void precalcErrorR_58H(uint8* srcimg, int width, int startx, int starty, uint8 (colorsRGB444)[2][3],int colorRGB444_packed, unsigned int *precalc_errR) 
+void precalcErrorR_58H(uint8* srcimg, int width, int startx, int starty, uint8 (colorsRGB444)[2][3],int colorRGB444_packed, unsigned int *precalc_errR)
 {
-    double block_error = 0, 
-           //best_block_error = MAXIMUM_ERROR, 
-           pixel_error, 
+    double block_error = 0,
+           //best_block_error = MAXIMUM_ERROR,
+           pixel_error,
            best_pixel_error;
     int diff[3];
     unsigned int pixel_colors;
     uint8 possible_colors[2][3];
     uint8 colors[2][3];
-    
+
     decompressColor(R_BITS58H, G_BITS58H, B_BITS58H, colorsRGB444, colors);
 
     // Test all distances
-    for (uint8 d = 0; d < BINPOW(TABLE_BITS_58H); ++d) 
+    for (uint8 d = 0; d < BINPOW(TABLE_BITS_58H); ++d)
     {
         possible_colors[0][R] = CLAMP(0,colors[0][R] - table58H[d],255);
         possible_colors[1][R] = CLAMP(0,colors[0][R] + table58H[d],255);
 
-        block_error = 0;    
+        block_error = 0;
         pixel_colors = 0;
 
         // Loop block
-        for (size_t y = 0; y < BLOCKHEIGHT; ++y) 
+        for (size_t y = 0; y < BLOCKHEIGHT; ++y)
         {
-            for (size_t x = 0; x < BLOCKWIDTH; ++x) 
+            for (size_t x = 0; x < BLOCKWIDTH; ++x)
             {
                 best_pixel_error = MAXIMUM_ERROR;
 
                 // Loop possible block colors
-                for (uint8 c = 0; c < 2; ++c) 
+                for (uint8 c = 0; c < 2; ++c)
                 {
                     diff[R] = srcimg[3*((starty+y)*width+startx+x)+R] - CLAMP(0,possible_colors[c][R],255);
 
                     pixel_error =    weight[R]*SQUARE(diff[R]);
 
                     // Choose best error
-                    if (pixel_error < best_pixel_error) 
+                    if (pixel_error < best_pixel_error)
                     {
                         best_pixel_error = pixel_error;
-                    } 
+                    }
                 }
                 precalc_errR[((colorRGB444_packed>>8)*8 + d)*16 + (y*4)+x] = (unsigned int) best_pixel_error;
             }
@@ -13954,39 +13956,39 @@ void precalcErrorR_58H(uint8* srcimg, int width, int startx, int starty, uint8 (
 #if EXHAUSTIVE_CODE_ACTIVE
 // Precalculates tables used in the exhaustive compression of the H-mode.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-void precalcErrorRG_58Hperceptual1000(uint8* srcimg, int width, int startx, int starty, uint8 (colorsRGB444)[2][3],int colorRGB444_packed, unsigned int *precalc_errRG) 
+void precalcErrorRG_58Hperceptual1000(uint8* srcimg, int width, int startx, int starty, uint8 (colorsRGB444)[2][3],int colorRGB444_packed, unsigned int *precalc_errRG)
 {
-    unsigned int block_error = 0, 
+    unsigned int block_error = 0,
            //best_block_error = MAXERR1000,
-           pixel_error, 
+           pixel_error,
            best_pixel_error;
     int diff[3];
     unsigned int pixel_colors;
     uint8 possible_colors[2][3];
     uint8 colors[2][3];
-    
+
     decompressColor(R_BITS58H, G_BITS58H, B_BITS58H, colorsRGB444, colors);
 
     // Test all distances
-    for (uint8 d = 0; d < BINPOW(TABLE_BITS_58H); ++d) 
+    for (uint8 d = 0; d < BINPOW(TABLE_BITS_58H); ++d)
     {
         possible_colors[0][R] = CLAMP(0,colors[0][R] - table58H[d],255);
         possible_colors[0][G] = CLAMP(0,colors[0][G] - table58H[d],255);
         possible_colors[1][R] = CLAMP(0,colors[0][R] + table58H[d],255);
         possible_colors[1][G] = CLAMP(0,colors[0][G] + table58H[d],255);
 
-        block_error = 0;    
+        block_error = 0;
         pixel_colors = 0;
 
         // Loop block
-        for (size_t y = 0; y < BLOCKHEIGHT; ++y) 
+        for (size_t y = 0; y < BLOCKHEIGHT; ++y)
         {
-            for (size_t x = 0; x < BLOCKWIDTH; ++x) 
+            for (size_t x = 0; x < BLOCKWIDTH; ++x)
             {
                 best_pixel_error = MAXERR1000;
 
                 // Loop possible block colors
-                for (uint8 c = 0; c < 2; ++c) 
+                for (uint8 c = 0; c < 2; ++c)
                 {
                     diff[R] = srcimg[3*((starty+y)*width+startx+x)+R] - CLAMP(0,possible_colors[c][R],255);
                     diff[G] = srcimg[3*((starty+y)*width+startx+x)+G] - CLAMP(0,possible_colors[c][G],255);
@@ -13995,10 +13997,10 @@ void precalcErrorRG_58Hperceptual1000(uint8* srcimg, int width, int startx, int 
                                     PERCEPTUAL_WEIGHT_G_SQUARED_TIMES1000*SQUARE(diff[G]);
 
                     // Choose best error
-                    if (pixel_error < best_pixel_error) 
+                    if (pixel_error < best_pixel_error)
                     {
                         best_pixel_error = pixel_error;
-                    } 
+                    }
                 }
                 precalc_errRG[((colorRGB444_packed>>4)*8 + d)*16 + (y*4)+x] = (unsigned int) best_pixel_error;
             }
@@ -14010,39 +14012,39 @@ void precalcErrorRG_58Hperceptual1000(uint8* srcimg, int width, int startx, int 
 #if EXHAUSTIVE_CODE_ACTIVE
 // Precalculates tables used in the exhaustive compression of the H-mode.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-void precalcErrorRG_58H(uint8* srcimg, int width, int startx, int starty, uint8 (colorsRGB444)[2][3],int colorRGB444_packed, unsigned int *precalc_errRG) 
+void precalcErrorRG_58H(uint8* srcimg, int width, int startx, int starty, uint8 (colorsRGB444)[2][3],int colorRGB444_packed, unsigned int *precalc_errRG)
 {
-    double block_error = 0, 
-           //best_block_error = MAXIMUM_ERROR, 
-           pixel_error, 
+    double block_error = 0,
+           //best_block_error = MAXIMUM_ERROR,
+           pixel_error,
            best_pixel_error;
     int diff[3];
     unsigned int pixel_colors;
     uint8 possible_colors[2][3];
     uint8 colors[2][3];
-    
+
     decompressColor(R_BITS58H, G_BITS58H, B_BITS58H, colorsRGB444, colors);
 
     // Test all distances
-    for (uint8 d = 0; d < BINPOW(TABLE_BITS_58H); ++d) 
+    for (uint8 d = 0; d < BINPOW(TABLE_BITS_58H); ++d)
     {
         possible_colors[0][R] = CLAMP(0,colors[0][R] - table58H[d],255);
         possible_colors[0][G] = CLAMP(0,colors[0][G] - table58H[d],255);
         possible_colors[1][R] = CLAMP(0,colors[0][R] + table58H[d],255);
         possible_colors[1][G] = CLAMP(0,colors[0][G] + table58H[d],255);
 
-        block_error = 0;    
+        block_error = 0;
         pixel_colors = 0;
 
         // Loop block
-        for (size_t y = 0; y < BLOCKHEIGHT; ++y) 
+        for (size_t y = 0; y < BLOCKHEIGHT; ++y)
         {
-            for (size_t x = 0; x < BLOCKWIDTH; ++x) 
+            for (size_t x = 0; x < BLOCKWIDTH; ++x)
             {
                 best_pixel_error = MAXIMUM_ERROR;
 
                 // Loop possible block colors
-                for (uint8 c = 0; c < 2; ++c) 
+                for (uint8 c = 0; c < 2; ++c)
                 {
                     diff[R] = srcimg[3*((starty+y)*width+startx+x)+R] - CLAMP(0,possible_colors[c][R],255);
                     diff[G] = srcimg[3*((starty+y)*width+startx+x)+G] - CLAMP(0,possible_colors[c][G],255);
@@ -14051,10 +14053,10 @@ void precalcErrorRG_58H(uint8* srcimg, int width, int startx, int starty, uint8 
                                     weight[G]*SQUARE(diff[G]);
 
                     // Choose best error
-                    if (pixel_error < best_pixel_error) 
+                    if (pixel_error < best_pixel_error)
                     {
                         best_pixel_error = pixel_error;
-                    } 
+                    }
                 }
                 precalc_errRG[((colorRGB444_packed>>4)*8 + d)*16 + (y*4)+x] = (unsigned int) best_pixel_error;
             }
@@ -14066,9 +14068,9 @@ void precalcErrorRG_58H(uint8* srcimg, int width, int startx, int starty, uint8 
 #if EXHAUSTIVE_CODE_ACTIVE
 // Precalculates a table used in the exhaustive compression of the H-mode.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-void precalcError58Hperceptual1000(uint8* block, uint8 (colorsRGB444)[2][3],int colorRGB444_packed, unsigned int *precalc_err) 
+void precalcError58Hperceptual1000(uint8* block, uint8 (colorsRGB444)[2][3],int colorRGB444_packed, unsigned int *precalc_err)
 {
-    unsigned int pixel_error, 
+    unsigned int pixel_error,
            best_pixel_error;
     int possible_colors[2][3];
     uint8 colors[2][3];
@@ -14143,9 +14145,9 @@ void precalcError58Hperceptual1000(uint8* block, uint8 (colorsRGB444)[2][3],int 
 #if EXHAUSTIVE_CODE_ACTIVE
 // Precalculates a table used in the exhaustive compression of the H-mode.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-void precalcError58H(uint8* block, uint8 (colorsRGB444)[2][3],int colorRGB444_packed, unsigned int *precalc_err) 
+void precalcError58H(uint8* block, uint8 (colorsRGB444)[2][3],int colorRGB444_packed, unsigned int *precalc_err)
 {
-    unsigned int pixel_error, 
+    unsigned int pixel_error,
            best_pixel_error;
     int possible_colors[2][3];
     uint8 colors[2][3];
@@ -14216,7 +14218,7 @@ void precalcError58H(uint8* block, uint8 (colorsRGB444)[2][3],int colorRGB444_pa
 #if EXHAUSTIVE_CODE_ACTIVE
 // Calculate a minimum error for the H-mode when doing exhaustive compression.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-unsigned int calculateErrorFromPrecalcR58Hperceptual1000(int *colorsRGB444_packed, unsigned int *precalc_errR, unsigned int best_err_so_far) 
+unsigned int calculateErrorFromPrecalcR58Hperceptual1000(int *colorsRGB444_packed, unsigned int *precalc_errR, unsigned int best_err_so_far)
 {
     unsigned int block_error = 0;
     unsigned int best_block_error = MAXERR1000;
@@ -14233,9 +14235,9 @@ unsigned int calculateErrorFromPrecalcR58Hperceptual1000(int *colorsRGB444_packe
         block_error += precalc_col2tab[value];\
 
     // Test all distances
-    for (uint8 d = 0; d < 8; ++d) 
+    for (uint8 d = 0; d < 8; ++d)
     {
-        block_error = 0;    
+        block_error = 0;
         precalc_col1tab = &precalc_col1[d*16];
         precalc_col2tab = &precalc_col2[d*16];
         // Loop block
@@ -14304,7 +14306,7 @@ unsigned int calculateErrorFromPrecalcR58Hperceptual1000(int *colorsRGB444_packe
         }
         /* end unroll loop */
 
-        if (block_error < best_block_error) 
+        if (block_error < best_block_error)
             best_block_error = block_error;
     }
     return best_block_error;
@@ -14314,7 +14316,7 @@ unsigned int calculateErrorFromPrecalcR58Hperceptual1000(int *colorsRGB444_packe
 #if EXHAUSTIVE_CODE_ACTIVE
 // Calculate a minimum error for the H-mode when doing exhaustive compression.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-unsigned int calculateErrorFromPrecalcR58H(int *colorsRGB444_packed, unsigned int *precalc_errR, unsigned int best_err_so_far) 
+unsigned int calculateErrorFromPrecalcR58H(int *colorsRGB444_packed, unsigned int *precalc_errR, unsigned int best_err_so_far)
 {
     unsigned int block_error = 0;
     unsigned int best_block_error = MAXIMUM_ERROR;
@@ -14331,9 +14333,9 @@ unsigned int calculateErrorFromPrecalcR58H(int *colorsRGB444_packed, unsigned in
         block_error += precalc_col2tab[value];\
 
     // Test all distances
-    for (uint8 d = 0; d < 8; ++d) 
+    for (uint8 d = 0; d < 8; ++d)
     {
-        block_error = 0;    
+        block_error = 0;
         precalc_col1tab = &precalc_col1[d*16];
         precalc_col2tab = &precalc_col2[d*16];
         // Loop block
@@ -14402,7 +14404,7 @@ unsigned int calculateErrorFromPrecalcR58H(int *colorsRGB444_packed, unsigned in
         }
         /* end unroll loop */
 
-        if (block_error < best_block_error) 
+        if (block_error < best_block_error)
             best_block_error = block_error;
 
     }
@@ -14413,7 +14415,7 @@ unsigned int calculateErrorFromPrecalcR58H(int *colorsRGB444_packed, unsigned in
 #if EXHAUSTIVE_CODE_ACTIVE
 // Calculate a minimum error for the H-mode when doing exhaustive compression.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-unsigned int calculateErrorFromPrecalcRG58Hperceptual1000(int *colorsRGB444_packed, unsigned int *precalc_errRG, unsigned int best_err_so_far) 
+unsigned int calculateErrorFromPrecalcRG58Hperceptual1000(int *colorsRGB444_packed, unsigned int *precalc_errRG, unsigned int best_err_so_far)
 {
     unsigned int block_error = 0;
     unsigned int best_block_error = MAXIMUM_ERROR;
@@ -14430,9 +14432,9 @@ unsigned int calculateErrorFromPrecalcRG58Hperceptual1000(int *colorsRGB444_pack
         block_error += precalc_col2tab[value];\
 
     // Test all distances
-    for (uint8 d = 0; d < 8; ++d) 
+    for (uint8 d = 0; d < 8; ++d)
     {
-        block_error = 0;    
+        block_error = 0;
         precalc_col1tab = &precalc_col1[d*16];
         precalc_col2tab = &precalc_col2[d*16];
         // Loop block
@@ -14501,7 +14503,7 @@ unsigned int calculateErrorFromPrecalcRG58Hperceptual1000(int *colorsRGB444_pack
         }
         /* end unroll loop */
 
-        if (block_error < best_block_error) 
+        if (block_error < best_block_error)
             best_block_error = block_error;
     }
     return best_block_error;
@@ -14511,7 +14513,7 @@ unsigned int calculateErrorFromPrecalcRG58Hperceptual1000(int *colorsRGB444_pack
 #if EXHAUSTIVE_CODE_ACTIVE
 // Calculate a minimum error for the H-mode when doing exhaustive compression.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-unsigned int calculateErrorFromPrecalcRG58H(int *colorsRGB444_packed, unsigned int *precalc_errRG, unsigned int best_err_so_far) 
+unsigned int calculateErrorFromPrecalcRG58H(int *colorsRGB444_packed, unsigned int *precalc_errRG, unsigned int best_err_so_far)
 {
     unsigned int block_error = 0;
     unsigned int best_block_error = MAXIMUM_ERROR;
@@ -14528,9 +14530,9 @@ unsigned int calculateErrorFromPrecalcRG58H(int *colorsRGB444_packed, unsigned i
         block_error += precalc_col2tab[value];\
 
     // Test all distances
-    for (uint8 d = 0; d < 8; ++d) 
+    for (uint8 d = 0; d < 8; ++d)
     {
-        block_error = 0;    
+        block_error = 0;
         precalc_col1tab = &precalc_col1[d*16];
         precalc_col2tab = &precalc_col2[d*16];
         // Loop block
@@ -14599,7 +14601,7 @@ unsigned int calculateErrorFromPrecalcRG58H(int *colorsRGB444_packed, unsigned i
         }
         /* end unroll loop */
 
-        if (block_error < best_block_error) 
+        if (block_error < best_block_error)
             best_block_error = block_error;
     }
     return best_block_error;
@@ -14609,7 +14611,7 @@ unsigned int calculateErrorFromPrecalcRG58H(int *colorsRGB444_packed, unsigned i
 #if EXHAUSTIVE_CODE_ACTIVE
 // Calculate a minimum error for the H-mode when doing exhaustive compression.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-unsigned int calculateErrorFromPrecalc58Hperceptual1000(int *colorsRGB444_packed, unsigned int *precalc_err, unsigned int total_best_err) 
+unsigned int calculateErrorFromPrecalc58Hperceptual1000(int *colorsRGB444_packed, unsigned int *precalc_err, unsigned int total_best_err)
 {
     unsigned int block_error;\
     unsigned int *precalc_col1, *precalc_col2;\
@@ -14701,7 +14703,7 @@ unsigned int calculateErrorFromPrecalc58Hperceptual1000(int *colorsRGB444_packed
 #if EXHAUSTIVE_CODE_ACTIVE
 // Calculate a minimum error for the H-mode when doing exhaustive compression.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-unsigned int calculateErrorFromPrecalc58H(int *colorsRGB444_packed, unsigned int *precalc_err, unsigned int total_best_err) 
+unsigned int calculateErrorFromPrecalc58H(int *colorsRGB444_packed, unsigned int *precalc_err, unsigned int total_best_err)
 {
     unsigned int block_error;\
     unsigned int *precalc_col1, *precalc_col2;\
@@ -14791,7 +14793,7 @@ unsigned int calculateErrorFromPrecalc58H(int *colorsRGB444_packed, unsigned int
 #endif
 
 #if EXHAUSTIVE_CODE_ACTIVE
-// The below code should compress the block to 58 bits. 
+// The below code should compress the block to 58 bits.
 // This is supposed to match the first of the three modes in TWOTIMER.
 // The bit layout is thought to be:
 //
@@ -14801,11 +14803,11 @@ unsigned int calculateErrorFromPrecalc58H(int *colorsRGB444_packed, unsigned int
 //|31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10 09 08 07 06 05 04 03 02 01 00|
 //|----------------------------------------index bits---------------------------------------------|
 //
-// The distance d is three bits, d2 (MSB), d1 and d0 (LSB). d0 is not stored explicitly. 
+// The distance d is three bits, d2 (MSB), d1 and d0 (LSB). d0 is not stored explicitly.
 // Instead if the 12-bit word red0,green0,blue0 < red1,green1,blue1, d0 is assumed to be 0.
 // Else, it is assumed to be 1.
 
-// The below code should compress the block to 58 bits. 
+// The below code should compress the block to 58 bits.
 // This is supposed to match the first of the three modes in TWOTIMER.
 // The bit layout is thought to be:
 //
@@ -14815,11 +14817,11 @@ unsigned int calculateErrorFromPrecalc58H(int *colorsRGB444_packed, unsigned int
 //|31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10 09 08 07 06 05 04 03 02 01 00|
 //|----------------------------------------index bits---------------------------------------------|
 //
-// The distance d is three bits, d2 (MSB), d1 and d0 (LSB). d0 is not stored explicitly. 
+// The distance d is three bits, d2 (MSB), d1 and d0 (LSB). d0 is not stored explicitly.
 // Instead if the 12-bit word red0,green0,blue0 < red1,green1,blue1, d0 is assumed to be 0.
 // Else, it is assumed to be 1.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-unsigned int compressBlockTHUMB58HExhaustivePerceptual(uint8 *img,int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2, unsigned int best_error_so_far) 
+unsigned int compressBlockTHUMB58HExhaustivePerceptual(uint8 *img,int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2, unsigned int best_error_so_far)
 {
     unsigned int best_error_using_Hmode;
     uint8 best_colorsRGB444[2][3];
@@ -14838,7 +14840,7 @@ unsigned int compressBlockTHUMB58HExhaustivePerceptual(uint8 *img,int width,int 
     unsigned int *precalc_err_R;        // smallest pixel error for an entire table
     uint8 block[4*4*4];
 
-    best_error_using_Hmode = MAXERR1000;    
+    best_error_using_Hmode = MAXERR1000;
 
     precalc_err = (unsigned int*) malloc(4096*8*16*sizeof(unsigned int));
     if(!precalc_err){printf("Out of memory allocating \n");exit(1);}
@@ -14935,7 +14937,7 @@ unsigned int compressBlockTHUMB58HExhaustivePerceptual(uint8 *img,int width,int 
                                                 error = calculateErrorFromPrecalc58Hperceptual1000(colorsRGB444_packed, precalc_err, best_error_so_far);
                                                 if(error < best_error_so_far)
                                                 {
-                                                    best_error_so_far = error;    
+                                                    best_error_so_far = error;
                                                     best_error_using_Hmode = error;
                                                     best_colorsRGB444_packed[0] = colorsRGB444_packed[0];
                                                     best_colorsRGB444_packed[1] = colorsRGB444_packed[1];
@@ -14963,7 +14965,7 @@ unsigned int compressBlockTHUMB58HExhaustivePerceptual(uint8 *img,int width,int 
     free(precalc_err_R);
 
     error = (unsigned int) calculateErrorAndCompress58Hperceptual1000(img, width, startx, starty, best_colorsRGB444, distance, pixel_indices);
-    best_distance = distance; 
+    best_distance = distance;
     best_pixel_indices = pixel_indices;
 
     //                   | col0 >= col1      col0 < col1
@@ -14984,7 +14986,7 @@ unsigned int compressBlockTHUMB58HExhaustivePerceptual(uint8 *img,int width,int 
         best_pixel_indices = (0x55555555 & best_pixel_indices) | (0xaaaaaaaa & (~best_pixel_indices));
     }
 
-    // Put the compress params into the compression block 
+    // Put the compress params into the compression block
     compressed1 = 0;
 
     PUTBITSHIGH( compressed1, best_colorsRGB444[0][R], 4, 57);
@@ -15003,7 +15005,7 @@ unsigned int compressBlockTHUMB58HExhaustivePerceptual(uint8 *img,int width,int 
 #endif
 
 #if EXHAUSTIVE_CODE_ACTIVE
-// The below code should compress the block to 58 bits. 
+// The below code should compress the block to 58 bits.
 // This is supposed to match the first of the three modes in TWOTIMER.
 // The bit layout is thought to be:
 //
@@ -15013,11 +15015,11 @@ unsigned int compressBlockTHUMB58HExhaustivePerceptual(uint8 *img,int width,int 
 //|31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10 09 08 07 06 05 04 03 02 01 00|
 //|----------------------------------------index bits---------------------------------------------|
 //
-// The distance d is three bits, d2 (MSB), d1 and d0 (LSB). d0 is not stored explicitly. 
+// The distance d is three bits, d2 (MSB), d1 and d0 (LSB). d0 is not stored explicitly.
 // Instead if the 12-bit word red0,green0,blue0 < red1,green1,blue1, d0 is assumed to be 0.
 // Else, it is assumed to be 1.
 
-// The below code should compress the block to 58 bits. 
+// The below code should compress the block to 58 bits.
 // This is supposed to match the first of the three modes in TWOTIMER.
 // The bit layout is thought to be:
 //
@@ -15027,11 +15029,11 @@ unsigned int compressBlockTHUMB58HExhaustivePerceptual(uint8 *img,int width,int 
 //|31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10 09 08 07 06 05 04 03 02 01 00|
 //|----------------------------------------index bits---------------------------------------------|
 //
-// The distance d is three bits, d2 (MSB), d1 and d0 (LSB). d0 is not stored explicitly. 
+// The distance d is three bits, d2 (MSB), d1 and d0 (LSB). d0 is not stored explicitly.
 // Instead if the 12-bit word red0,green0,blue0 < red1,green1,blue1, d0 is assumed to be 0.
 // Else, it is assumed to be 1.
 // NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2005-2013. All Rights Reserved.
-unsigned int compressBlockTHUMB58HExhaustive(uint8 *img,int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2, unsigned int best_error_so_far) 
+unsigned int compressBlockTHUMB58HExhaustive(uint8 *img,int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2, unsigned int best_error_so_far)
 {
     unsigned int best_error_using_Hmode;
     uint8 best_colorsRGB444[2][3];
@@ -15050,7 +15052,7 @@ unsigned int compressBlockTHUMB58HExhaustive(uint8 *img,int width,int height,int
     unsigned int *precalc_err_R;        // smallest pixel error for an entire table
     uint8 block[4*4*4];
 
-    best_error_using_Hmode = MAXIMUM_ERROR;    
+    best_error_using_Hmode = MAXIMUM_ERROR;
 
     precalc_err = (unsigned int*) malloc(4096*8*16*sizeof(unsigned int));
     if(!precalc_err){printf("Out of memory allocating \n");exit(1);}
@@ -15146,7 +15148,7 @@ unsigned int compressBlockTHUMB58HExhaustive(uint8 *img,int width,int height,int
                                                 error = calculateErrorFromPrecalc58H(colorsRGB444_packed, precalc_err, best_error_so_far);
                                                 if(error < best_error_so_far)
                                                 {
-                                                    best_error_so_far = error;    
+                                                    best_error_so_far = error;
                                                     best_error_using_Hmode = error;
                                                     best_colorsRGB444_packed[0] = colorsRGB444_packed[0];
                                                     best_colorsRGB444_packed[1] = colorsRGB444_packed[1];
@@ -15174,7 +15176,7 @@ unsigned int compressBlockTHUMB58HExhaustive(uint8 *img,int width,int height,int
     free(precalc_err_R);
 
     error = (unsigned int) calculateErrorAndCompress58H(img, width, startx, starty, best_colorsRGB444, distance, pixel_indices);
-    best_distance = distance; 
+    best_distance = distance;
     best_pixel_indices = pixel_indices;
 
     //                   | col0 >= col1      col0 < col1
@@ -15195,7 +15197,7 @@ unsigned int compressBlockTHUMB58HExhaustive(uint8 *img,int width,int height,int
         best_pixel_indices = (0x55555555 & best_pixel_indices) | (0xaaaaaaaa & (~best_pixel_indices));
     }
 
-    // Put the compress params into the compression block 
+    // Put the compress params into the compression block
     compressed1 = 0;
 
     PUTBITSHIGH( compressed1, best_colorsRGB444[0][R], 4, 57);
@@ -15227,14 +15229,14 @@ void compressBlockETC1Exhaustive(uint8 *img, uint8 *imgdec,int width,int height,
     unsigned int etc1_individual_word1;
     unsigned int etc1_individual_word2;
     unsigned int error_etc1_individual;
-    
+
     unsigned int error_best;
     signed char best_char;
     int best_mode;
 
     error_currently_best = 255*255*16*3;
 
-    // First pass -- quickly find a low error so that we can later cull away a lot of 
+    // First pass -- quickly find a low error so that we can later cull away a lot of
     // calculations later that are guaranteed to be higher than that error.
     unsigned int error_etc1;
     unsigned int etc1_word1;
@@ -15284,7 +15286,7 @@ void compressBlockETC1Exhaustive(uint8 *img, uint8 *imgdec,int width,int height,
 void compressBlockETC1ExhaustivePerceptual(uint8 *img, uint8 *imgdec,int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2)
 {
     unsigned int error_currently_best;
-    
+
     unsigned int etc1_differential_word1;
     unsigned int etc1_differential_word2;
     unsigned int error_etc1_differential;
@@ -15300,7 +15302,7 @@ void compressBlockETC1ExhaustivePerceptual(uint8 *img, uint8 *imgdec,int width,i
 
     error_currently_best = 255*255*16*1000;
 
-    // First pass -- quickly find a low error so that we can later cull away a lot of 
+    // First pass -- quickly find a low error so that we can later cull away a lot of
     // calculations later that are guaranteed to be higher than that error.
     unsigned int error_etc1;
     unsigned int etc1_word1;
@@ -15355,7 +15357,7 @@ void compressBlockETC1ExhaustivePerceptual(uint8 *img, uint8 *imgdec,int width,i
 void compressBlockETC2ExhaustivePerceptual(uint8 *img, uint8 *imgdec,int width,int height,int startx,int starty, unsigned int &compressed1, unsigned int &compressed2)
 {
     unsigned int error_currently_best;
-    
+
     unsigned int etc1_differential_word1;
     unsigned int etc1_differential_word2;
     unsigned int error_etc1_differential;
@@ -15376,20 +15378,20 @@ void compressBlockETC2ExhaustivePerceptual(uint8 *img, uint8 *imgdec,int width,i
     unsigned int thumbH_word1;
     unsigned int thumbH_word2;
     unsigned int error_thumbH;
-    
+
     unsigned int thumbT59_word1;
     unsigned int thumbT59_word2;
     unsigned int thumbT_word1;
     unsigned int thumbT_word2;
     unsigned int error_thumbT;
-    
+
     unsigned int error_best;
     signed char best_char;
     int best_mode;
 
     error_currently_best = 255*255*16*1000;
 
-    // First pass -- quickly find a low error so that we can later cull away a lot of 
+    // First pass -- quickly find a low error so that we can later cull away a lot of
     // calculations later that are guaranteed to be higher than that error.
     unsigned int error_etc1;
     unsigned int etc1_word1;
@@ -15401,7 +15403,7 @@ void compressBlockETC2ExhaustivePerceptual(uint8 *img, uint8 *imgdec,int width,i
     if(error_etc1 < error_currently_best)
         error_currently_best = error_etc1;
 
-    // The planar mode treats every channel independently and should not be affected by the weights in the error measure. 
+    // The planar mode treats every channel independently and should not be affected by the weights in the error measure.
     // We can hence use the nonperceptual version of the encoder also to find the best perceptual description of the block.
     compressBlockPlanar57(img, width, height, startx, starty, planar57_word1, planar57_word2);
     decompressBlockPlanar57errorPerComponent(planar57_word1, planar57_word2, imgdec, width, height, startx, starty, img, error_planar_red, error_planar_green, error_planar_blue);
@@ -15419,20 +15421,20 @@ void compressBlockETC2ExhaustivePerceptual(uint8 *img, uint8 *imgdec,int width,i
     stuff58bits(thumbH58_word1, thumbH58_word2, thumbH_word1, thumbH_word2);
     if(error_thumbH < error_currently_best)
         error_currently_best = error_thumbH;
-    
+
     // Second pass --- now find the lowest error, but only if it is lower than error_currently_best
 
     // Correct the individual errors for the different planes so that they sum to 1000 instead of 1.
     error_planar_red *=PERCEPTUAL_WEIGHT_R_SQUARED_TIMES1000;
     error_planar_green *=PERCEPTUAL_WEIGHT_G_SQUARED_TIMES1000;
     error_planar_blue *=PERCEPTUAL_WEIGHT_B_SQUARED_TIMES1000;
-    compressBlockPlanar57ExhaustivePerceptual(img, width, height, startx, starty, planar57_word1, planar57_word2, error_currently_best, error_planar_red, error_planar_green, error_planar_blue);    
+    compressBlockPlanar57ExhaustivePerceptual(img, width, height, startx, starty, planar57_word1, planar57_word2, error_currently_best, error_planar_red, error_planar_green, error_planar_blue);
     decompressBlockPlanar57(planar57_word1, planar57_word2, imgdec, width, height, startx, starty);
     error_planar = 1000*calcBlockPerceptualErrorRGB(img, imgdec, width, height, startx, starty);
     stuff57bits(planar57_word1, planar57_word2, planar_word1, planar_word2);
     if(error_planar < error_currently_best)
         error_currently_best = (unsigned int) error_planar;
-    
+
     error_etc1_differential = compressBlockDifferentialExhaustivePerceptual(img, width, height, startx, starty, etc1_differential_word1, etc1_differential_word2, error_currently_best);
     if(error_etc1_differential < error_currently_best)
         error_currently_best = error_etc1_differential;
@@ -15531,20 +15533,20 @@ void compressBlockETC2Exhaustive(uint8 *img, uint8 *imgdec,int width,int height,
     unsigned int thumbH_word1;
     unsigned int thumbH_word2;
     unsigned int error_thumbH;
-    
+
     unsigned int thumbT59_word1;
     unsigned int thumbT59_word2;
     unsigned int thumbT_word1;
     unsigned int thumbT_word2;
     unsigned int error_thumbT;
-    
+
     unsigned int error_best;
     signed char best_char;
     int best_mode;
 
     error_currently_best = 255*255*16*3;
 
-    // First pass -- quickly find a low error so that we can later cull away a lot of 
+    // First pass -- quickly find a low error so that we can later cull away a lot of
     // calculations later that are guaranteed to be higher than that error.
     unsigned int error_etc1;
     unsigned int etc1_word1;
@@ -15582,7 +15584,7 @@ void compressBlockETC2Exhaustive(uint8 *img, uint8 *imgdec,int width,int height,
     stuff57bits(planar57_word1, planar57_word2, planar_word1, planar_word2);
     if(error_planar < error_currently_best)
         error_currently_best = (unsigned int) error_planar;
-    
+
     error_etc1_individual = compressBlockIndividualExhaustive(img, width, height, startx, starty, etc1_individual_word1, etc1_individual_word2, error_currently_best);
     if(error_etc1_individual < error_currently_best)
         error_currently_best = error_etc1_individual;
@@ -15670,7 +15672,7 @@ void compressImageFile(uint8 *img, uint8 *alphaimg,int width,int height,char *ds
         printf("Could not allocate decompression buffer --- exiting\n");
     }
 
-    magic[0]   = 'P'; magic[1]   = 'K'; magic[2] = 'M'; magic[3] = ' '; 
+    magic[0]   = 'P'; magic[1]   = 'K'; magic[2] = 'M'; magic[3] = ' ';
 
     if(codec==CODEC_ETC2)
     {
@@ -15687,18 +15689,18 @@ void compressImageFile(uint8 *img, uint8 *alphaimg,int width,int height,char *ds
         h=expandedheight/4; h*=4;
         wi = w;
         hi = h;
-        if(ktxFile) 
+        if(ktxFile)
         {
             //.ktx file: KTX header followed by compressed binary data.
             KTX_header header;
             //identifier
-            for(int i=0; i<12; i++) 
+            for(int i=0; i<12; i++)
             {
                 header.identifier[i]=ktx_identifier[i];
             }
             //endianess int.. if this comes out reversed, all of the other ints will too.
             header.endianness=KTX_ENDIAN_REF;
-            
+
             //these values are always 0/1 for compressed textures.
             header.glType=0;
             header.glTypeSize=1;
@@ -15715,11 +15717,11 @@ void compressImageFile(uint8 *img, uint8 *alphaimg,int width,int height,char *ds
 
             //and no metadata..
             header.bytesOfKeyValueData=0;
-            
+
             int halfbytes=1;
             //header.glInternalFormat=?
             //header.glBaseInternalFormat=?
-            if(format==ETC2PACKAGE_R_NO_MIPMAPS) 
+            if(format==ETC2PACKAGE_R_NO_MIPMAPS)
             {
                 header.glBaseInternalFormat=GL_R;
                 if(formatSigned)
@@ -15727,7 +15729,7 @@ void compressImageFile(uint8 *img, uint8 *alphaimg,int width,int height,char *ds
                 else
                     header.glInternalFormat=GL_COMPRESSED_R11_EAC;
             }
-            else if(format==ETC2PACKAGE_RG_NO_MIPMAPS) 
+            else if(format==ETC2PACKAGE_RG_NO_MIPMAPS)
             {
                 halfbytes=2;
                 header.glBaseInternalFormat=GL_RG;
@@ -15736,56 +15738,56 @@ void compressImageFile(uint8 *img, uint8 *alphaimg,int width,int height,char *ds
                 else
                     header.glInternalFormat=GL_COMPRESSED_RG11_EAC;
             }
-            else if(format==ETC2PACKAGE_RGB_NO_MIPMAPS) 
+            else if(format==ETC2PACKAGE_RGB_NO_MIPMAPS)
             {
                 header.glBaseInternalFormat=GL_RGB;
                 header.glInternalFormat=GL_COMPRESSED_RGB8_ETC2;
             }
-            else if(format==ETC2PACKAGE_sRGB_NO_MIPMAPS) 
+            else if(format==ETC2PACKAGE_sRGB_NO_MIPMAPS)
             {
                 header.glBaseInternalFormat=GL_SRGB;
                 header.glInternalFormat=GL_COMPRESSED_SRGB8_ETC2;
             }
-            else if(format==ETC2PACKAGE_RGBA_NO_MIPMAPS) 
+            else if(format==ETC2PACKAGE_RGBA_NO_MIPMAPS)
             {
                 halfbytes=2;
                 header.glBaseInternalFormat=GL_RGBA;
                 header.glInternalFormat=GL_COMPRESSED_RGBA8_ETC2_EAC;
             }
-            else if(format==ETC2PACKAGE_sRGBA_NO_MIPMAPS) 
+            else if(format==ETC2PACKAGE_sRGBA_NO_MIPMAPS)
             {
                 halfbytes=2;
                 header.glBaseInternalFormat=GL_SRGB8_ALPHA8;
                 header.glInternalFormat=GL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC;
             }
-            else if(format==ETC2PACKAGE_RGBA1_NO_MIPMAPS) 
+            else if(format==ETC2PACKAGE_RGBA1_NO_MIPMAPS)
             {
                 header.glBaseInternalFormat=GL_RGBA;
                 header.glInternalFormat=GL_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2;
             }
-            else if(format==ETC2PACKAGE_sRGBA1_NO_MIPMAPS) 
+            else if(format==ETC2PACKAGE_sRGBA1_NO_MIPMAPS)
             {
                 header.glBaseInternalFormat=GL_SRGB8_ALPHA8;
                 header.glInternalFormat=GL_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2;
             }
-            else if(format==ETC1_RGB_NO_MIPMAPS) 
+            else if(format==ETC1_RGB_NO_MIPMAPS)
             {
                 header.glBaseInternalFormat=GL_RGB;
                 header.glInternalFormat=GL_ETC1_RGB8_OES;
             }
-            else 
+            else
             {
                 printf("internal error: bad format!\n");
                 exit(1);
             }
             //write header
             fwrite(&header,sizeof(KTX_header),1,f);
-            
+
             //write size of compressed data.. which depend on the expanded size..
             unsigned int imagesize=(w*h*halfbytes)/2;
             fwrite(&imagesize,sizeof(int),1,f);
         }
-        else 
+        else
         {
             //.pkm file, contains small header..
 
@@ -15794,18 +15796,18 @@ void compressImageFile(uint8 *img, uint8 *alphaimg,int width,int height,char *ds
             fwrite(&magic[1], sizeof(unsigned char), 1, f);
             fwrite(&magic[2], sizeof(unsigned char), 1, f);
             fwrite(&magic[3], sizeof(unsigned char), 1, f);
-        
+
             // Write version
             fwrite(&version[0], sizeof(unsigned char), 1, f);
             fwrite(&version[1], sizeof(unsigned char), 1, f);
 
             // Write texture type
-            if(texture_type==ETC2PACKAGE_RG_NO_MIPMAPS&&formatSigned) 
+            if(texture_type==ETC2PACKAGE_RG_NO_MIPMAPS&&formatSigned)
             {
                 unsigned short temp = ETC2PACKAGE_RG_SIGNED_NO_MIPMAPS;
                 write_big_endian_2byte_word(&temp,f);
             }
-            else if(texture_type==ETC2PACKAGE_R_NO_MIPMAPS&&formatSigned) 
+            else if(texture_type==ETC2PACKAGE_R_NO_MIPMAPS&&formatSigned)
             {
                 unsigned short temp = ETC2PACKAGE_R_SIGNED_NO_MIPMAPS;
                 write_big_endian_2byte_word(&temp,f);
@@ -15821,9 +15823,9 @@ void compressImageFile(uint8 *img, uint8 *alphaimg,int width,int height,char *ds
             // a 128 x 129 image, we have to extend it to 128 x 132 pixels.
             // Then the wi and hi written above will be 128 and 132, but the
             // additional information that we write below will be 128 and 129,
-            // to indicate that it is only the top 129 lines of data in the 
+            // to indicate that it is only the top 129 lines of data in the
             // decompressed image that will be valid data, and the rest will
-            // be just garbage. 
+            // be just garbage.
 
             unsigned short activew, activeh;
             activew = width;
@@ -15836,15 +15838,15 @@ void compressImageFile(uint8 *img, uint8 *alphaimg,int width,int height,char *ds
         int countblocks = 0;
         double percentageblocks=-1.0;
         double oldpercentageblocks;
-        
-        if(format==ETC2PACKAGE_RG_NO_MIPMAPS) 
+
+        if(format==ETC2PACKAGE_RG_NO_MIPMAPS)
         {
             //extract data from red and green channel into two alpha channels.
             //note that the image will be 16-bit per channel in this case.
             alphaimg= (unsigned char*)malloc(expandedwidth*expandedheight*2);
             alphaimg2=(unsigned char*)malloc(expandedwidth*expandedheight*2);
             setupAlphaTableAndValtab();
-            if(!alphaimg||!alphaimg2) 
+            if(!alphaimg||!alphaimg2)
             {
                 printf("failed allocating space for alpha buffers!\n");
                 exit(1);
@@ -15868,38 +15870,38 @@ void compressImageFile(uint8 *img, uint8 *alphaimg,int width,int height,char *ds
                 oldpercentageblocks = percentageblocks;
                 percentageblocks = 100.0*countblocks/(1.0*totblocks);
                 //compress color channels
-                if(codec==CODEC_ETC) 
+                if(codec==CODEC_ETC)
                 {
-                    if(metric==METRIC_NONPERCEPTUAL) 
+                    if(metric==METRIC_NONPERCEPTUAL)
                     {
                         if(speed==SPEED_FAST)
                             compressBlockDiffFlipFast(img, imgdec, expandedwidth, expandedheight, 4*x, 4*y, block1, block2);
                         else
 #if EXHAUSTIVE_CODE_ACTIVE
-                            compressBlockETC1Exhaustive(img, imgdec, expandedwidth, expandedheight, 4*x, 4*y, block1, block2);        
+                            compressBlockETC1Exhaustive(img, imgdec, expandedwidth, expandedheight, 4*x, 4*y, block1, block2);
 #else
                             printf("Not implemented in this version\n");
 #endif
                     }
-                    else 
+                    else
                     {
                         if(speed==SPEED_FAST)
                             compressBlockDiffFlipFastPerceptual(img, imgdec, expandedwidth, expandedheight, 4*x, 4*y, block1, block2);
                         else
 #if EXHAUSTIVE_CODE_ACTIVE
-                            compressBlockETC1ExhaustivePerceptual(img, imgdec, expandedwidth, expandedheight, 4*x, 4*y, block1, block2);    
+                            compressBlockETC1ExhaustivePerceptual(img, imgdec, expandedwidth, expandedheight, 4*x, 4*y, block1, block2);
 #else
                             printf("Not implemented in this version\n");
 #endif
                     }
                 }
-                else 
+                else
                 {
-                    if(format==ETC2PACKAGE_R_NO_MIPMAPS||format==ETC2PACKAGE_RG_NO_MIPMAPS) 
+                    if(format==ETC2PACKAGE_R_NO_MIPMAPS||format==ETC2PACKAGE_RG_NO_MIPMAPS)
                     {
                         //don't compress color
                     }
-                    else if(format==ETC2PACKAGE_RGBA1_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA1_NO_MIPMAPS) 
+                    else if(format==ETC2PACKAGE_RGBA1_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA1_NO_MIPMAPS)
                     {
                         //this is only available for fast/nonperceptual
                         if(speed == SPEED_SLOW && first_time_message)
@@ -15909,32 +15911,32 @@ void compressImageFile(uint8 *img, uint8 *alphaimg,int width,int height,char *ds
                         }
                         compressBlockETC2Fast(img, alphaimg,imgdec, expandedwidth, expandedheight, 4*x, 4*y, block1, block2);
                     }
-                    else if(metric==METRIC_NONPERCEPTUAL) 
+                    else if(metric==METRIC_NONPERCEPTUAL)
                     {
                         if(speed==SPEED_FAST)
                             compressBlockETC2Fast(img, alphaimg,imgdec, expandedwidth, expandedheight, 4*x, 4*y, block1, block2);
                         else
 #if EXHAUSTIVE_CODE_ACTIVE
-                            compressBlockETC2Exhaustive(img, imgdec, expandedwidth, expandedheight, 4*x, 4*y, block1, block2);        
+                            compressBlockETC2Exhaustive(img, imgdec, expandedwidth, expandedheight, 4*x, 4*y, block1, block2);
 #else
                             printf("Not implemented in this version\n");
 #endif
                     }
-                    else 
+                    else
                     {
                         if(speed==SPEED_FAST)
                             compressBlockETC2FastPerceptual(img, imgdec, expandedwidth, expandedheight, 4*x, 4*y, block1, block2);
                         else
 #if EXHAUSTIVE_CODE_ACTIVE
-                            compressBlockETC2ExhaustivePerceptual(img, imgdec, expandedwidth, expandedheight, 4*x, 4*y, block1, block2);    
+                            compressBlockETC2ExhaustivePerceptual(img, imgdec, expandedwidth, expandedheight, 4*x, 4*y, block1, block2);
 #else
                             printf("Not implemented in this version\n");
 #endif
                     }
                 }
-                
+
                 //compression of alpha channel in case of 4-bit alpha. Uses 8-bit alpha channel as input, and has 8-bit precision.
-                if(format==ETC2PACKAGE_RGBA_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA_NO_MIPMAPS) 
+                if(format==ETC2PACKAGE_RGBA_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA_NO_MIPMAPS)
                 {
                     uint8 alphadata[8];
                     if(speed==SPEED_SLOW)
@@ -15946,21 +15948,21 @@ void compressImageFile(uint8 *img, uint8 *alphaimg,int width,int height,char *ds
                 }
 
                 //store compressed color channels
-                if(format!=ETC2PACKAGE_R_NO_MIPMAPS&&format!=ETC2PACKAGE_RG_NO_MIPMAPS) 
+                if(format!=ETC2PACKAGE_R_NO_MIPMAPS&&format!=ETC2PACKAGE_RG_NO_MIPMAPS)
                 {
                     write_big_endian_4byte_word(&block1, f);
                     write_big_endian_4byte_word(&block2, f);
                 }
 
                 //1-channel or 2-channel alpha compression: uses 16-bit data as input, and has 11-bit precision
-                if(format==ETC2PACKAGE_R_NO_MIPMAPS||format==ETC2PACKAGE_RG_NO_MIPMAPS) 
-                { 
+                if(format==ETC2PACKAGE_R_NO_MIPMAPS||format==ETC2PACKAGE_RG_NO_MIPMAPS)
+                {
                     uint8 alphadata[8];
                     compressBlockAlpha16(alphaimg,4*x,4*y,expandedwidth,expandedheight,alphadata);
                     fwrite(alphadata,1,8,f);
                 }
                 //compression of second alpha channel in RG-compression
-                if(format==ETC2PACKAGE_RG_NO_MIPMAPS) 
+                if(format==ETC2PACKAGE_RG_NO_MIPMAPS)
                 {
                     uint8 alphadata[8];
                     compressBlockAlpha16(alphaimg2,4*x,4*y,expandedwidth,expandedheight,alphadata);
@@ -15969,7 +15971,7 @@ void compressImageFile(uint8 *img, uint8 *alphaimg,int width,int height,char *ds
 #if 1
                 if(verbose)
                 {
-                    if(speed==SPEED_FAST) 
+                    if(speed==SPEED_FAST)
                     {
                         if( ((int)(percentageblocks) != (int)(oldpercentageblocks) ) || percentageblocks == 100.0)
                             printf("Compressed %d of %d blocks, %.0f%% finished.\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b", countblocks, totblocks, 100.0*countblocks/(1.0*totblocks));
@@ -15996,7 +15998,7 @@ void compressFile(char *srcfile,char *dstfile)
     timeb tstruct;
     int tstart;
     int tstop;
-    // 0: compress from .any to .pkm with SPEED_FAST, METRIC_NONPERCEPTUAL, ETC 
+    // 0: compress from .any to .pkm with SPEED_FAST, METRIC_NONPERCEPTUAL, ETC
     // 1: compress from .any to .pkm with SPEED_MEDIUM, METRIC_NONPERCEPTUAL, ETC
     // 2: compress from .any to .pkm with SPEED_SLOW, METRIC_NONPERCEPTUAL, ETC
     // 3: compress from .any to .pkm with SPEED_FAST, METRIC_PERCEPTUAL, ETC
@@ -16004,7 +16006,7 @@ void compressFile(char *srcfile,char *dstfile)
     // 5: compress from .any to .pkm with SPEED_SLOW, METRIC_PERCEPTUAL, ETC
     // 6: decompress from .pkm to .any
     // 7: calculate PSNR between .any and .any
-    // 8: compress from .any to .pkm with SPEED_FAST, METRIC_NONPERCEPTUAL, ETC2 
+    // 8: compress from .any to .pkm with SPEED_FAST, METRIC_NONPERCEPTUAL, ETC2
     // 9: compress from .any to .pkm with SPEED_MEDIUM, METRIC_NONPERCEPTUAL, ETC2
     //10: compress from .any to .pkm with SPEED_SLOW, METRIC_NONPERCEPTUAL, ETC2
     //11: compress from .any to .pkm with SPEED_FAST, METRIC_PERCEPTUAL, ETC2
@@ -16049,7 +16051,7 @@ void compressFile(char *srcfile,char *dstfile)
         {
             //make sure that alphasrcimg contains the alpha channel or is null here, and pass it to compressimagefile
             uint8* alphaimg=NULL;
-            if(format==ETC2PACKAGE_RGBA_NO_MIPMAPS||format==ETC2PACKAGE_RGBA1_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA1_NO_MIPMAPS) 
+            if(format==ETC2PACKAGE_RGBA_NO_MIPMAPS||format==ETC2PACKAGE_RGBA1_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA_NO_MIPMAPS||format==ETC2PACKAGE_sRGBA1_NO_MIPMAPS)
             {
                 char str[300];
                 //printf("reading alpha channel....");
@@ -16059,7 +16061,7 @@ void compressFile(char *srcfile,char *dstfile)
                 printf("ok!\n");
                 setupAlphaTableAndValtab();
             }
-            else if(format==ETC2PACKAGE_R_NO_MIPMAPS) 
+            else if(format==ETC2PACKAGE_R_NO_MIPMAPS)
             {
                 char str[300];
                 sprintf(str,"imconv %s alpha.pgm\n",srcfile);
@@ -16073,7 +16075,7 @@ void compressFile(char *srcfile,char *dstfile)
             tstart=time(NULL);
             ftime( &tstruct );
             tstart=tstart*1000+tstruct.millitm;
-            compressImageFile(srcimg,alphaimg,width,height,dstfile,extendedwidth, extendedheight);            
+            compressImageFile(srcimg,alphaimg,width,height,dstfile,extendedwidth, extendedheight);
             tstop = time(NULL);
             ftime( &tstruct );
             tstop = tstop*1000+tstruct.millitm;
@@ -16129,20 +16131,20 @@ int main(int argc,char *argv[])
 {
     if(argc==3 || argc==4 || argc == 5 || argc == 7 || argc == 9 || argc == 11 || argc == 13)
     {
-        // The source file is always the second last one. 
+        // The source file is always the second last one.
         char srcfile[200];
         char dstfile[200];
         readArguments(argc,argv,srcfile,dstfile);
-        
+
         //int q = find_pos_of_extension(srcfile);
         //int q2 = find_pos_of_extension(dstfile);
-        
+
         if(!fileExist(srcfile))
         {
             printf("Error: file <%s> does not exist.\n",srcfile);
             exit(0);
         }
-        
+
         if(mode==MODE_UNCOMPRESS)
         {
             printf("Decompressing .pkm/.ktx file ...\n");
@@ -16181,9 +16183,9 @@ int main(int argc,char *argv[])
         printf("      -v {on|off}                        Detailed progress info. (default on)\n");
         printf("                                                            \n");
         printf("Examples: \n");
-        printf("  etcpack img.ppm img.pkm                Compresses img.ppm to img.pkm in\n"); 
+        printf("  etcpack img.ppm img.pkm                Compresses img.ppm to img.pkm in\n");
         printf("                                         ETC2 RGB format\n");
-        printf("  etcpack img.ppm img.ktx                Compresses img.ppm to img.ktx in\n"); 
+        printf("  etcpack img.ppm img.ktx                Compresses img.ppm to img.ktx in\n");
         printf("                                         ETC2 RGB format\n");
         printf("  etcpack img.pkm img_copy.ppm           Decompresses img.pkm to img_copy.ppm\n");
         printf("  etcpack -s slow img.ppm img.pkm        Compress using the slow mode.\n");

--- a/Compressonator/Source/Codec/GT/Codec_GT.cpp
+++ b/Compressonator/Source/Codec/GT/Codec_GT.cpp
@@ -8,10 +8,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -26,7 +26,9 @@
 //
 //////////////////////////////////////////////////////////////////////////////
 
+#ifdef _MSC_VER
 #pragma warning(disable:4100)    // Ignore warnings of unreferenced formal parameters
+#endif //_MSC_VER
 #include "Common.h"
 #include "Codec_GT.h"
 
@@ -64,7 +66,7 @@ unsigned int GTThreadProcEncode(void* param)
             tp->encoder->CompressBlock(tp->in, tp->out);
             tp->run = FALSE;
         }
-        
+
         using namespace chrono;
 
         std::this_thread::sleep_for( 0ms );
@@ -145,8 +147,10 @@ CCodec_GT::~CCodec_GT()
                 // If we don't wait then there is a race condition here where we have
                 // told the thread to run but it hasn't yet been scheduled - if we set
                 // the exit flag before it runs then its block will not be processed.
+#ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable:4127) //warning C4127: conditional expression is constant
+#endif //_MSC_VER
                 while(1)
                 {
                     if(g_EncodeParameterStorage[i].run != TRUE)
@@ -154,7 +158,9 @@ CCodec_GT::~CCodec_GT()
                         break;
                     }
                 }
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif //_MSC_VER
                 // Signal to the thread that it can exit
                 g_EncodeParameterStorage[i].exit = TRUE;
             }
@@ -185,7 +191,7 @@ CCodec_GT::~CCodec_GT()
         delete[] g_EncodeParameterStorage;
         g_EncodeParameterStorage = NULL;
 
-        
+
         for(int i=0; i < m_NumEncodingThreads; i++)
         {
             if (m_encoder[i])
@@ -221,7 +227,7 @@ CodecError CCodec_GT::InitializeGTLibrary()
         m_LiveThreads = 0;
         m_LastThread  = 0;
         m_NumEncodingThreads = min(m_NumThreads, MAX_GT_THREADS);
-        if (m_NumEncodingThreads == 0) m_NumEncodingThreads = 1; 
+        if (m_NumEncodingThreads == 0) m_NumEncodingThreads = 1;
         m_Use_MultiThreading = m_NumEncodingThreads > 1;
 
         g_EncodeParameterStorage = new GTEncodeThreadParam[m_NumEncodingThreads];
@@ -246,7 +252,7 @@ CodecError CCodec_GT::InitializeGTLibrary()
             // Create single encoder instance
             m_encoder[i] = new GTBlockEncoder();
 
-            
+
             // Cleanup if problem!
             if(!m_encoder[i])
             {
@@ -350,7 +356,7 @@ if (m_Use_MultiThreading)
     // Tell the thread to start working
     g_EncodeParameterStorage[threadIndex].run = TRUE;
 }
-else 
+else
 {
         // Copy the input data into the thread storage
         memcpy(g_EncodeParameterStorage[0].in, in, MAX_SUBSET_SIZE * MAX_DIMENSION_BIG * sizeof(double));
@@ -417,13 +423,13 @@ CodecError CCodec_GT::Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, 
     const CMP_DWORD dwBlocksXY = dwBlocksX*dwBlocksY;
 
 
-    #ifdef USE_DBGTRACE
+#ifdef USE_DBGTRACE
     DbgTrace(("IN : BufferType %d ChannelCount %d ChannelDepth %d",bufferIn.GetBufferType(),bufferIn.GetChannelCount(),bufferIn.GetChannelDepth()));
     DbgTrace(("   : Height %d Width %d Pitch %d isFloat %d",bufferIn.GetHeight(),bufferIn.GetWidth(),bufferIn.GetWidth(),bufferIn.IsFloat()));
 
     DbgTrace(("OUT: BufferType %d ChannelCount %d ChannelDepth %d",bufferOut.GetBufferType(),bufferOut.GetChannelCount(),bufferOut.GetChannelDepth()));
     DbgTrace(("   : Height %d Width %d Pitch %d isFloat %d",bufferOut.GetHeight(),bufferOut.GetWidth(),bufferOut.GetWidth(),bufferOut.IsFloat()));
-    #endif;
+#endif
 
     char            row,col,srcIndex;
 
@@ -474,15 +480,15 @@ CodecError CCodec_GT::Compress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut, 
                 BYTE            out[16];
                 BYTE            in[16];
             } data;
-            
+
             memset(data.in,0,sizeof(data));
-            
+
             union DBLOCKS
             {
                 double            blockToSave[16][4];
                 double            block[64];
             } savedata;
-        
+
             CMP_BYTE destBlock[BLOCK_SIZE_4X4X4];
             memset(savedata.block,0,sizeof(savedata));
             m_decoder->DecompressBlock(savedata.blockToSave,data.in);
@@ -524,10 +530,10 @@ CodecError CCodec_GT::Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut
 {
     assert(bufferIn.GetWidth() == bufferOut.GetWidth());
     assert(bufferIn.GetHeight() == bufferOut.GetHeight());
-    
+
     CodecError err = InitializeGTLibrary();
     if (err != CE_OK) return err;
-    
+
     if(bufferIn.GetWidth() != bufferOut.GetWidth() || bufferIn.GetHeight() != bufferOut.GetHeight())
         return CE_Unknown;
 
@@ -553,7 +559,7 @@ CodecError CCodec_GT::Decompress(CCodecBuffer& bufferIn, CCodecBuffer& bufferOut
             } CompData;
 
             CMP_BYTE destBlock[BLOCK_SIZE_4X4X4];
-            
+
             bufferIn.ReadBlock(i*4, j*4, CompData.compressedBlock, 4);
 
             // Encode to the appropriate location in the compressed image

--- a/Compressonator/Source/Common/HDR_Encode.cpp
+++ b/Compressonator/Source/Common/HDR_Encode.cpp
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -29,6 +29,7 @@
 
 
 #include "HDR_Encode.h"
+#include "Common.h"
 #include <assert.h>
 #include <math.h>
 #include <float.h>
@@ -94,7 +95,7 @@ inline int NBits(int n, bool bIsSigned)
 
  int QuantizeToInt(short value, int prec, bool signedfloat16, float exposure)
  {
-     (exposure);
+     UNREFERENCED_PARAMETER(exposure);
 
      if (prec <= 1) return 0;
      bool negvalue = false;
@@ -1133,7 +1134,7 @@ void GetEndPoints(float EndPoints[MAX_SUBSETS][MAX_END_POINTS][MAX_DIMENSION_BIG
     // Save Min and Max OutB points as EndPoints
     for (int subset = 0; subset<max_subsets; subset++)
     {
-        // We now have points on direction vector(s) 
+        // We now have points on direction vector(s)
         // find the min and max points
         float min = FLT_MAX;
         float max = 0;
@@ -1215,7 +1216,7 @@ void eigenVector_d(float cov[MAX_DIMENSION_BIG][MAX_DIMENSION_BIG], float vector
     // will work for non-zero non-negative matricies only
 
 #define EV_ITERATION_NUMBER 20
-#define EV_SLACK            2        /* additive for exp base 2)*/    
+#define EV_SLACK            2        /* additive for exp base 2)*/
 
 
     int i, j, k, l, m, n, p, q;
@@ -1260,7 +1261,7 @@ void eigenVector_d(float cov[MAX_DIMENSION_BIG][MAX_DIMENSION_BIG], float vector
                     float temp = 0;
                     for (k = 0; k<dimension; k++)
                     {
-                        // Notes: 
+                        // Notes:
                         // This is the most consuming portion of the code and needs optimizing for perfromance
                         temp += c[l][i][k] * c[l][k][j];
                     }
@@ -1421,7 +1422,7 @@ void quant_AnD_Shell(float* v_, int k, int n, int *idx)
             }
         }
 
-        // position which should be in 0 
+        // position which should be in 0
         j = ++j % n;
 
         for (i = j; i < n; i++)
@@ -1473,7 +1474,7 @@ float optQuantAnD_d(
     centerInPlace_d(centered, numEntries, mean, dimension);
     covariance_d(centered, numEntries, cov, dimension);
 
-    // check if they all are the same 
+    // check if they all are the same
 
     t = 0;
     for (j = 0; j<dimension; j++)
@@ -1521,7 +1522,7 @@ float optQuantAnD_d(
                 t = t - s * s * (float)numEntries;
                 //assert(t != 0);
                 t = (t == 0.0f ? 0.0f : 1.0f / t);
-                // We need to requantize 
+                // We need to requantize
 
                 q = sqrtf(q);
                 t *= q;
@@ -1634,7 +1635,7 @@ const float rampLerpWeights[5][16] =
 
 float rampf(int clog, int bits, float p1, float p2, int indexPos)
 {
-    (bits);
+    UNREFERENCED_PARAMETER(bits);
     // (clog+ LOG_CL_BASE) starts from 2 to 4
     return  (float)p1 + rampLerpWeights[clog + LOG_CL_BASE][indexPos] * (p2 - p1);
 }
@@ -1756,7 +1757,7 @@ short par_vectors_nd[2][8][128][2][MAX_DIMENSION_BIG] =
             { { 0,0,0 },{ 0,0,0 } },
             { { 1,1,1 },{ 1,1,1 } }
         },
-    // 3*n+2    BCC          3*n+1        BCC          3*n+1    
+    // 3*n+2    BCC          3*n+1        BCC          3*n+1
         { // BCC
             { { 0,0,0 },{ 0,0,0 } },
             { { 0,0,0 },{ 1,1,1 } },
@@ -1802,7 +1803,7 @@ short par_vectors_nd[2][8][128][2][MAX_DIMENSION_BIG] =
         },
 
 
-    // 3*n+5    Cartesian 3*n+3        FCC          3*n+2            //D^*[6]  
+    // 3*n+5    Cartesian 3*n+3        FCC          3*n+2            //D^*[6]
         {
 
             { { 0,0,0 },{ 0,0,0 } },
@@ -1858,7 +1859,7 @@ short par_vectors_nd[2][8][128][2][MAX_DIMENSION_BIG] =
             { { 0,0,0,0 },{ 0,0,0,0 } },
             { { 1,1,1,1 },{ 1,1,1,1 } }
         },
-    // 3*n+2    BCC          3*n+1        BCC          3*n+1    
+    // 3*n+2    BCC          3*n+1        BCC          3*n+1
         { // BCC
             { { 0,0,0,0 },{ 0,0,0,0 } },
             { { 0,0,0,0 },{ 1,1,1,1 } },
@@ -2000,8 +2001,8 @@ float quant_single_point_d
 #ifdef USE_RAMPS
                         int tf = (int)floorf(data[0][j]);
                         int tc = (int)ceilf(data[0][j]);
-                        // if they are not equal, the same representalbe point is used for 
-                        // both of them, as all representable points are integers in the rage 
+                        // if they are not equal, the same representalbe point is used for
+                        // both of them, as all representable points are integers in the rage
                         if (sperr(tf, CLT(clog), BTT(bits[j]), t1, t2, i) > sperr(tc, CLT(clog), BTT(bits[j]), t1, t2, i))
                             dr[j] = tc;
                         else if (sperr(tf, CLT(clog), BTT(bits[j]), t1, t2, i) < sperr(tc, CLT(clog), BTT(bits[j]), t1, t2, i))
@@ -2253,7 +2254,7 @@ void init_ramps()
     //        for (in_data = 0; in_data<SP_ERRIDX_MAX; in_data++)
     //            for (o1 = 0; o1<2; o1++)
     //                for (o2 = 0; o2<2; o2++)
-    //                    for (i = 0; i<16; i++) 
+    //                    for (i = 0; i<16; i++)
     //                         {
     //                             printf("sp_data[%2d].sp_idx[%2d][%2d][%2d][%2d][%2d][0] = %d\n", in_data,CLT(clog), BTT(bits),o1,o2,i, sp_data[in_data].sp_idx[CLT(clog)][BTT(bits)][o1][o2][i][0]);
     //                             printf("sp_data[%2d].sp_idx[%2d][%2d][%2d][%2d][%2d][1] = %d\n", in_data,CLT(clog), BTT(bits),o1,o2,i, sp_data[in_data].sp_idx[CLT(clog)][BTT(bits)][o1][o2][i][1]);
@@ -2557,7 +2558,7 @@ float ep_shaker_HD(
                         }
                         err_1 = err_0;
 
-                        s1 = s; // epo coding             
+                        s1 = s; // epo coding
                     }
                 }
 
@@ -2737,7 +2738,7 @@ float ep_shaker_2_d(
             return err_o;
         }
 
-        for (q = 1; Mi != 0 && q*Mi <= Mi_; q++) // does not work for single point collapsed index!!! 
+        for (q = 1; Mi != 0 && q*Mi <= Mi_; q++) // does not work for single point collapsed index!!!
             for (p = 0; p <= Mi_ - q*Mi; p++)
             {
                 int cidx[MAX_ENTRIES];
@@ -2894,7 +2895,7 @@ float ep_shaker_2_d(
                             }
                 }
 
-                if (err_1 <= err_0) { // we'd want to get expanded index; 
+                if (err_1 <= err_0) { // we'd want to get expanded index;
                     err_0 = err_1;
                     p0 = p;
                     q0 = q;

--- a/Compressonator/Source/Common/HDR_Encode.h
+++ b/Compressonator/Source/Common/HDR_Encode.h
@@ -12,10 +12,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -41,7 +41,7 @@ namespace HDR_Encode
 #define MAX_PARTITIONS          64                       // Maximum number of partition types
 #define NUM_BLOCK_TYPES         8                        // Number of block types in the format
 #define COMPRESSED_BLOCK_SIZE   16                       // Size of a compressed block in bytes
-#define MAX_DIMENSION_BIG       4                        // Maximun number of Channels per Texel,  
+#define MAX_DIMENSION_BIG       4                        // Maximun number of Channels per Texel,
                                                          // BC6H uses 3 channels in current encoder, 4th is reserved for future use
 #define F16MAX1                 0x7C00                   // Max 16bit half float value (0x7BFF) + 1
 #define MAX_END_POINTS          2                        // BC6H Maximum number of end point pairs (AB)
@@ -64,14 +64,16 @@ extern  void    Partition(  int       shape,
 // Used by optQuantAnD_d
 #define MAX_ENTRIES                             64
 #define MAX_TRY                                 4000
+#ifndef FLT_MAX_EXP
 #define FLT_MAX_EXP                             128 // DBL_MAX_EXP_ = 1024
+#endif //FLT_MAX_EXP
 #define MAX_PARTITIONS_TABLE                    (1+64+64)
 
 // Out contains all endpoints (out) calaculated for the input shape (data) and pattern (index)
 extern  float optQuantAnD_d(
     float data[MAX_ENTRIES][MAX_DIMENSION_BIG],
-        int numEntries, 
-        int numClusters, 
+        int numEntries,
+        int numClusters,
         int index[MAX_ENTRIES],
     float out[MAX_ENTRIES][MAX_DIMENSION_BIG],
     float direction[MAX_DIMENSION_BIG],

--- a/Compressonator/Source/Compress.cpp
+++ b/Compressonator/Source/Compress.cpp
@@ -8,10 +8,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
@@ -27,10 +27,10 @@
 //  Apr 2014    -    Refactored Library
 //                   Code clean to support MSV 2010 and up
 //////////////////////////////////////////////////////////////////////////////
-        
+
 #include "Compressonator.h"
 #include "Compress.h"
-#include <assert.h>    
+#include <assert.h>
 
 #include <algorithm>
 
@@ -79,10 +79,10 @@ CodecType GetCodecType(CMP_FORMAT format)
         case CMP_FORMAT_BC3:                     return CT_DXT5;
         case CMP_FORMAT_BC4:                     return CT_ATI1N;
         case CMP_FORMAT_BC5:                     return CT_ATI2N_XY;
-        case CMP_FORMAT_BC6H:                    return CT_BC6H; 
+        case CMP_FORMAT_BC6H:                    return CT_BC6H;
         case CMP_FORMAT_BC6H_SF:                 return CT_BC6H_SF;
-        case CMP_FORMAT_BC7:                     return CT_BC7;    
-        case CMP_FORMAT_ASTC:                    return CT_ASTC;    
+        case CMP_FORMAT_BC7:                     return CT_BC7;
+        case CMP_FORMAT_ASTC:                    return CT_ASTC;
         case CMP_FORMAT_ATC_RGB:                 return CT_ATC_RGB;
         case CMP_FORMAT_ATC_RGBA_Explicit:       return CT_ATC_RGBA_Explicit;
         case CMP_FORMAT_ATC_RGBA_Interpolated:   return CT_ATC_RGBA_Interpolated;
@@ -131,17 +131,17 @@ bool NeedSwizzle(CMP_FORMAT destformat)
     switch (destformat)
     {
     case CMP_FORMAT_BC4:
-    case CMP_FORMAT_ATI1N:        // same as BC4    
-    case CMP_FORMAT_ATI2N:        // same as BC4    
+    case CMP_FORMAT_ATI1N:        // same as BC4
+    case CMP_FORMAT_ATI2N:        // same as BC4
     case CMP_FORMAT_BC5:
-    case CMP_FORMAT_ATI2N_XY:    // same as BC5    
-    case CMP_FORMAT_ATI2N_DXT5:    // same as BC5    
+    case CMP_FORMAT_ATI2N_XY:    // same as BC5
+    case CMP_FORMAT_ATI2N_DXT5:    // same as BC5
     case CMP_FORMAT_BC1:
-    case CMP_FORMAT_DXT1:        // same as BC1     
+    case CMP_FORMAT_DXT1:        // same as BC1
     case CMP_FORMAT_BC2:
-    case CMP_FORMAT_DXT3:        // same as BC2     
+    case CMP_FORMAT_DXT3:        // same as BC2
     case CMP_FORMAT_BC3:
-    case CMP_FORMAT_DXT5:        // same as BC3     
+    case CMP_FORMAT_DXT5:        // same as BC3
     case CMP_FORMAT_ATC_RGB:
     case CMP_FORMAT_ATC_RGBA_Explicit:
     case CMP_FORMAT_ATC_RGBA_Interpolated:
@@ -330,7 +330,7 @@ CMP_ERROR Float2Byte(CMP_BYTE cBlock[], CMP_FLOAT* fBlock, CMP_Texture* srcTextu
 
                 //  6) Scale the values such that middle gray pixels are
                 //     mapped to a frame buffer value that is 3.5 f-stops
-                //     below the display's maximum intensity. 
+                //     below the display's maximum intensity.
                 r *= scale;
                 g *= scale;
                 b *= scale;
@@ -460,7 +460,7 @@ CMP_ERROR CompressTexture(const CMP_Texture* pSourceTexture, CMP_Texture* pDestT
         {
         case CT_BC7:
                 pCodec->SetParameter("MultiThreading", (CMP_DWORD) !pOptions->bDisableMultiThreading);
-                
+
                 if (!pOptions->bDisableMultiThreading)
                     pCodec->SetParameter("NumThreads", (CMP_DWORD) pOptions->dwnumThreads);
                 else
@@ -508,7 +508,7 @@ CMP_ERROR CompressTexture(const CMP_Texture* pSourceTexture, CMP_Texture* pDestT
 
     CodecBufferType srcBufferType = GetCodecBufferType(pSourceTexture->format);
 
-    CCodecBuffer* pSrcBuffer  = CreateCodecBuffer(srcBufferType, 
+    CCodecBuffer* pSrcBuffer  = CreateCodecBuffer(srcBufferType,
                                                   pSourceTexture->nBlockWidth, pSourceTexture->nBlockHeight, pSourceTexture->nBlockDepth,
                                                   pSourceTexture->dwWidth, pSourceTexture->dwHeight, pSourceTexture->dwPitch, pSourceTexture->pData);
     CCodecBuffer* pDestBuffer = pCodec->CreateBuffer(
@@ -553,8 +553,8 @@ public:
     CodecError m_errorCode;
 };
 
-CATICompressThreadData::CATICompressThreadData() : m_pCodec(NULL), m_pSrcBuffer(NULL), m_pDestBuffer(NULL), 
-                                                   m_pFeedbackProc(NULL), m_pUser1(NULL), m_pUser2(NULL),
+CATICompressThreadData::CATICompressThreadData() : m_pCodec(NULL), m_pSrcBuffer(NULL), m_pDestBuffer(NULL),
+                                                   m_pFeedbackProc(NULL), m_pUser1(CMP_NULL), m_pUser2(CMP_NULL),
                                                    m_errorCode( CE_OK )
 {
 }
@@ -578,9 +578,9 @@ void ThreadedCompressProc(void *lpParameter)
 CMP_ERROR ThreadedCompressTexture(const CMP_Texture* pSourceTexture, CMP_Texture* pDestTexture, const CMP_CompressOptions* pOptions, CMP_Feedback_Proc pFeedbackProc, CMP_DWORD_PTR pUser1, CMP_DWORD_PTR pUser2, CodecType destType)
 {
     // Note function should not be called for the following Codecs....
-    if (destType == CT_BC7)  return CMP_ABORTED; 
+    if (destType == CT_BC7)  return CMP_ABORTED;
     if (destType == CT_GT)   return CMP_ABORTED;
-    if (destType == CT_ASTC) return CMP_ABORTED; 
+    if (destType == CT_ASTC) return CMP_ABORTED;
 
     CMP_DWORD dwMaxThreadCount = min(f_dwProcessorCount, MAX_THREADS);
     CMP_DWORD dwLinesRemaining = pDestTexture->dwHeight;
@@ -640,8 +640,8 @@ CMP_ERROR ThreadedCompressTexture(const CMP_Texture* pSourceTexture, CMP_Texture
 
             switch(destType)
             {
-            case CT_BC6H: 
-                    // Reserved 
+            case CT_BC6H:
+                    // Reserved
                     break;
             }
 
@@ -674,7 +674,7 @@ CMP_ERROR ThreadedCompressTexture(const CMP_Texture* pSourceTexture, CMP_Texture
 
         if(dwHeight > 0)
         {
-            threadData.m_pSrcBuffer = CreateCodecBuffer(srcBufferType, 
+            threadData.m_pSrcBuffer = CreateCodecBuffer(srcBufferType,
                                                         pSourceTexture->nBlockWidth, pSourceTexture->nBlockHeight, pSourceTexture->nBlockDepth,
                                                         pSourceTexture->dwWidth, dwHeight, pSourceTexture->dwPitch, pSourceData);
             threadData.m_pDestBuffer = threadData.m_pCodec->CreateBuffer(


### PR DESCRIPTION
- fixes for many GCC warnings due to #pragma warning
- added CMP_NULL definition for usage with CMP_DWORD_PTR to fix GCC warning
- fixed an issue where std::byte conflicted with a definition of byte, preventing compilation with the latest C++17 standard

If any MSVC feature is used please enclose it in an #ifdef _MSC_VER preprocessor conditional block.