### PR TITLE
Fixed destination pointer calculation when converting from RGBA to RGB

### DIFF
--- a/cmp_compressonatorlib/buffer/codecbuffer_rgb888.cpp
+++ b/cmp_compressonatorlib/buffer/codecbuffer_rgb888.cpp
@@ -203,7 +203,7 @@ bool CCodecBuffer_RGB888::WriteBlockRGBA(CMP_DWORD x, CMP_DWORD y, CMP_BYTE w, C
 
     for(CMP_DWORD j = 0; j < h && (y + j) < GetHeight(); j++) {
         CMP_BYTE* pSrcData = (CMP_BYTE*) &pdwBlock[(j * w)];
-        CMP_BYTE* pDestData = (CMP_BYTE*) (GetData() + ((y + j) * m_dwPitch) + (x * sizeof(nChannelCount)));
+        CMP_BYTE* pDestData = (CMP_BYTE*) (GetData() + ((y + j) * m_dwPitch) + (x * nChannelCount));
         for(CMP_DWORD i = 0; i < dwWidth; i++) {
             *pDestData++ = *pSrcData++;
             *pDestData++ = *pSrcData++;


### PR DESCRIPTION
I have fixed an error in CCodecBuffer_RGB888::WriteBlockRGBA function: Instead of using nChannelCount value (which is 3 for RGB texels), it uses the size of nChannelCount variable(which is 4 for most modern systems). It causes buffer overflow as the pointer goes after the buffer limits in addition to writing to the wrong location.