### PR TITLE
Fixed GetCodecType for CMP_FORMAT_ABGR_32F format

### DIFF
--- a/cmp_compressonatorlib/compress.cpp
+++ b/cmp_compressonatorlib/compress.cpp
@@ -89,6 +89,7 @@ CodecType GetCodecType(CMP_FORMAT format) {
         return CT_None;
     case CMP_FORMAT_ARGB_32F:
     case CMP_FORMAT_RGBA_32F:
+    case CMP_FORMAT_ABGR_32F:
         return CT_None;
     case CMP_FORMAT_RG_32F:
         return CT_None;


### PR DESCRIPTION
Previous fix (https://github.com/GPUOpen-Tools/compressonator/pull/278) doesn't work if `CMP_FORMAT_ABGR_32F ` is a destination format. 
Sorry for not checking it earlier. 