### PR TITLE
Fix for N first blocks garbage BC7 encodings, for N threaded CPUs.

### DIFF
--- a/Compressonator/Applications/_Plugins/CCMP_Encode/HPC/Compute_CPU_HPC.cpp
+++ b/Compressonator/Applications/_Plugins/CCMP_Encode/HPC/Compute_CPU_HPC.cpp
@@ -43,8 +43,8 @@ unsigned int    _stdcall ProcEncode(void* param)
 {
    ThreadParam *tp = (ThreadParam*)param;
 
-   tp->run = false;
    //printf("Thead Active [%4x]\n",std::this_thread::get_id());
+   std::this_thread::sleep_for(0ms);
 
    while (tp->exit == false)
    {

--- a/Compressonator/Applications/_Plugins/CCMP_Encode/HPC/Compute_CPU_HPC.cpp
+++ b/Compressonator/Applications/_Plugins/CCMP_Encode/HPC/Compute_CPU_HPC.cpp
@@ -46,7 +46,7 @@ unsigned int    _stdcall ProcEncode(void* param)
    //printf("Thead Active [%4x]\n",std::this_thread::get_id());
    std::this_thread::sleep_for(0ms);
 
-   while (tp->exit == false)
+   do 
    {
        if (tp->run == true)
        {
@@ -56,7 +56,7 @@ unsigned int    _stdcall ProcEncode(void* param)
 
         using namespace chrono;
         std::this_thread::sleep_for(0ms);
-   }
+   } while (tp->exit == false);
 
    // printf("Thead Closed [%x] run[%d]\n",std::this_thread::get_id(),tp->run?1:0);
    return 0;

--- a/Compressonator/Applications/_Plugins/CCMP_Encode/HPC/Compute_CPU_HPC.cpp
+++ b/Compressonator/Applications/_Plugins/CCMP_Encode/HPC/Compute_CPU_HPC.cpp
@@ -46,7 +46,7 @@ unsigned int    _stdcall ProcEncode(void* param)
    //printf("Thead Active [%4x]\n",std::this_thread::get_id());
    std::this_thread::sleep_for(0ms);
 
-   do 
+   while (tp->exit == false)
    {
        if (tp->run == true)
        {
@@ -56,7 +56,7 @@ unsigned int    _stdcall ProcEncode(void* param)
 
         using namespace chrono;
         std::this_thread::sleep_for(0ms);
-   } while (tp->exit == false);
+   }
 
    // printf("Thead Closed [%x] run[%d]\n",std::this_thread::get_id(),tp->run?1:0);
    return 0;


### PR DESCRIPTION
First of all, this fix has been done from debugging BC7 HPC codepath, where tp->run has already initialized with false value.
In my case I tested the encoding on a FX-8320 and i7-8sthing (W10: 18363) both with 8 threads, where in both cases first 8 blocks on encoding was likely (non deterministic) garbage. Some of the first 8 blocks was fine, but most of them not (garbage).
So I will begin with my explanation of the bug based on the old code.
Let's say the just created thread (around at line 100 std::thread is called) is created and "runs" first to line where `tp->run = false;` executes. Everything is fine :D.
Now let's say it doesn't "runs" first but command `m_EncodeParameterStorage[threadIndex].run = true;` (around at line 179) runs first, Then encoding has a "green" light but if `tp->run = false;` runs on the newly created threads we have a f up. No encoding happens at that block.
So what does this fix does? Just avoids the chance of "green" light to turn back to "red" if initialzing code of the new thread runs slower than the main thread code.

Sorry for my lossy explanation but trying to pass how I saw the code and fixed it.