### PR TITLE
Add missing options to API

### DIFF
--- a/Compressonator/CMP_Core/shaders/BC1_Encode_kernel.cpp
+++ b/Compressonator/CMP_Core/shaders/BC1_Encode_kernel.cpp
@@ -202,6 +202,15 @@ int CMP_CDECL SetChannelWeightsBC1(void *options,
     return CGU_CORE_OK;
 }
 
+int CMP_CDECL SetGammaBC1(void *options,
+                          CGU_BOOL sRGB) {
+    if (!options) return CGU_CORE_ERR_INVALIDPTR;
+    CMP_BC15Options *BC15optionsDefault = (CMP_BC15Options *)options;
+
+    BC15optionsDefault->m_bIsSRGB = sRGB;
+    return CGU_CORE_OK;
+}
+
 int CMP_CDECL CompressBlockBC1(const unsigned char *srcBlock,
                                unsigned int srcStrideInBytes,
                                CMP_GLOBAL unsigned char cmpBlock[8],

--- a/Compressonator/CMP_Core/shaders/BC2_Encode_kernel.cpp
+++ b/Compressonator/CMP_Core/shaders/BC2_Encode_kernel.cpp
@@ -121,6 +121,15 @@ int CMP_CDECL SetChannelWeightsBC2(void *options,
     return CGU_CORE_OK;
 }
 
+int CMP_CDECL SetGammaBC2(void *options,
+                          CGU_BOOL sRGB) {
+    if (!options) return CGU_CORE_ERR_INVALIDPTR;
+    CMP_BC15Options *BC15optionsDefault = (CMP_BC15Options *)options;
+
+    BC15optionsDefault->m_bIsSRGB = sRGB;
+    return CGU_CORE_OK;
+}
+
 #define EXPLICIT_ALPHA_PIXEL_MASK 0xf
 #define EXPLICIT_ALPHA_PIXEL_BPP  4
 

--- a/Compressonator/CMP_Core/shaders/BC3_Encode_kernel.cpp
+++ b/Compressonator/CMP_Core/shaders/BC3_Encode_kernel.cpp
@@ -124,6 +124,14 @@ int CMP_CDECL SetChannelWeightsBC3(void *options,
     return CGU_CORE_OK;
 }
 
+int CMP_CDECL SetGammaBC3(void *options,
+                          CGU_BOOL sRGB) {
+    if (!options) return CGU_CORE_ERR_INVALIDPTR;
+    CMP_BC15Options *BC15optionsDefault = (CMP_BC15Options *)options;
+
+    BC15optionsDefault->m_bIsSRGB = sRGB;
+    return CGU_CORE_OK;
+}
 
 void DecompressBC3_Internal(CMP_GLOBAL CGU_UINT8 rgbaBlock[64],
                             const CGU_UINT32 compressedBlock[4],

--- a/Compressonator/CMP_Core/shaders/BC4_Encode_kernel.cpp
+++ b/Compressonator/CMP_Core/shaders/BC4_Encode_kernel.cpp
@@ -127,6 +127,15 @@ int CMP_CDECL SetQualityBC4(void *options,
     return CGU_CORE_OK;
 }
 
+int CMP_CDECL SetSignedBC4(void *options,
+                           CGU_BOOL snorm) {
+    if (!options) return CGU_CORE_ERR_INVALIDPTR;
+    CMP_BC15Options *BC15optionsDefault = reinterpret_cast <CMP_BC15Options *>(options);
+    
+    BC15optionsDefault->m_bIsSNORM = snorm;
+    return CGU_CORE_OK;
+}
+
 int CMP_CDECL CompressBlockBC4(const unsigned char *srcBlock,
                                unsigned int srcStrideInBytes,
                                CMP_GLOBAL unsigned char cmpBlock[8],

--- a/Compressonator/CMP_Core/shaders/BC5_Encode_kernel.cpp
+++ b/Compressonator/CMP_Core/shaders/BC5_Encode_kernel.cpp
@@ -176,6 +176,14 @@ int CMP_CDECL SetQualityBC5(void *options,
     return CGU_CORE_OK;
 }
 
+int CMP_CDECL SetSignedBC5(void *options,
+                           CGU_BOOL snorm) {
+    if (!options) return CGU_CORE_ERR_INVALIDPTR;
+    CMP_BC15Options *BC15optionsDefault = reinterpret_cast <CMP_BC15Options *>(options);
+    
+    BC15optionsDefault->m_bIsSNORM = snorm;
+    return CGU_CORE_OK;
+}
 
 int CMP_CDECL CompressBlockBC5(const CGU_UINT8 *srcBlockR,
                                unsigned int srcStrideInBytes1,

--- a/Compressonator/CMP_Core/shaders/BC6_Encode_kernel.cpp
+++ b/Compressonator/CMP_Core/shaders/BC6_Encode_kernel.cpp
@@ -3803,7 +3803,7 @@ int CMP_CDECL CreateOptionsBC6(void **options)
 {
     (*options) = new BC6H_Encode;
     if (!options) return CGU_CORE_ERR_NEWMEM;
-    SetDefaultBC6Options((BC6H_Encode *)options);
+    SetDefaultBC6Options((BC6H_Encode *)(*options));
     return CGU_CORE_OK;
 }
 
@@ -3834,6 +3834,14 @@ int CMP_CDECL SetMaskBC6(void *options, CGU_UINT32 mask)
     if (!options) return CGU_CORE_ERR_INVALIDPTR;
     BC6H_Encode *BC6options = (BC6H_Encode *)options;
     BC6options->m_validModeMask = mask;
+    return CGU_CORE_OK;
+}
+
+int CMP_CDECL SetSignedBC6(void *options, CGU_BOOL sf16)
+{
+    if (!options) return CGU_CORE_ERR_INVALIDPTR;
+    BC6H_Encode *BC6options = (BC6H_Encode *)options;
+    BC6options->m_isSigned = sf16;
     return CGU_CORE_OK;
 }
 

--- a/Compressonator/CMP_Core/shaders/BC7_Encode_Kernel.cpp
+++ b/Compressonator/CMP_Core/shaders/BC7_Encode_Kernel.cpp
@@ -5188,6 +5188,15 @@ int CMP_CDECL SetAlphaOptionsBC7(void *options, CGU_BOOL imageNeedsAlpha, CGU_BO
     return CGU_CORE_OK;
 }
 
+int CMP_CDECL SetGammaBC7(void *options,
+                          CGU_BOOL sRGB) {
+    if (!options) return CGU_CORE_ERR_INVALIDPTR;
+    BC7_Encode *BC7options = (BC7_Encode *)options;
+
+    // BC7options->sRGB = sRGB; // TODO: Implement this option
+    return CGU_CORE_ERR_UNKOWN; // Since it doesn't work today
+}
+
 int CMP_CDECL CompressBlockBC7( const unsigned char *srcBlock,
                                 unsigned int srcStrideInBytes,
                                 CMP_GLOBAL unsigned char cmpBlock[16],

--- a/Compressonator/CMP_Core/source/CMP_Core.h
+++ b/Compressonator/CMP_Core/source/CMP_Core.h
@@ -97,6 +97,21 @@ int CMP_CDECL SetMaskBC7(void *options, unsigned char mask);
 int CMP_CDECL SetAlphaOptionsBC7(void *options, bool imageNeedsAlpha, bool colourRestrict, bool alphaRestrict);
 int CMP_CDECL SetErrorThresholdBC7(void *options, float minThreshold, float maxThreshold);
 
+// Set if the content is in sRGB color space (true) or linear (false).
+// The default is false.
+int CMP_CDECL SetGammaBC1(void *options, bool sRGB);
+int CMP_CDECL SetGammaBC2(void *options, bool sRGB);
+int CMP_CDECL SetGammaBC3(void *options, bool sRGB);
+int CMP_CDECL SetGammaBC7(void *options, bool sRGB);
+
+// Set if the content is signed (true) or unsigned (false).
+// The default is false.
+// For BC4 and BC5 this determines if the encoded or decoded byte is treated as SNORM or UNORM.
+// For BC6, the encoded or decoded data is always FP16, but affects the clamping of the values UF16 vs SF16.
+int CMP_CDECL SetSignedBC4(void *options, bool snorm);
+int CMP_CDECL SetSignedBC5(void *options, bool snorm);
+int CMP_CDECL SetSignedBC6(void *options, bool sf16);
+
 //======================================================================================================
 // (4x4) Block level 4 channel source CompressBlock and DecompressBlock API for BCn Codecs
 //======================================================================================================


### PR DESCRIPTION
See https://github.com/GPUOpen-Tools/compressonator/issues/115

Add the missing pieces, however some may not take effect until next point release (ie: BC7 Gamma, BC4&5 signedness).

Also fix issue with BC6 option creation trampling callers stack.