### PR TITLE
Revert "OpenCL: Changed CGU_UINT64 typedef back to "unsigned long""

### DIFF
--- a/cmp_core/shaders/common_def.h
+++ b/cmp_core/shaders/common_def.h
@@ -324,13 +324,13 @@ typedef unsigned int CGU_UINT;
 typedef int          CGUV_INT;
 typedef int          CGV_BOOL;
 
-typedef char           CGU_INT8;
-typedef unsigned char  CGU_UINT8;
-typedef short          CGU_INT16;
-typedef unsigned short CGU_UINT16;
-typedef int            CGU_INT32;
-typedef unsigned int   CGU_UINT32;
-typedef unsigned long  CGU_UINT64;
+typedef char               CGU_INT8;
+typedef unsigned char      CGU_UINT8;
+typedef short              CGU_INT16;
+typedef unsigned short     CGU_UINT16;
+typedef int                CGU_INT32;
+typedef unsigned int       CGU_UINT32;
+typedef unsigned long long CGU_UINT64;
 
 typedef char           CGV_INT8;
 typedef unsigned char  CGV_UINT8;


### PR DESCRIPTION
Reverts GPUOpen-Tools/compressonator#209
See: https://docs.microsoft.com/en-us/cpp/cpp/data-type-ranges?view=msvc-170 
The original definition is correct, for 8 byte size, reverting this change for further investigation