### PR TITLE
Compressonator Framework Build Added to GitHub Action File

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,15 +7,11 @@ env:
   BUILD_TYPE: Release
 
 jobs:
-  build:
-    # The CMake configure and build commands are platform agnostic and should work equally
-    # well on Windows or Mac.  You can convert this to a matrix build if you need
-    # cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+  build_compressonator_cli:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory
@@ -43,11 +39,97 @@ jobs:
       run: cmake --build . --config $BUILD_TYPE
 
     - name: Upload Build Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with: 
-          name: compressonatlrCLI_64_Windows_Master_Build
+          name: CompressonatorCLI_64_Windows_Master_Build
           path: ${{github.workspace}}/build/bin/Release
+  
+  build_compressonator_framework:
+    runs-on: windows-latest
 
+    steps:
+      - uses: actions/checkout@v3
 
+      - name: Create Build Environment
+        # Some projects don't allow in-source building, so create a separate build directory
+        # We'll use this as our working directory for all subsequent commands
+        run: cmake -E make_directory ${{github.workspace}}/build
+      
+      - name: Sync external libs
+        working-directory: ${{github.workspace}}/scripts
+        run: python fetch_dependencies.py
+      
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
 
+      - name: Build Framework Release Win32
+        run: 'msbuild -target:build -property:Configuration=Release -property:Platform=Win32 -m VS2019\cmp_framework.sln'
 
+      - name: Build Framework Debug Win32
+        run: 'msbuild -target:build -property:Configuration=Debug -property:Platform=Win32 -m VS2019\cmp_framework.sln'
+
+      - name: Build Framework Release x64
+        run: 'msbuild -target:build -property:Configuration=Release -property:Platform=x64 -m VS2019\cmp_framework.sln'
+      
+      - name: Build Framework Debug x64
+        run: 'msbuild -target:build -property:Configuration=Debug -property:Platform=x64 -m VS2019\cmp_framework.sln'
+
+      - name: Build Framework Release_MD Win32
+        run: 'msbuild -target:build -property:Configuration=Release_MD -property:Platform=Win32 -m VS2019\cmp_framework.sln'
+
+      - name: Build Framework Debug_MD Win32
+        run: 'msbuild -target:build -property:Configuration=Debug_MD -property:Platform=Win32 -m VS2019\cmp_framework.sln'
+
+      - name: Build Framework Release_MD x64
+        run: 'msbuild -target:build -property:Configuration=Release_MD -property:Platform=x64 -m VS2019\cmp_framework.sln'
+
+      - name: Build Framework Debug_MD x64
+        run: 'msbuild -target:build -property:Configuration=Debug_MD -property:Platform=x64 -m VS2019\cmp_framework.sln'
+
+      - name: Build Framework Release_DLL Win32
+        run: 'msbuild -target:build -property:Configuration=Release_DLL -property:Platform=Win32 -m VS2019\cmp_framework.sln'
+
+      - name: Build Framework Debug_DLL Win32
+        run: 'msbuild -target:build -property:Configuration=Debug_DLL -property:Platform=Win32 -m VS2019\cmp_framework.sln'
+
+      - name: Build Framework Release_DLL x64
+        run: 'msbuild -target:build -property:Configuration=Release_DLL -property:Platform=x64 -m VS2019\cmp_framework.sln'
+
+      - name: Build Framework Debug_DLL x64
+        run: 'msbuild -target:build -property:Configuration=Debug_DLL -property:Platform=x64 -m VS2019\cmp_framework.sln'
+
+      - name: Build Framework Release_MD_DLL Win32
+        run: 'msbuild -target:build -property:Configuration=Release_MD_DLL -property:Platform=Win32 -m VS2019\cmp_framework.sln'
+
+      - name: Build Framework Debug_MD_DLL Win32
+        run: 'msbuild -target:build -property:Configuration=Debug_MD_DLL -property:Platform=Win32 -m VS2019\cmp_framework.sln'
+
+      - name: Build Framework Release_MD_DLL x64
+        run: 'msbuild -target:build -property:Configuration=Release_MD_DLL -property:Platform=x64 -m VS2019\cmp_framework.sln'
+
+      - name: Build Framework Debug_MD_DLL x64
+        run: 'msbuild -target:build -property:Configuration=Debug_MD_DLL -property:Platform=x64 -m VS2019\cmp_framework.sln'
+
+      - name: Create folder structure for build results
+        run: |
+          mkdir CompressonatorFramework_result\lib\encoders
+          mkdir CompressonatorFramework_result\include
+          mkdir CompressonatorFramework_result\lib\VS2019\x64
+          mkdir CompressonatorFramework_result\lib\VS2019\x86
+
+      - name: Copy files into build results directory
+        shell: bash
+        run: |
+          cp build/Release*/x64/{*.lib,*.dll} CompressonatorFramework_result/lib/VS2019/x64/
+          cp build/Release*/Win32/{*.lib,*.dll} CompressonatorFramework_result/lib/VS2019/x86/
+          cp build/Debug*/x64/{*.lib,*.dll} CompressonatorFramework_result/lib/VS2019/x64/
+          cp build/Debug*/Win32/{*.lib,*.dll} CompressonatorFramework_result/lib/VS2019/x86/
+          cp build/Release/x64/Plugins/Compute/{*.h,*.hlsl,*.cpp} CompressonatorFramework_result/lib/encoders/
+          cp cmp_compressonatorlib/compressonator.h CompressonatorFramework_result/include/
+
+      # Will probably want to collect the files into a better structure before running this command
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v3
+        with: 
+          name: CompressonatorFramework_Windows_Master_Build
+          path: CompressonatorFramework_result/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,9 +96,6 @@ endif()
 # The following options that have been removed
 set(LIB_BUILD_MESHCOMPRESSOR OFF)
 
-set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "Supported configuration options" FORCE)
-set(CMAKE_INSTALL_PREFIX "${PROJECT_SOURCE_DIR}/build-out")
-
 set(PROJECT_EXTERNAL_LIBDIR ${PROJECT_SOURCE_DIR}/../common/lib/ext)
 
 # ----------------------------------------------------------------------------

--- a/examples/cmp_prototype/CMakeLists.txt
+++ b/examples/cmp_prototype/CMakeLists.txt
@@ -24,11 +24,10 @@ target_include_directories(cmp_prototype PUBLIC
 
 target_link_libraries(cmp_prototype
     PRIVATE
-    ExtGLM 
+    ExtGLM
     ExtGLFW
     CMP_Framework
     CMP_Compressonator
-    d3d11.lib
 )
 
 set_target_properties(cmp_prototype 

--- a/scripts/windows_build_sdk.bat
+++ b/scripts/windows_build_sdk.bat
@@ -10,10 +10,6 @@ IF NOT [%1] == [] set ROOTDIR=%1
 set WORKDIR=%ROOTDIR%\
 set BUILDTMP=%ROOTDIR%\tmp
 
-set CMAKE_PATH=cmake
-set SCRIPT_DIR=%~dp0
-set CURRENT_DIR=%CD%
-
 REM Create Tmp directory for intermediate files
 IF NOT EXIST "%buildTMP%" mkdir "%buildTMP%"
 


### PR DESCRIPTION
The CMake YAML file was modified to add a job to build Compressonator Framework. It builds all the variations of the Framework using the solution files in the VS2019 folder and collects them into a folder structure that is identical to the release build, making it easy to copy and paste the folder structure into existing installations to update them. The packages created by this build _do not_ contain extra licence information or DLLs so an existing installation is required.