### PR TITLE
- fall back to stb since function exists for CLI

### DIFF
--- a/applications/_plugins/common/textureio.cpp
+++ b/applications/_plugins/common/textureio.cpp
@@ -761,7 +761,9 @@ int AMDLoadMIPSTextureImage(const char *SourceFile, MipSet *MipSetIn, bool use_O
 
         return result;
 #else
-        return -1;
+        //DS - fallback to stb, push for a minimal commandline size and load time...
+        extern CMP_ERROR stb_load(const char* SourceFile, MipSet* MipSetIn); 
+        return stb_load(SourceFile, MipSetIn);
 #endif
     }
 


### PR DESCRIPTION
There is a strange difference between CMP_LoadTexture and AMDLoadMIPSTextureImage in which the later requires QT for simple formats. The goal being to have a minimal and useful dev CLI tool. Plus QT is a hot mess that reasonable people wouldn't install.