### PR TITLE
Compress images inside glTF 2.0

### DIFF
--- a/Compressonator/Applications/_Plugins/Common/cmdline.cpp
+++ b/Compressonator/Applications/_Plugins/Common/cmdline.cpp
@@ -1578,6 +1578,24 @@ bool CompressDecompressMesh(std::string SourceFile, std::string DestFile)
                         memset(&inMips, 0, sizeof(CMP_MipSet));
                         int ret  = AMDLoadMIPSTextureImage((imgSrcDir + input).c_str(), &inMips, false, &g_pluginManager);
 
+                        if (inMips.m_nMipLevels < g_CmdPrams.MipsLevel)
+                        {
+                          CMP_INT requestLevel = g_CmdPrams.MipsLevel; // Request 10 miplevels for the source image
+
+                          //------------------------------------------------------------------------
+                          // Checks what the minimum image size will be for the requested mip levels
+                          // if the request is too large, a adjusted minimum size will be returned
+                          //------------------------------------------------------------------------
+                          CMP_INT nMinSize = CMP_CalcMinMipSize(inMips.m_nHeight, inMips.m_nWidth, 10);
+
+                          //--------------------------------------------------------------
+                          // now that the minimum size is known, generate the miplevels
+                          // users can set any requested minumum size to use. The correct
+                          // miplevels will be set acordingly.
+                          //--------------------------------------------------------------
+                          CMP_GenerateMIPLevels(&inMips, nMinSize);
+                        }
+
                         CMP_MipSet mipSetCmp;
                         memset(&mipSetCmp, 0, sizeof(CMP_MipSet));
 

--- a/Compressonator/Applications/_Plugins/Common/cmdline.cpp
+++ b/Compressonator/Applications/_Plugins/Common/cmdline.cpp
@@ -1587,8 +1587,17 @@ bool CompressDecompressMesh(std::string SourceFile, std::string DestFile)
                         kernel_options.threads  = g_CmdPrams.CompressOptions.dwnumThreads;
                         kernel_options.height   = inMips.dwHeight;
                         kernel_options.width    = inMips.dwWidth;
+                        kernel_options.encodeWith = g_CmdPrams.CompressOptions.nEncodeWith;
 
                         auto cmp_status = CMP_ProcessTexture(&inMips, &mipSetCmp, kernel_options, CompressionCallback);
+                        if (cmp_status == CMP_ERR_FAILED_HOST_SETUP)
+                        {
+                            g_CmdPrams.CompressOptions.nEncodeWith = CMP_Compute_type::CMP_CPU;
+                            kernel_options.encodeWith = g_CmdPrams.CompressOptions.nEncodeWith;
+                            memset(&mipSetCmp, 0, sizeof(CMP_MipSet));
+                            cmp_status = CMP_ProcessTexture(&inMips, &mipSetCmp, kernel_options, CompressionCallback);
+                        }
+
                         if (cmp_status != CMP_OK)
                         {
                             PrintInfo("Error: Something went wrong while compressing image!\n");

--- a/Compressonator/Applications/_Plugins/Common/cmdline.cpp
+++ b/Compressonator/Applications/_Plugins/Common/cmdline.cpp
@@ -1578,7 +1578,7 @@ bool CompressDecompressMesh(std::string SourceFile, std::string DestFile)
                         memset(&inMips, 0, sizeof(CMP_MipSet));
                         int ret  = AMDLoadMIPSTextureImage((imgSrcDir + input).c_str(), &inMips, false, &g_pluginManager);
 
-                        if (inMips.m_nMipLevels < g_CmdPrams.MipsLevel)
+                        if (inMips.m_nMipLevels < g_CmdPrams.MipsLevel && ! g_CmdPrams.use_noMipMaps)
                         {
                           CMP_INT requestLevel = g_CmdPrams.MipsLevel; // Request 10 miplevels for the source image
 
@@ -1605,6 +1605,8 @@ bool CompressDecompressMesh(std::string SourceFile, std::string DestFile)
                         kernel_options.format   = g_CmdPrams.CompressOptions.DestFormat;
                         kernel_options.fquality = g_CmdPrams.CompressOptions.fquality;
                         kernel_options.threads  = g_CmdPrams.CompressOptions.dwnumThreads;
+                        kernel_options.height   = inMips.dwHeight;
+                        kernel_options.width    = inMips.dwWidth;
 
                         auto cmp_status = CMP_ProcessTexture(&inMips, &mipSetCmp, kernel_options, CompressionCallback);
                         if (cmp_status != CMP_OK)
@@ -1621,18 +1623,6 @@ bool CompressDecompressMesh(std::string SourceFile, std::string DestFile)
                         }
                     }
 
-/*
-                    //TODO: wrapper to handle more arguments: mipcount, threadcount, astc block size & quality
-                    //TODO: non-hardcoded process name
-                    boost::process::child c = boost::process::child("CompressonatorCLI-bin", "-fd", "BC7", imgSrcDir + input, output);
-                    c.wait();
-                    int exit_code = c.exit_code();
-                    if(exit_code != 0)
-                    {
-                      PrintInfo("Error: Something went wrong while compressing image!\n");
-                      return false;
-                    }
-*/
                     boost::filesystem::copy(imgSrcDir+input, dstFolder + input);
 
                 }

--- a/Compressonator/Applications/_Plugins/Common/cmdline.h
+++ b/Compressonator/Applications/_Plugins/Common/cmdline.h
@@ -164,6 +164,8 @@ class CCmdLineParamaters
     int decompress_nIterations;
     double compute_setup_fDuration;
 
+    bool compressImagesFromGLTF;
+
     // Analysis data
     double    SSIM;            // Structural Similarity Index: Average of RGB Channels
     double    PSNR;            // Peak Signal to Noise Ratio: Average of RGB Channels

--- a/Compressonator/Applications/_Plugins/Common/cmdline.h
+++ b/Compressonator/Applications/_Plugins/Common/cmdline.h
@@ -116,6 +116,8 @@ class CCmdLineParamaters
         CompressOptions.DestFormat     = CMP_FORMAT_Unknown;
         CompressOptions.SourceFormat   = CMP_FORMAT_Unknown;
 
+        compressImagesFromGLTF = false;
+
         LogProcessResultsFile.assign(LOG_PROCESS_RESULTS_FILE_TXT);
     }
 

--- a/Compressonator/Applications/_Plugins/Common/gltf/tiny_gltf2_utils.cpp
+++ b/Compressonator/Applications/_Plugins/Common/gltf/tiny_gltf2_utils.cpp
@@ -4794,7 +4794,6 @@ namespace tinygltf2
             if(option.DestFormat != CMP_FORMAT_Unknown)
             {
                 output["extensionsUsed"].push_back("MSFT_texture_dds");
-                PrintInfo("Compressing all images inside gltf\n");
             }
             json textures;
             for (unsigned int i = 0; i < model->textures.size(); ++i)

--- a/Compressonator/CMP_CompressonatorLib/Common.h
+++ b/Compressonator/CMP_CompressonatorLib/Common.h
@@ -31,7 +31,6 @@
 #include <string>
 #include <cstring>
 
-#include "UseDefinitions.h"
 #include "Compressonator.h"
 
 using namespace std;

--- a/Compressonator/CMP_CompressonatorLib/Compressonator.h
+++ b/Compressonator/CMP_CompressonatorLib/Compressonator.h
@@ -31,7 +31,7 @@
 #include <vector>
 #include <stddef.h>
 
-#include "UseDefinitions.h"
+#include "../UseDefinitions.h"
 
 #ifndef _LINUX
 using namespace std;

--- a/Compressonator/CMP_Framework/Compute_Base.cpp
+++ b/Compressonator/CMP_Framework/Compute_Base.cpp
@@ -667,6 +667,7 @@ CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSe
 
             // Do the compression
             if (CMP_CompressTexture(&kernelOptions, *srcMipSet, *dstMipSet,pFeedbackProc) != CMP_OK) {
+                CMips.FreeMipSet(dstMipSet);
                 CMP_DestroyComputeLibrary(false);
                 PrintInfo("Failed to run compute plugin: CPU will be used for compression.\n");
                 return CMP_ERR_FAILED_HOST_SETUP;


### PR DESCRIPTION
This adds the `-compress-gltf-images` flag to the CLI version. It will cause compression of images referenced in glTF file, save those as DDS files and use [MSFT_texture_dds](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Vendor/MSFT_texture_dds) to reference compressed variants in outputted glTF-file.

TextureIO is used for file opening and saving DDS (there was already a comment that this feature should use it).
For compression this uses "Compressonator Framework"'s CMP_ProcessTexture-functions, which seems to only work with BC-formats right now. This choice was made as I couldn't get other ways to produce the `CMP_MipSet` required by TextureIO. 
