### PR TITLE
Fix unsigned int8 to float conversion in CMP_Core RG to BC5 compression function

### DIFF
--- a/CMP_Core/shaders/BC5_Encode_kernel.cpp
+++ b/CMP_Core/shaders/BC5_Encode_kernel.cpp
@@ -115,8 +115,8 @@ void  CompressBlockBC5_DualChannel_Internal(const CGU_UINT8 srcBlockR[16],
 
     for (CGU_INT i =0; i< 16; i++)
     {
-        srcAlphaRF[i] = srcBlockR[i];
-        srcAlphaGF[i] = srcBlockG[i];
+        srcAlphaRF[i] = (CGU_FLOAT)( srcBlockR[i] ) / 255.0f;
+        srcAlphaGF[i] = (CGU_FLOAT)( srcBlockG[i] ) / 255.0f;
     } 
 
     cmpBlock = cmp_compressAlphaBlock(srcAlphaRF,BC15options->m_fquality);


### PR DESCRIPTION
In function CompressBlockBC5_DualChannel_Internal, the conversion from uint8 srcBlockR/srcBlockG to float srcAlphaRF/srcAlphaGF is not complete.