### PR TITLE
Ignore format-security error

### DIFF
--- a/Compressonator/Applications/_Plugins/Common/cmdline.cpp
+++ b/Compressonator/Applications/_Plugins/Common/cmdline.cpp
@@ -1827,6 +1827,11 @@ bool GenerateImageProps(std::string ImageFile)
 
 void LocalPrintF(char* buff)
 {
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wformat-security"            // warning : warning: format string is not a string literal
+#elif defined(__GNUC__)
+#pragma GCC diagnostic ignored "-Wformat-security"              // warning : format string is not a string literal (potentially insecure)
+#endif
     printf(buff);
 }
 


### PR DESCRIPTION
Without this patch, the project does not build with newer compiler
versions like gcc 9.