### PR TITLE
Fix version macros

### DIFF
--- a/cmp_compressonatorlib/compressonator.h
+++ b/cmp_compressonatorlib/compressonator.h
@@ -28,7 +28,8 @@
 #define COMPRESSONATOR_H
 
 #define AMD_COMPRESS_VERSION_MAJOR 4  // The major version number of this release.
-#define AMD_COMPRESS_VERSION_MINOR 3  // The minor version number of this release.
+#define AMD_COMPRESS_VERSION_MINOR 5  // The minor version number of this release.
+#define AMD_COMPRESS_VERSION_PATCH 52 // The patch version number of this release.
 
 #include <stdint.h>
 #include <vector>


### PR DESCRIPTION
- Bump minor version to 5
- Add patch version (52)

We need it in order to restrain compressonator versions for https://gitea.wildfiregames.com/0ad/0ad/pulls/7243