### PR TITLE
Fixed calculation of buffer size 

### DIFF
--- a/cmp_compressonatorlib/compressonator.cpp
+++ b/cmp_compressonatorlib/compressonator.cpp
@@ -135,11 +135,11 @@ CMP_DWORD CalcBufferSize(CMP_FORMAT format, CMP_DWORD dwWidth, CMP_DWORD dwHeigh
 
     case CMP_FORMAT_RG_16:
     case CMP_FORMAT_RG_16F:
-        return ((dwPitch) ? (dwPitch * dwHeight) : (dwWidth * 4 * sizeof(CMP_WORD) * dwHeight));
+        return ((dwPitch) ? (dwPitch * dwHeight) : (dwWidth * 2 * sizeof(CMP_WORD) * dwHeight));
 
     case CMP_FORMAT_R_16:
     case CMP_FORMAT_R_16F:
-        return ((dwPitch) ? (dwPitch * dwHeight) : (dwWidth * 4 * sizeof(CMP_WORD) * dwHeight));
+        return ((dwPitch) ? (dwPitch * dwHeight) : (dwWidth * 1 * sizeof(CMP_WORD) * dwHeight));
 
 #ifdef ARGB_32_SUPPORT
     case CMP_FORMAT_ARGB_32:


### PR DESCRIPTION
Fixed calculation of buffer size for CMP_FORMAT_RG_16, CMP_FORMAT_RG_16F, CMP_FORMAT_R_16, CMP_FORMAT_R_16F formats

Fix for [issue#273](https://github.com/GPUOpen-Tools/compressonator/issues/273)