### PR TITLE
Add missing initialisation of m_CMIPS for the image plugins

### DIFF
--- a/cmp_framework/compute_base.cpp
+++ b/cmp_framework/compute_base.cpp
@@ -1069,6 +1069,7 @@ CMP_ERROR CMP_API CMP_SaveTexture(const char* DestFile, CMP_MipSet* MipSetIn)
     if (plugin_Image) {
         bool holdswizzle = MipSetIn->m_swizzle;
 
+        plugin_Image->TC_PluginSetSharedIO(&m_CMIPS);
         if (plugin_Image->TC_PluginFileSaveTexture(DestFile, (MipSet*)MipSetIn) == 0) {
             filesaved = true;
         }


### PR DESCRIPTION
If there is no call of TC_PluginFileLoadTexture() before a call of TC_PluginFileSaveTexture(), then the global CMIPS object in the plugin is not initialized (for example DDS_CMips), causing TC_PluginFileSaveTexture to crash (DDS_CMips is used in all the SaveDDS_* functions)
I have added the call to TC_PluginSetSharedIO() before TC_PluginFileSaveTexture() to properly initialize the CMIPS object.