### PR TITLE
Fix issues with Linux build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,16 +216,17 @@ else()
     endif()
 endif()
 
+# Configure Externals, they must be added via 'include' before the applications
+include(ExternalProject)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+include(external/cmake/dependencyinfo.cmake)
+include(external/cmake/CMakeLists.txt)
+include(external/CMakeLists.txt)
+
 if (CMP_HOST_WINDOWS)
     add_compile_definitions(WIN32_LEAN_AND_MEAN=1 _WIN32)
 
     set(CMAKE_EXE_LINKER_FLAGS "/INCREMENTAL:NO")
-    # Configure Externals, they must be added via 'include' before the applications
-    include(${CMAKE_ROOT}/modules/externalproject.cmake)
-    set_property(GLOBAL PROPERTY USE_FOLDERS ON)
-    include(external/cmake/dependencyinfo.cmake)
-    include(external/cmake/CMakeLists.txt)
-    include(external/CMakeLists.txt)
 else()
     if (CMP_HOST_LINUX)
         #gltf code needs _LINUX define

--- a/applications/_plugins/common/cmdline.cpp
+++ b/applications/_plugins/common/cmdline.cpp
@@ -69,7 +69,7 @@ using namespace tinygltf2;
 
 #ifndef _WIN32
 #include <fcntl.h> /* For O_RDWR */
-#include <gltf/stb_image.h>
+#include <stb_image.h>
 #include <stdarg.h>
 #include <time.h>
 #include <wchar.h>

--- a/examples/cmp_prototype/CMakeLists.txt
+++ b/examples/cmp_prototype/CMakeLists.txt
@@ -24,11 +24,10 @@ target_include_directories(cmp_prototype PUBLIC
 
 target_link_libraries(cmp_prototype
     PRIVATE
-    ExtGLM 
+    ExtGLM
     ExtGLFW
     CMP_Framework
     CMP_Compressonator
-    d3d11.lib
 )
 
 set_target_properties(cmp_prototype 

--- a/external/glfw/CMakeLists.txt
+++ b/external/glfw/CMakeLists.txt
@@ -2,15 +2,25 @@ cmake_minimum_required(VERSION 3.13)
 
 message(STATUS "++++++++++++++++++ External GLFW" )
 
-# if(POLICY CMP0091)
-#   cmake_policy(SET CMP0091 NEW)
-# endif()
+# Setting default values for GLFW variables so that we build what we need
+SET(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries" FORCE)
+SET(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "Build the GLFW example programs" FORCE)
+SET(GLFW_BUILD_TESTS OFF CACHE BOOL "Build the GLFW test programs" FORCE)
+SET(GLFW_BUILD_DOCS OFF CACHE BOOL "Build the GLFW documentation" FORCE)
+SET(GLFW_INSTALL OFF CACHE BOOL "Generate installation target" FORCE)
 
-#project(CompressonatorGLFW)
+ExternalProject_Add(extern_glfw
+    SOURCE_DIR ${PROJECT_SOURCE_DIR}/../common/lib/ext/glfw
+    BINARY_DIR ${PROJECT_SOURCE_DIR}/../common/lib/ext/glfw/build
+    INSTALL_COMMAND cmake -E echo "Skipping install step."
+)
+
 add_library(ExtGLFW INTERFACE)
 
-set(ExtGLFW_BIN_PATH ${PROJECT_SOURCE_DIR}/../common/lib/ext/glfw/glfw-3.3.2.bin.WIN64)
-set(GLFW_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/../common/lib/ext/glfw/glfw-3.3.2.bin.WIN64/include)
+set(GLFW_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/../common/lib/ext/glfw/include)
 
-target_link_libraries(ExtGLFW INTERFACE ${PROJECT_SOURCE_DIR}/../common/lib/ext/glfw/glfw-3.3.2.bin.WIN64/lib-vc2017/glfw3.lib)
-target_include_directories(ExtGLFW INTERFACE ${PROJECT_SOURCE_DIR}/../common/lib/ext/glfw/glfw-3.3.2.bin.WIN64/include)
+target_include_directories(ExtGLFW INTERFACE ${PROJECT_SOURCE_DIR}/../common/lib/ext/glfw/include)
+
+target_link_libraries(ExtGLFW INTERFACE
+    ${PROJECT_SOURCE_DIR}/../common/lib/ext/glfw/build/src/$<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>/glfw3.lib
+)

--- a/scripts/fetch_dependencies.py
+++ b/scripts/fetch_dependencies.py
@@ -15,6 +15,7 @@ import urllib
 import zipfile
 import tarfile
 import platform
+import shutil
 
 isPython3OrAbove = None
 if sys.version_info[0] >= 3:
@@ -74,38 +75,40 @@ ghRoot = "https://github.com/GPUOpen-Tools/"
 
 # Libs to build on Window
 gitMappingWin = {
-     ghRoot+"Catch2.git"                         : ["../common/lib/ext/catch2",     "master"],
-     ghRoot+"common_lib_ext_glew_1.9.git"        : ["../common/lib/ext/glew",       "master"],
-     ghRoot+"common_lib_ext_opencv_2.49.git"     : ["../common/lib/ext/opencv",     "master"],
-     ghRoot+"common_lib_ext_openexr_2.2.git"     : ["../common/lib/ext/openexr",    "master"],
-     ghRoot+"common_lib_ext_opengl.git"          : ["../common/lib/ext/opengl",     "master"],
-     ghRoot+"common_lib_ext_tinyxml_2.6.2.git"   : ["../common/lib/ext/tinyxml",    "master"],
-     ghRoot+"common_lib_ext_zlib_1.2.10.git"     : ["../common/lib/ext/zlib",       "master"],
-     "https://github.com/g-truc/glm.git"         : ["../common/lib/ext/glm",        "0.9.8.0"],
-     "https://github.com/discord/rapidxml.git"   : ["../common/lib/ext/rapidxml",   "master"],
-     "https://github.com/KhronosGroup/KTX-Software.git" : ["../common/lib/ext/ktx", "v4.0.0-beta4"],
-     "https://github.com/apitrace/dxsdk"         : ["../common/lib/ext/apitrace/dxsdk", "master"],
+    ghRoot+"Catch2.git"                         : ["../common/lib/ext/catch2",     "master"],
+    ghRoot+"common_lib_ext_glew_1.9.git"        : ["../common/lib/ext/glew",       "master"],
+    ghRoot+"common_lib_ext_opencv_2.49.git"     : ["../common/lib/ext/opencv",     "master"],
+    ghRoot+"common_lib_ext_openexr_2.2.git"     : ["../common/lib/ext/openexr",    "master"],
+    ghRoot+"common_lib_ext_opengl.git"          : ["../common/lib/ext/opengl",     "master"],
+    ghRoot+"common_lib_ext_tinyxml_2.6.2.git"   : ["../common/lib/ext/tinyxml",    "master"],
+    ghRoot+"common_lib_ext_zlib_1.2.10.git"     : ["../common/lib/ext/zlib",       "master"],
+    "https://github.com/g-truc/glm.git"         : ["../common/lib/ext/glm",        "0.9.8.0"],
+    "https://github.com/discord/rapidxml.git"   : ["../common/lib/ext/rapidxml",   "master"],
+    "https://github.com/KhronosGroup/KTX-Software.git" : ["../common/lib/ext/ktx", "v4.0.0-beta4"],
+    "https://github.com/apitrace/dxsdk"         : ["../common/lib/ext/apitrace/dxsdk", "master"],
+    "https://github.com/glfw/glfw/"             : ["../common/lib/ext/glfw",        "3.3.2"]
 }
 
 # Libs to build on Linux
 gitMappingLin = {
-     ghRoot+"common_lib_ext_openexr_2.2.git"     : ["../common/lib/ext/openexr",    "master"],
-     "https://github.com/g-truc/glm.git"         : ["../common/lib/ext/glm",        "0.9.8.0"],
-     "https://github.com/discord/rapidxml.git"   : ["../common/lib/ext/rapidxml",   "master"],
+    ghRoot+"common_lib_ext_openexr_2.2.git"     : ["../common/lib/ext/openexr",    "master"],
+    "https://github.com/g-truc/glm.git"         : ["../common/lib/ext/glm",        "0.9.8.0"],
+    "https://github.com/discord/rapidxml.git"   : ["../common/lib/ext/rapidxml",   "master"],
+    "https://github.com/glfw/glfw/"             : ["../common/lib/ext/glfw",        "3.3.2"]
 }
 
 # Libs to build on Unix
 gitMappingUni = {
-     ghRoot+"common_lib_ext_openexr_2.2.git"     : ["../common/lib/ext/openexr",    "master"],
-     "https://github.com/g-truc/glm.git"         : ["../common/lib/ext/glm",        "0.9.8.0"],
-     "https://github.com/discord/rapidxml.git"   : ["../common/lib/ext/rapidxml",   "master"],
+    ghRoot+"common_lib_ext_openexr_2.2.git"     : ["../common/lib/ext/openexr",    "master"],
+    "https://github.com/g-truc/glm.git"         : ["../common/lib/ext/glm",        "0.9.8.0"],
+    "https://github.com/discord/rapidxml.git"   : ["../common/lib/ext/rapidxml",   "master"],
+    "https://github.com/glfw/glfw/"             : ["../common/lib/ext/glfw",        "3.3.2"]
 }
 
 # The following section contains OS-specific dependencies that are downloaded and placed in the specified target directory.
 # key = GitHub release link
 # value = location
 downloadMappingWin = {
-    "https://github.com/glfw/glfw/releases/download/3.3.2/glfw-3.3.2.bin.WIN64.zip" : "../../common/lib/ext/glfw/",
     "https://github.com/microsoft/DirectXTex/archive/jun2020b.zip" : "../../common/lib/ext/directxtex/",
     "https://github.com/GPUOpen-LibrariesAndSDKs/OCL-SDK/files/1406216/lightOCLSDK.zip" : "../../common/lib/ext/opencl/",
 }
@@ -119,6 +122,10 @@ downloadMappingUni = {
     "http://download.savannah.nongnu.org/releases/openexr/ilmbase-2.2.0.tar.gz": "../../common/lib/ext/openexr2/ilmbase",
     "http://download.savannah.nongnu.org/releases/openexr/openexr-2.2.0.tar.gz": "../../common/lib/ext/openexr2/openexr",
 }
+
+userAgentWin = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246"
+userAgentLin = "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1"
+userAgentUni = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/601.3.9 (KHTML, like Gecko) Version/9.0.2 Safari/601.3.9"
 
 # detect the OS
 MACHINE_OS = ""
@@ -139,15 +146,19 @@ print("BUILD MACHINE AS:",MACHINE_OS)
 # reference the correct archive path
 gitMapping = ""
 downloadMapping = ""
+userAgentString = ""
 if MACHINE_OS == "LINUX":
     gitMapping = gitMappingLin
     downloadMapping = downloadMappingLin
+    userAgentString = userAgentLin
 if MACHINE_OS == "WINDOWS":
     gitMapping = gitMappingWin
     downloadMapping = downloadMappingWin
+    userAgentString = userAgentWin
 if MACHINE_OS == "UNIX":
     gitMapping = gitMappingUni
     downloadMapping = downloadMappingUni
+    userAgentString = userAgentUni
 
 # for each dependency - test if it has already been fetched - if not, then fetch it, otherwise update it to top of tree
 def downloadgit(key, path, reqdCommit):
@@ -204,7 +215,11 @@ def downloadandunzip(key, value):
     if False == os.path.isfile(zipPath):
         print("\nDownloading " + key + " into " + zipPath)
         if isPython3OrAbove:
-            urllib.request.urlretrieve(key, zipPath)
+            req = urllib.request.Request(key, headers={"User-Agent": userAgentString})
+            
+            with urllib.request.urlopen(req) as response:
+                with open(zipPath, 'wb') as outputFile:
+                    shutil.copyfileobj(response, outputFile)
         else:
             urllib.urlretrieve(key, zipPath)
         if os.path.splitext(zipPath)[1] == ".zip":


### PR DESCRIPTION
Reworked how files are downloaded in the fetch dependencies script, removing the use of urllib.request.urlretrieve which would have permission issues on Linux.

Changed external GLFW download from a Windows-only zip file, to downloading and building from the GitHub repository. Enabling use by both Windows and Linux.