### PR TITLE
Fix compile error with /c++:20.

### DIFF
--- a/cmp_core/shaders/bcn_common_kernel.h
+++ b/cmp_core/shaders/bcn_common_kernel.h
@@ -224,7 +224,7 @@ typedef struct
     CGU_Vec3i  avg;
 } CMP_EncodeData;
 
-typedef struct
+typedef struct CMP_BC1_Block_t
 {
     // Union struct not supported on GPU
     // 8 Bytes Total


### PR DESCRIPTION
Unnamed classes may not contain member functions in C++. This triggers a warning in MSVC in C++14/17 mode (C5208) which turns into an error in C++20 mode C7626.

See: https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5208?view=msvc-170