### PR TITLE
Replaced boost proeprty_map with rapidxml

### DIFF
--- a/Applications/CompressonatorGUI/Components/cpImageCompare.cpp
+++ b/Applications/CompressonatorGUI/Components/cpImageCompare.cpp
@@ -29,6 +29,9 @@
 #include <QIcon>
 #include <QMap>
 
+// for XML file processing
+#include <cmp_rapidxml.hpp>
+
 #include "cpImageCompare.h"
 #include "cpMainComponents.h"
 
@@ -393,53 +396,56 @@ bool CImageCompare::setAnalysisResultView()
     if ((CMP_FileExists(m_analyzedResult)))
     {
         // populate tree structure pt
-        using boost::property_tree::ptree;
-        ptree pt;
-        std::ifstream input(m_analyzedResult);
-        read_xml(input, pt);
+
+        rapidxml::file<>* xmlResultsFile = new rapidxml::file<>(m_analyzedResult.c_str());
+        rapidxml::xml_document<> xmlDoc; xmlDoc.parse<rapidxml::parse_no_data_nodes>(xmlResultsFile->data());
 
         // traverse pt
-        BOOST_FOREACH(ptree::value_type const&v, pt.get_child("ANALYSIS"))
+        rapidxml::xml_node<>* levelElement = xmlDoc.first_node("ANALYSIS");
+        for (rapidxml::xml_node<>* child = levelElement->first_node(); child != NULL; child = child->next_sibling())
         {
-            if (v.first == "DATA")
+            if (std::string(child->name()) == "DATA")
             {
                 if (ssimAnalysis && !psnrAnalysis)
                 {
-                    
-                    m_ssimAnalysis->m_SSIM = v.second.get<double>("SSIM");
-                    m_ssimAnalysis->m_SSIM_Blue = v.second.get<double>("SSIM_BLUE");
-                    m_ssimAnalysis->m_SSIM_Green = v.second.get<double>("SSIM_GREEN");
-                    m_ssimAnalysis->m_SSIM_Red = v.second.get<double>("SSIM_RED");
+                    m_ssimAnalysis->m_SSIM = std::stod(child->first_node("SSIM")->value());
+                    m_ssimAnalysis->m_SSIM_Blue = std::stod(child->first_node("SSIM_BLUE")->value());
+                    m_ssimAnalysis->m_SSIM_Green = std::stod(child->first_node("SSIM_GREEN")->value());
+                    m_ssimAnalysis->m_SSIM_Red = std::stod(child->first_node("SSIM_RED")->value());
                 }
                 else if (!ssimAnalysis && psnrAnalysis)
                 {
-                    m_psnrAnalysis->m_MSE = v.second.get<double>("MSE");
-                    m_psnrAnalysis->m_PSNR = v.second.get<double>("PSNR");
-                    m_psnrAnalysis->m_PSNR_Blue = v.second.get<double>("PSNR_BLUE");
-                    m_psnrAnalysis->m_PSNR_Green = v.second.get<double>("PSNR_GREEN");
-                    m_psnrAnalysis->m_PSNR_Red = v.second.get<double>("PSNR_RED");
+                    m_psnrAnalysis->m_MSE = std::stod(child->first_node("MSE")->value()); 
+                    m_psnrAnalysis->m_PSNR = std::stod(child->first_node("PSNR")->value());
+                    m_psnrAnalysis->m_PSNR_Blue = std::stod(child->first_node("PSNR_BLUE")->value());
+                    m_psnrAnalysis->m_PSNR_Green = std::stod(child->first_node("PSNR_GREEN")->value());
+                    m_psnrAnalysis->m_PSNR_Red = std::stod(child->first_node("PSNR_RED")->value());
                 }
                 else if (ssimAnalysis && psnrAnalysis)
                 {
                
-                    m_allAnalysis->m_SSIM = v.second.get<double>("SSIM");
-                    m_allAnalysis->m_SSIM_Blue = v.second.get<double>("SSIM_BLUE");
-                    m_allAnalysis->m_SSIM_Green = v.second.get<double>("SSIM_GREEN");
-                    m_allAnalysis->m_SSIM_Red = v.second.get<double>("SSIM_RED");
+                    m_allAnalysis->m_SSIM = std::stod(child->first_node("SSIM")->value());
+                    m_allAnalysis->m_SSIM_Blue = std::stod(child->first_node("SSIM_BLUE")->value());
+                    m_allAnalysis->m_SSIM_Green = std::stod(child->first_node("SSIM_GREEN")->value());
+                    m_allAnalysis->m_SSIM_Red = std::stod(child->first_node("PSNSSIM_REDR_RED")->value());
 
-                    m_allAnalysis->m_MSE = v.second.get<double>("MSE");
-                    m_allAnalysis->m_PSNR = v.second.get<double>("PSNR");
-                    m_allAnalysis->m_PSNR_Blue = v.second.get<double>("PSNR_BLUE");
-                    m_allAnalysis->m_PSNR_Green = v.second.get<double>("PSNR_GREEN");
-                    m_allAnalysis->m_PSNR_Red = v.second.get<double>("PSNR_RED");
+                    m_allAnalysis->m_MSE = std::stod(child->first_node("MSE")->value());
+                    m_allAnalysis->m_PSNR = std::stod(child->first_node("PSNR")->value());
+                    m_allAnalysis->m_PSNR_Blue = std::stod(child->first_node("PSNR_BLUE")->value());
+                    m_allAnalysis->m_PSNR_Green = std::stod(child->first_node("PSNR_GREEN")->value());
+                    m_allAnalysis->m_PSNR_Red = std::stod(child->first_node("PSNR_RED")->value());
                 }
             }
         }
        // QFile::remove(QString::fromStdString(m_analyzedResult));
+        xmlDoc.clear();
+        delete xmlResultsFile;
         return true;
     }
     else
+    {
         return false;
+    }
 }
 
 CImageCompare::~CImageCompare()

--- a/Applications/CompressonatorGUI/Components/cpImageCompare.h
+++ b/Applications/CompressonatorGUI/Components/cpImageCompare.h
@@ -30,9 +30,6 @@
 #include <QtWidgets>
 #include "cpImageView.h"
 #include "cpImageAnalysis.h"
-#include <boost/foreach.hpp>
-#include <boost/property_tree/xml_parser.hpp>
-#include <boost/property_tree/ptree.hpp>
 #include "acCustomDockWidget.h"
 #include "cpProjectData.h"
 #include "CMP_FileIO.h"
@@ -81,9 +78,9 @@ private:
     cpImageView               *m_imageviewDiff;
     cpImageView               *m_imageviewFile2;
     C_AnalysisData            *m_imageAnalysis;
-    C_SSIM_Analysis            *m_ssimAnalysis;
-    C_MSE_PSNR_Analysis        *m_allAnalysis;
-    C_PSNR_MSE_Analysis        *m_psnrAnalysis;
+    C_SSIM_Analysis           *m_ssimAnalysis;
+    C_MSE_PSNR_Analysis       *m_allAnalysis;
+    C_PSNR_MSE_Analysis       *m_psnrAnalysis;
  
     const QString              m_title;
     QString                    m_sourceFile;

--- a/Applications/CompressonatorGUI/VS2017/MainApp.vcxproj
+++ b/Applications/CompressonatorGUI/VS2017/MainApp.vcxproj
@@ -1563,15 +1563,19 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_MD|Win32'">
     <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(Compressonator_RAPIDXML);$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_MD|x64'">
     <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(Compressonator_RAPIDXML);$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_MD|Win32'">
     <TargetName>Compressonator</TargetName>
+    <IncludePath>$(Compressonator_RAPIDXML);$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_MD|x64'">
     <TargetName>Compressonator</TargetName>
+    <IncludePath>$(Compressonator_RAPIDXML);$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_MD|Win32'">
     <ClCompile>

--- a/Applications/_Plugins/CAnalysis/Analysis/VS2017/CAnalysis.vcxproj
+++ b/Applications/_Plugins/CAnalysis/Analysis/VS2017/CAnalysis.vcxproj
@@ -113,15 +113,19 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_MD|Win32'">
     <TargetExt>.lib</TargetExt>
+    <IncludePath>$(Compressonator_RAPIDXML);$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_MD|x64'">
     <TargetExt>.lib</TargetExt>
+    <IncludePath>$(Compressonator_RAPIDXML);$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_MD|Win32'">
     <TargetExt>.lib</TargetExt>
+    <IncludePath>$(Compressonator_RAPIDXML);$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_MD|x64'">
     <TargetExt>.lib</TargetExt>
+    <IncludePath>$(Compressonator_RAPIDXML);$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug_MD|Win32'">
     <ClCompile>

--- a/Compressonator_Root.props
+++ b/Compressonator_Root.props
@@ -16,6 +16,7 @@
     <Compressonator_OPENEXR>$(SolutionDir)..\..\..\..\Common\Lib\Ext\OpenEXR\openexr-2.2.0\</Compressonator_OPENEXR>
     <Compressonator_ILMBASE>$(SolutionDir)..\..\..\..\Common\Lib\Ext\OpenEXR\ilmbase-2.2.0\</Compressonator_ILMBASE>
     <Compressonator_OPENGL>$(SolutionDir)..\..\..\..\Common\Lib\Ext\OpenGL\</Compressonator_OPENGL>
+    <Compressonator_RAPIDXML>$(SolutionDir)..\..\..\External\rapidxml\</Compressonator_RAPIDXML>
     <Compressonator_TINYXML>$(SolutionDir)..\..\..\..\Common\Lib\Ext\tinyxml\2.6.2\</Compressonator_TINYXML>
     <Compressonator_ZLIB>$(SolutionDir)..\..\..\..\Common\Lib\Ext\zlib\1.2.8\</Compressonator_ZLIB>
     <Compressonator_FLTK>$(SolutionDir)..\..\..\..\Common\Lib\Ext\Fltk\1.3.4\</Compressonator_FLTK>

--- a/External/rapidxml/CMakeLists.txt
+++ b/External/rapidxml/CMakeLists.txt
@@ -1,0 +1,11 @@
+
+
+set(RAPIDXML_DIR ${CMAKE_CURRENT_LIST_DIR}/rapidxml-submodule)
+
+add_library(ExtRapidXML INTERFACE)
+
+target_include_directories(ExtRapidXML INTERFACE
+
+    ${RAPIDXML_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}
+)

--- a/External/rapidxml/cmp_rapidxml.hpp
+++ b/External/rapidxml/cmp_rapidxml.hpp
@@ -1,0 +1,49 @@
+#ifndef CMP_RAPIDXML_H_INCLUDE
+#define CMP_RAPIDXML_H_INCLUDE
+
+#if defined(_WIN32) && !defined(NO_LEGACY_BEHAVIOR)
+#include "rapidxml-submodule/rapidxml.hpp"
+#include "rapidxml-submodule/rapidxml_utils.hpp"
+#else
+#include <rapidxml.hpp>
+#include <rapidxml_utils.hpp>
+#endif
+/* Adding declarations to make it compatible with gcc 4.7 and greater */
+namespace rapidxml
+{
+    namespace internal
+    {
+        template <class OutIt, class Ch>
+        inline OutIt print_children(OutIt out, const xml_node<Ch>* node, int flags, int indent);
+
+        template <class OutIt, class Ch>
+        inline OutIt print_attributes(OutIt out, const xml_node<Ch>* node, int flags);
+
+        template <class OutIt, class Ch>
+        inline OutIt print_data_node(OutIt out, const xml_node<Ch>* node, int flags, int indent);
+
+        template <class OutIt, class Ch>
+        inline OutIt print_cdata_node(OutIt out, const xml_node<Ch>* node, int flags, int indent);
+
+        template <class OutIt, class Ch>
+        inline OutIt print_element_node(OutIt out, const xml_node<Ch>* node, int flags, int indent);
+
+        template <class OutIt, class Ch>
+        inline OutIt print_declaration_node(OutIt out, const xml_node<Ch>* node, int flags, int indent);
+
+        template <class OutIt, class Ch>
+        inline OutIt print_comment_node(OutIt out, const xml_node<Ch>* node, int flags, int indent);
+
+        template <class OutIt, class Ch>
+        inline OutIt print_doctype_node(OutIt out, const xml_node<Ch>* node, int flags, int indent);
+
+        template <class OutIt, class Ch>
+        inline OutIt print_pi_node(OutIt out, const xml_node<Ch>* node, int flags, int indent);
+    }
+}
+#if defined(_WIN32) && !defined(NO_LEGACY_BEHAVIOR)
+#include "rapidxml-submodule/rapidxml_print.hpp"
+#else
+#include <rapidxml_print.hpp>
+#endif
+#endif

--- a/build/fetch_dependencies.py
+++ b/build/fetch_dependencies.py
@@ -75,7 +75,8 @@ gitMapping = {
     ghRoot+"common-lib-ext-OpenGL.git"          : ["Common/Lib/Ext/OpenGL",     "master"],
     ghRoot+"common-lib-ext-tinyxml-2.6.2.git"   : ["Common/Lib/Ext/tinyxml",    "master"],
     ghRoot+"common-lib-ext-zlib-1.2.8.git"      : ["Common/Lib/Ext/zlib",       "master"],
-    "https://github.com/g-truc/glm.git"         : ["Common/Lib/Ext/glm",        "master"]
+    "https://github.com/g-truc/glm.git"         : ["Common/Lib/Ext/glm",        "master"],
+    "https://github.com/discord/rapidxml.git"   : ["External/rapidxml/rapidxml-submodule", "master"]
 }
 
 # The following section contains OS-specific dependencies that are downloaded and placed in the specified target directory.


### PR DESCRIPTION
First step to removing boost as a dependency. RapidXML is the what boost uses in it's `property_tree` so the performance should be pretty comparable. With boost removed as a dependency, compiling for all platforms becomes way simpler.