### PR TITLE
OpenCL: Changed CGU_UINT64 typedef back to "unsigned long"

### DIFF
--- a/cmp_core/shaders/common_def.h
+++ b/cmp_core/shaders/common_def.h
@@ -324,13 +324,13 @@ typedef unsigned int CGU_UINT;
 typedef int          CGUV_INT;
 typedef int          CGV_BOOL;
 
-typedef char               CGU_INT8;
-typedef unsigned char      CGU_UINT8;
-typedef short              CGU_INT16;
-typedef unsigned short     CGU_UINT16;
-typedef int                CGU_INT32;
-typedef unsigned int       CGU_UINT32;
-typedef unsigned long long CGU_UINT64;
+typedef char           CGU_INT8;
+typedef unsigned char  CGU_UINT8;
+typedef short          CGU_INT16;
+typedef unsigned short CGU_UINT16;
+typedef int            CGU_INT32;
+typedef unsigned int   CGU_UINT32;
+typedef unsigned long  CGU_UINT64;
 
 typedef char           CGV_INT8;
 typedef unsigned char  CGV_UINT8;


### PR DESCRIPTION
In OpenCL, "unsigned long long" corresponds to a 128bit integer and is a reserved type name: https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_C.html#reserved-data-types

The Nvidia CUDA implementation of the OpenCL C compiler reported the following error:
```
common_def.h:333:18: error: use of 128 bit type is not supported
typedef unsigned long long CGU_UINT64;
                 ^
```

I don't think this change impacts other compilers, but I haven't thoroughly tested it.