### PR TITLE
Fix loop bound

### DIFF
--- a/applications/_plugins/common/atiformats.cpp
+++ b/applications/_plugins/common/atiformats.cpp
@@ -195,7 +195,7 @@ CMP_CHAR* GetFormatDesc(CMP_FORMAT nFormat) {
 }
 
 CMP_CHAR* GetTextureTypeDesc(CMP_TextureType nTextureType) { // depthsupport
-    for(CMP_DWORD i = 0; i < FORMAT_DESC_COUNT; i++)
+    for(CMP_DWORD i = 0; i < TEXTURE_TYPE_DESC_COUNT; i++)
         if(nTextureType == g_TextureTypeDesc[i].nTextureType)
             return g_TextureTypeDesc[i].pszTextureTypeDesc;
 


### PR DESCRIPTION
Fix out of bound access of array `g_TextureTypeDesc`. Found with `-fsanitize=undefined`.