### PR TITLE
Added BC4 and BC5 tests

### DIFF
--- a/Compressonator/Applications/_Plugins/Common/UtilFuncs.cpp
+++ b/Compressonator/Applications/_Plugins/Common/UtilFuncs.cpp
@@ -59,7 +59,7 @@ void SwizzleBytes(void* src, unsigned long numBytes)
 }
 #ifdef _WIN32
 
-static float HalfToFloat(uint16_t h)
+float HalfToFloat(uint16_t h)
 {
     union FP32
     {
@@ -73,8 +73,8 @@ static float HalfToFloat(uint16_t h)
         };
     };
 
-    static const FP32 magic      = { (254 - 15) << 23 };
-    static const FP32 was_infnan = { (127 + 16) << 23 };
+    const FP32 magic      = { (254 - 15) << 23 };
+    const FP32 was_infnan = { (127 + 16) << 23 };
 
     FP32 o;
     o.u = (h & 0x7fff) << 13;       // exponent/mantissa bits

--- a/Compressonator/Applications/_Plugins/Common/UtilFuncs.h
+++ b/Compressonator/Applications/_Plugins/Common/UtilFuncs.h
@@ -47,6 +47,7 @@ HWND FindTopLevelWindow(TCHAR* pszName);
 
 void SwizzleBytes(void* src, unsigned long numBytes);
 #ifdef _WIN32
+float HalfToFloat(uint16_t h);
 void getFileNameExt(const char *FilePathName, char *fnameExt, int maxbuffsize);
 bool writeObjFileState(std::string filename, std::string state);
 std::string readObjFileState(std::string filename);

--- a/Compressonator/CMP_Core/test/BlockConstants.h
+++ b/Compressonator/CMP_Core/test/BlockConstants.h
@@ -77,6 +77,54 @@ static const unsigned char BC3_Red_Green_Ignore_Alpha [] {0xff, 0xff, 0x0 , 0x0 
 static const unsigned char BC3_Green_Blue_Ignore_Alpha [] {0xff, 0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0xff, 0x7 , 0xff, 0x7 , 0x0 , 0x0 , 0x0 , 0x0 };
 static const unsigned char BC3_Red_Half_Alpha [] {0x7b, 0x7b, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0xf8, 0x0 , 0xf8, 0x0 , 0x0 , 0x0 , 0x0 };
 static const unsigned char BC3_Green_Half_Alpha [] {0x7b, 0x7b, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0xe0, 0x7 , 0xe0, 0x7 , 0x0 , 0x0 , 0x0 , 0x0 };
+static const unsigned char BC4_Red_Ignore_Alpha [] {0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
+static const unsigned char BC4_Blue_Half_Alpha [] {0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24};
+static const unsigned char BC4_White_Half_Alpha [] {0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
+static const unsigned char BC4_Black_Half_Alpha [] {0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24};
+static const unsigned char BC4_Red_Blue_Half_Alpha [] {0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
+static const unsigned char BC4_Red_Green_Half_Alpha [] {0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
+static const unsigned char BC4_Green_Blue_Half_Alpha [] {0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24};
+static const unsigned char BC4_Red_Full_Alpha [] {0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
+static const unsigned char BC4_Green_Full_Alpha [] {0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24};
+static const unsigned char BC4_Blue_Full_Alpha [] {0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24};
+static const unsigned char BC4_White_Full_Alpha [] {0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
+static const unsigned char BC4_Green_Ignore_Alpha [] {0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24};
+static const unsigned char BC4_Black_Full_Alpha [] {0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24};
+static const unsigned char BC4_Red_Blue_Full_Alpha [] {0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
+static const unsigned char BC4_Red_Green_Full_Alpha [] {0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
+static const unsigned char BC4_Green_Blue_Full_Alpha [] {0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24};
+static const unsigned char BC4_Blue_Ignore_Alpha [] {0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24};
+static const unsigned char BC4_White_Ignore_Alpha [] {0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
+static const unsigned char BC4_Black_Ignore_Alpha [] {0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24};
+static const unsigned char BC4_Red_Blue_Ignore_Alpha [] {0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
+static const unsigned char BC4_Red_Green_Ignore_Alpha [] {0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
+static const unsigned char BC4_Green_Blue_Ignore_Alpha [] {0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24};
+static const unsigned char BC4_Red_Half_Alpha [] {0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
+static const unsigned char BC4_Green_Half_Alpha [] {0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24};
+static const unsigned char BC5_Red_Ignore_Alpha [] {0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24};
+static const unsigned char BC5_Blue_Half_Alpha [] {0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24, 0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24};
+static const unsigned char BC5_White_Half_Alpha [] {0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
+static const unsigned char BC5_Black_Half_Alpha [] {0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24, 0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24};
+static const unsigned char BC5_Red_Blue_Half_Alpha [] {0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24};
+static const unsigned char BC5_Red_Green_Half_Alpha [] {0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
+static const unsigned char BC5_Green_Blue_Half_Alpha [] {0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24, 0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
+static const unsigned char BC5_Red_Full_Alpha [] {0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24};
+static const unsigned char BC5_Green_Full_Alpha [] {0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24, 0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
+static const unsigned char BC5_Blue_Full_Alpha [] {0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24, 0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24};
+static const unsigned char BC5_White_Full_Alpha [] {0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
+static const unsigned char BC5_Green_Ignore_Alpha [] {0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24, 0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
+static const unsigned char BC5_Black_Full_Alpha [] {0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24, 0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24};
+static const unsigned char BC5_Red_Blue_Full_Alpha [] {0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24};
+static const unsigned char BC5_Red_Green_Full_Alpha [] {0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
+static const unsigned char BC5_Green_Blue_Full_Alpha [] {0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24, 0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
+static const unsigned char BC5_Blue_Ignore_Alpha [] {0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24, 0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24};
+static const unsigned char BC5_White_Ignore_Alpha [] {0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
+static const unsigned char BC5_Black_Ignore_Alpha [] {0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24, 0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24};
+static const unsigned char BC5_Red_Blue_Ignore_Alpha [] {0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24};
+static const unsigned char BC5_Red_Green_Ignore_Alpha [] {0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
+static const unsigned char BC5_Green_Blue_Ignore_Alpha [] {0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24, 0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
+static const unsigned char BC5_Red_Half_Alpha [] {0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24};
+static const unsigned char BC5_Green_Half_Alpha [] {0xff, 0x0 , 0x49, 0x92, 0x24, 0x49, 0x92, 0x24, 0xff, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
 static const unsigned char BC6_Red_Ignore_Alpha [] {0xe3, 0x3d, 0x0 , 0x0 , 0x78, 0xf , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
 static const unsigned char BC6_Blue_Half_Alpha [] {0x3 , 0x0 , 0x0 , 0xde, 0x3 , 0x0 , 0x80, 0xf7, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
 static const unsigned char BC6_White_Half_Alpha [] {0xe3, 0xbd, 0xf7, 0xde, 0x7b, 0xef, 0xbd, 0xf7, 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 , 0x0 };
@@ -198,6 +246,54 @@ Block BC3_Red_Green_Ignore_Alpha_Block = {BC3_Red_Green_Ignore_Alpha, nullptr};
 Block BC3_Green_Blue_Ignore_Alpha_Block = {BC3_Green_Blue_Ignore_Alpha, nullptr};
 Block BC3_Red_Half_Alpha_Block = {BC3_Red_Half_Alpha, nullptr};
 Block BC3_Green_Half_Alpha_Block = {BC3_Green_Half_Alpha, nullptr};
+Block BC4_Red_Ignore_Alpha_Block = {BC4_Red_Ignore_Alpha, nullptr};
+Block BC4_Blue_Half_Alpha_Block = {BC4_Blue_Half_Alpha, nullptr};
+Block BC4_White_Half_Alpha_Block = {BC4_White_Half_Alpha, nullptr};
+Block BC4_Black_Half_Alpha_Block = {BC4_Black_Half_Alpha, nullptr};
+Block BC4_Red_Blue_Half_Alpha_Block = {BC4_Red_Blue_Half_Alpha, nullptr};
+Block BC4_Red_Green_Half_Alpha_Block = {BC4_Red_Green_Half_Alpha, nullptr};
+Block BC4_Green_Blue_Half_Alpha_Block = {BC4_Green_Blue_Half_Alpha, nullptr};
+Block BC4_Red_Full_Alpha_Block = {BC4_Red_Full_Alpha, nullptr};
+Block BC4_Green_Full_Alpha_Block = {BC4_Green_Full_Alpha, nullptr};
+Block BC4_Blue_Full_Alpha_Block = {BC4_Blue_Full_Alpha, nullptr};
+Block BC4_White_Full_Alpha_Block = {BC4_White_Full_Alpha, nullptr};
+Block BC4_Green_Ignore_Alpha_Block = {BC4_Green_Ignore_Alpha, nullptr};
+Block BC4_Black_Full_Alpha_Block = {BC4_Black_Full_Alpha, nullptr};
+Block BC4_Red_Blue_Full_Alpha_Block = {BC4_Red_Blue_Full_Alpha, nullptr};
+Block BC4_Red_Green_Full_Alpha_Block = {BC4_Red_Green_Full_Alpha, nullptr};
+Block BC4_Green_Blue_Full_Alpha_Block = {BC4_Green_Blue_Full_Alpha, nullptr};
+Block BC4_Blue_Ignore_Alpha_Block = {BC4_Blue_Ignore_Alpha, nullptr};
+Block BC4_White_Ignore_Alpha_Block = {BC4_White_Ignore_Alpha, nullptr};
+Block BC4_Black_Ignore_Alpha_Block = {BC4_Black_Ignore_Alpha, nullptr};
+Block BC4_Red_Blue_Ignore_Alpha_Block = {BC4_Red_Blue_Ignore_Alpha, nullptr};
+Block BC4_Red_Green_Ignore_Alpha_Block = {BC4_Red_Green_Ignore_Alpha, nullptr};
+Block BC4_Green_Blue_Ignore_Alpha_Block = {BC4_Green_Blue_Ignore_Alpha, nullptr};
+Block BC4_Red_Half_Alpha_Block = {BC4_Red_Half_Alpha, nullptr};
+Block BC4_Green_Half_Alpha_Block = {BC4_Green_Half_Alpha, nullptr};
+Block BC5_Red_Ignore_Alpha_Block = {BC5_Red_Ignore_Alpha, nullptr};
+Block BC5_Blue_Half_Alpha_Block = {BC5_Blue_Half_Alpha, nullptr};
+Block BC5_White_Half_Alpha_Block = {BC5_White_Half_Alpha, nullptr};
+Block BC5_Black_Half_Alpha_Block = {BC5_Black_Half_Alpha, nullptr};
+Block BC5_Red_Blue_Half_Alpha_Block = {BC5_Red_Blue_Half_Alpha, nullptr};
+Block BC5_Red_Green_Half_Alpha_Block = {BC5_Red_Green_Half_Alpha, nullptr};
+Block BC5_Green_Blue_Half_Alpha_Block = {BC5_Green_Blue_Half_Alpha, nullptr};
+Block BC5_Red_Full_Alpha_Block = {BC5_Red_Full_Alpha, nullptr};
+Block BC5_Green_Full_Alpha_Block = {BC5_Green_Full_Alpha, nullptr};
+Block BC5_Blue_Full_Alpha_Block = {BC5_Blue_Full_Alpha, nullptr};
+Block BC5_White_Full_Alpha_Block = {BC5_White_Full_Alpha, nullptr};
+Block BC5_Green_Ignore_Alpha_Block = {BC5_Green_Ignore_Alpha, nullptr};
+Block BC5_Black_Full_Alpha_Block = {BC5_Black_Full_Alpha, nullptr};
+Block BC5_Red_Blue_Full_Alpha_Block = {BC5_Red_Blue_Full_Alpha, nullptr};
+Block BC5_Red_Green_Full_Alpha_Block = {BC5_Red_Green_Full_Alpha, nullptr};
+Block BC5_Green_Blue_Full_Alpha_Block = {BC5_Green_Blue_Full_Alpha, nullptr};
+Block BC5_Blue_Ignore_Alpha_Block = {BC5_Blue_Ignore_Alpha, nullptr};
+Block BC5_White_Ignore_Alpha_Block = {BC5_White_Ignore_Alpha, nullptr};
+Block BC5_Black_Ignore_Alpha_Block = {BC5_Black_Ignore_Alpha, nullptr};
+Block BC5_Red_Blue_Ignore_Alpha_Block = {BC5_Red_Blue_Ignore_Alpha, nullptr};
+Block BC5_Red_Green_Ignore_Alpha_Block = {BC5_Red_Green_Ignore_Alpha, nullptr};
+Block BC5_Green_Blue_Ignore_Alpha_Block = {BC5_Green_Blue_Ignore_Alpha, nullptr};
+Block BC5_Red_Half_Alpha_Block = {BC5_Red_Half_Alpha, nullptr};
+Block BC5_Green_Half_Alpha_Block = {BC5_Green_Half_Alpha, nullptr};
 BlockBC6 BC6_Red_Ignore_Alpha_Block = {BC6_Red_Ignore_Alpha, nullptr};
 BlockBC6 BC6_Blue_Half_Alpha_Block = {BC6_Blue_Half_Alpha, nullptr};
 BlockBC6 BC6_White_Half_Alpha_Block = {BC6_White_Half_Alpha, nullptr};
@@ -320,6 +416,54 @@ static std::unordered_map<std::string, Block> blocks {
 	{ "BC3_Green_Blue_Ignore_Alpha", BC3_Green_Blue_Ignore_Alpha_Block},
 	{ "BC3_Red_Half_Alpha", BC3_Red_Half_Alpha_Block},
 	{ "BC3_Green_Half_Alpha", BC3_Green_Half_Alpha_Block},
+	{ "BC4_Red_Ignore_Alpha", BC4_Red_Ignore_Alpha_Block},
+	{ "BC4_Blue_Half_Alpha", BC4_Blue_Half_Alpha_Block},
+	{ "BC4_White_Half_Alpha", BC4_White_Half_Alpha_Block},
+	{ "BC4_Black_Half_Alpha", BC4_Black_Half_Alpha_Block},
+	{ "BC4_Red_Blue_Half_Alpha", BC4_Red_Blue_Half_Alpha_Block},
+	{ "BC4_Red_Green_Half_Alpha", BC4_Red_Green_Half_Alpha_Block},
+	{ "BC4_Green_Blue_Half_Alpha", BC4_Green_Blue_Half_Alpha_Block},
+	{ "BC4_Red_Full_Alpha", BC4_Red_Full_Alpha_Block},
+	{ "BC4_Green_Full_Alpha", BC4_Green_Full_Alpha_Block},
+	{ "BC4_Blue_Full_Alpha", BC4_Blue_Full_Alpha_Block},
+	{ "BC4_White_Full_Alpha", BC4_White_Full_Alpha_Block},
+	{ "BC4_Green_Ignore_Alpha", BC4_Green_Ignore_Alpha_Block},
+	{ "BC4_Black_Full_Alpha", BC4_Black_Full_Alpha_Block},
+	{ "BC4_Red_Blue_Full_Alpha", BC4_Red_Blue_Full_Alpha_Block},
+	{ "BC4_Red_Green_Full_Alpha", BC4_Red_Green_Full_Alpha_Block},
+	{ "BC4_Green_Blue_Full_Alpha", BC4_Green_Blue_Full_Alpha_Block},
+	{ "BC4_Blue_Ignore_Alpha", BC4_Blue_Ignore_Alpha_Block},
+	{ "BC4_White_Ignore_Alpha", BC4_White_Ignore_Alpha_Block},
+	{ "BC4_Black_Ignore_Alpha", BC4_Black_Ignore_Alpha_Block},
+	{ "BC4_Red_Blue_Ignore_Alpha", BC4_Red_Blue_Ignore_Alpha_Block},
+	{ "BC4_Red_Green_Ignore_Alpha", BC4_Red_Green_Ignore_Alpha_Block},
+	{ "BC4_Green_Blue_Ignore_Alpha", BC4_Green_Blue_Ignore_Alpha_Block},
+	{ "BC4_Red_Half_Alpha", BC4_Red_Half_Alpha_Block},
+	{ "BC4_Green_Half_Alpha", BC4_Green_Half_Alpha_Block},
+	{ "BC5_Red_Ignore_Alpha", BC5_Red_Ignore_Alpha_Block},
+	{ "BC5_Blue_Half_Alpha", BC5_Blue_Half_Alpha_Block},
+	{ "BC5_White_Half_Alpha", BC5_White_Half_Alpha_Block},
+	{ "BC5_Black_Half_Alpha", BC5_Black_Half_Alpha_Block},
+	{ "BC5_Red_Blue_Half_Alpha", BC5_Red_Blue_Half_Alpha_Block},
+	{ "BC5_Red_Green_Half_Alpha", BC5_Red_Green_Half_Alpha_Block},
+	{ "BC5_Green_Blue_Half_Alpha", BC5_Green_Blue_Half_Alpha_Block},
+	{ "BC5_Red_Full_Alpha", BC5_Red_Full_Alpha_Block},
+	{ "BC5_Green_Full_Alpha", BC5_Green_Full_Alpha_Block},
+	{ "BC5_Blue_Full_Alpha", BC5_Blue_Full_Alpha_Block},
+	{ "BC5_White_Full_Alpha", BC5_White_Full_Alpha_Block},
+	{ "BC5_Green_Ignore_Alpha", BC5_Green_Ignore_Alpha_Block},
+	{ "BC5_Black_Full_Alpha", BC5_Black_Full_Alpha_Block},
+	{ "BC5_Red_Blue_Full_Alpha", BC5_Red_Blue_Full_Alpha_Block},
+	{ "BC5_Red_Green_Full_Alpha", BC5_Red_Green_Full_Alpha_Block},
+	{ "BC5_Green_Blue_Full_Alpha", BC5_Green_Blue_Full_Alpha_Block},
+	{ "BC5_Blue_Ignore_Alpha", BC5_Blue_Ignore_Alpha_Block},
+	{ "BC5_White_Ignore_Alpha", BC5_White_Ignore_Alpha_Block},
+	{ "BC5_Black_Ignore_Alpha", BC5_Black_Ignore_Alpha_Block},
+	{ "BC5_Red_Blue_Ignore_Alpha", BC5_Red_Blue_Ignore_Alpha_Block},
+	{ "BC5_Red_Green_Ignore_Alpha", BC5_Red_Green_Ignore_Alpha_Block},
+	{ "BC5_Green_Blue_Ignore_Alpha", BC5_Green_Blue_Ignore_Alpha_Block},
+	{ "BC5_Red_Half_Alpha", BC5_Red_Half_Alpha_Block},
+	{ "BC5_Green_Half_Alpha", BC5_Green_Half_Alpha_Block},
 	{ "BC7_Red_Ignore_Alpha", BC7_Red_Ignore_Alpha_Block},
 	{ "BC7_Blue_Half_Alpha", BC7_Blue_Half_Alpha_Block},
 	{ "BC7_White_Half_Alpha", BC7_White_Half_Alpha_Block},

--- a/Compressonator/CMP_Core/test/CMakeLists.txt
+++ b/Compressonator/CMP_Core/test/CMakeLists.txt
@@ -9,5 +9,7 @@ target_sources(Tests
                 CompressonatorTests.cpp
                 CompressonatorTests.h
                 BlockConstants.h
+		../../Applications/_Plugins/Common/UtilFuncs.cpp
+		../../Applications/_Plugins/Common/UtilFuncs.h
                 )
 target_link_libraries(Tests Catch2::Catch2 CMP_Core)


### PR DESCRIPTION
UtilFuncs: HalfToFloat changed the signature to non-static and added HalfToFloat to UtilFuncs.h.
The CompressonatorTests.cpp does now use the HalfToFloat function instead of intrinsic.