### PR TITLE
windows build .bat files - Community edition support

### DIFF
--- a/build/windows_build_apps.bat
+++ b/build/windows_build_apps.bat
@@ -60,6 +60,7 @@ REM ###############################
 if EXIST "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise" goto :Enterprise
 if EXIST "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional" goto :Professional
 if EXIST "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools" goto :Docker
+if EXIST "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community" goto :Community
 
 echo on
 echo VS2019 is not installed on this machine
@@ -77,6 +78,10 @@ goto :vscmdset
 
 :Enterprise
 call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+goto :vscmdset
+
+:Community
+call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\Common7\Tools\VsDevCmd.bat"
 
 :vscmdset
 

--- a/build/windows_build_sdk.bat
+++ b/build/windows_build_sdk.bat
@@ -21,6 +21,7 @@ REM ######################################
 if EXIST "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise" goto :Enterprise
 if EXIST "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional" goto :Professional
 if EXIST "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools" goto :Docker
+if EXIST "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community" goto :Community
 
 echo on
 echo VS2019 is not installed on this machine
@@ -38,6 +39,10 @@ goto :vscmdset
 
 :Enterprise
 call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+goto :vscmdset
+
+:Community
+call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\Common7\Tools\VsDevCmd.bat"
 
 :vscmdset
 

--- a/build/windows_build_sdk_2022.bat
+++ b/build/windows_build_sdk_2022.bat
@@ -17,6 +17,7 @@ REM ###############################
 if EXIST "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise" goto :Enterprise
 if EXIST "%ProgramFiles%\Microsoft Visual Studio\2022\Professional" goto :Professional
 if EXIST "%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools" goto :Docker
+if EXIST "%ProgramFiles%\Microsoft Visual Studio\2022\Community" goto :Community
 
 echo on
 echo VS2022 is not installed on this machine
@@ -34,6 +35,10 @@ goto :vscmdset
 
 :Enterprise
 call "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
+goto :vscmdset
+
+:Community
+call "%ProgramFiles%\Microsoft Visual Studio\2022\Community\Common7\Tools\VsDevCmd.bat"
 
 :vscmdset
 


### PR DESCRIPTION
I understand the build process isn't entirely streamlined, but this will make it so a developer with MSVC Community won't hit an unnecessary speed bump when using the windows build.bat files.