### PR TITLE
Fix compressed to compressed texture conversion leaving leaked memory and threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,57 @@ message("Building Compressonator version ${PROJECT_VERSION_MAJOR}.${PROJECT_VERS
 # ------------------------------
 include(cmake/helperfunctions.cmake)
 
+# ----------------------------------
+# Check the target architecture
+# ----------------------------------
+################################################################################
+# Figure out build type and target platform
+################################################################################
+
+include(CheckCCompilerFlag)
+
+# See what CPU we appear to be targeting... 
+macro(check_cpu _CDEFS _NAME _VALUE)
+    check_c_source_compiles(
+        "
+        #if ( ${_CDEFS} )
+        int main(int argc, char **argv) { int yup = 1; return 0; }
+        #else
+        #error Not targeting this CPU architecture.
+        #endif
+        "
+        ${_VALUE}
+    )
+
+    if(${_VALUE})
+        if(AMD_COMPRESSONATOR_CHOSE_CPU)
+            message(STATUS "We appear to see two different CPU architectures!")
+            message(STATUS "We saw '${AMD_COMPRESSONATOR_CPU}' and '${_NAME}'.")
+            message(FATAL_ERROR "Please fix this before continuing.")
+        endif()
+        set(AMD_COMPRESSONATOR_CHOSE_CPU TRUE)
+        set(AMD_COMPRESSONATOR_CPU ${_NAME})
+        add_compile_definitions(${_VALUE}=1)
+    endif()
+endmacro(check_cpu)
+
+check_cpu(
+    "defined(__i386__) || defined(__i686__) || defined(_M_IX86) || defined(i386)"
+    "x86" AMD_COMPRESSONATOR_X86
+)
+
+check_cpu("defined(__x86_64__) || defined(_M_X64)" "amd64" AMD_COMPRESSONATOR_AMD64)
+
+check_cpu("defined(__EMSCRIPTEN__)" "emscripten" AMD_COMPRESSONATOR_EMSCRIPTEN)
+
+check_cpu("defined(__arm__)" "arm" AMD_COMPRESSONATOR_ARM)
+
+check_cpu("defined(__arm64__) || defined(__aarch64__)" "arm64" AMD_COMPRESSONATOR_ARM64)
+
+if (NOT AMD_COMPRESSONATOR_CHOSE_CPU)
+    message(FATAL_ERROR "We don't support this architecture yet")
+endif()
+
 
 # ------------------------------
 # Common compiler options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,8 @@ check_cpu("defined(__arm__)" "arm" AMD_COMPRESSONATOR_ARM)
 
 check_cpu("defined(__arm64__) || defined(__aarch64__)" "arm64" AMD_COMPRESSONATOR_ARM64)
 
+check_cpu("defined(__powerpc64__)" "powerpc64" AMD_COMPRESSONATOR_PPC64)
+
 if (NOT AMD_COMPRESSONATOR_CHOSE_CPU)
     message(FATAL_ERROR "We don't support this architecture yet")
 endif()

--- a/applications/_libs/cmp_math/cmp_math_common.cpp
+++ b/applications/_libs/cmp_math/cmp_math_common.cpp
@@ -40,12 +40,19 @@ float cpu_sqrtf(float* pIn)
 //---------------------------------------------
 // SSE: Computes square root of  a float value
 //---------------------------------------------
+union WrappedSSE
+{
+    __m128 val;
+    float  f[4];
+};
 float sse_sqrtf(float* pIn)
 {
     //printf("sse    : ");
-    __m128 val = _mm_load1_ps(pIn);
-    val        = _mm_sqrt_ss(val);
-    return val.m128_f32[0];
+
+    WrappedSSE v;
+    v.val       = _mm_load1_ps(pIn);
+    v.val       = _mm_sqrt_ss(v.val);
+    return v.f[0];
 }
 #endif
 #endif
@@ -78,11 +85,13 @@ float sse_rsqf(float* v)
 #else
 float sse_rsqf(float* v)
 {
-    __m128 val  = _mm_set_ss(*v);  // Copy float and zero the upper 3 elements
-    __m128 val1 = _mm_set_ss(1.0f);
-    val         = _mm_sqrt_ss(val);
-    val         = _mm_div_ss(val1, val);
-    return (val.m128_f32[0]);
+    WrappedSSE val;
+    WrappedSSE val1;
+    val.val  = _mm_set_ss(*v);  // Copy float and zero the upper 3 elements
+    val1.val = _mm_set_ss(1.0f);
+    val.val         = _mm_sqrt_ss(val.val);
+    val.val         = _mm_div_ss(val1.val, val.val);
+    return (val.f[0]);
 };
 #endif
 #endif

--- a/build/sdk/cmp_core/CMakeLists.txt
+++ b/build/sdk/cmp_core/CMakeLists.txt
@@ -72,82 +72,86 @@
 
 # Core SIMD options
 
-# SSE
-add_library(CMP_Core_SSE OBJECT)
-target_sources(
-    CMP_Core_SSE 
-    PRIVATE 
-    ${COMPRESSONATOR_ROOT_PATH}/cmp_core/source/core_simd_sse.cpp
-)
+# Metallicafan212: Actually check for support before linking it
+# 				   This fixes ARM builds
+if(AMD_COMPRESSONATOR_AMD64 OR AMD_COMPRESSONATOR_X86)
+	# SSE
+	add_library(CMP_Core_SSE OBJECT)
+	target_sources(
+		CMP_Core_SSE 
+		PRIVATE 
+		${COMPRESSONATOR_ROOT_PATH}/cmp_core/source/core_simd_sse.cpp
+	)
 
-target_include_directories(
-    CMP_Core_SSE 
-    PRIVATE 
-    ${COMPRESSONATOR_ROOT_PATH}/cmp_core/source 
-    ${COMPRESSONATOR_ROOT_PATH}/cmp_core/shaders
-)
+	target_include_directories(
+		CMP_Core_SSE 
+		PRIVATE 
+		${COMPRESSONATOR_ROOT_PATH}/cmp_core/source 
+		${COMPRESSONATOR_ROOT_PATH}/cmp_core/shaders
+	)
 
-if (UNIX)
-    target_compile_options(CMP_Core_SSE PRIVATE -march=nehalem)
+	if (UNIX)
+		target_compile_options(CMP_Core_SSE PRIVATE -march=nehalem)
+	endif()
+
+	set_target_properties(CMP_Core_SSE PROPERTIES 
+		FOLDER ${PROJECT_FOLDER_SDK_LIBS}
+		RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+		ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+	)
+
+	# AVX
+	add_library(CMP_Core_AVX OBJECT)
+	target_sources(
+		CMP_Core_AVX 
+		PRIVATE 
+		${COMPRESSONATOR_ROOT_PATH}/cmp_core/source/core_simd_avx.cpp
+	)
+	target_include_directories(
+		CMP_Core_AVX 
+		PRIVATE 
+		${COMPRESSONATOR_ROOT_PATH}/cmp_core/source 
+		${COMPRESSONATOR_ROOT_PATH}/cmp_core/shaders
+	)
+
+	if (WIN32)
+		target_compile_options(CMP_Core_AVX PRIVATE /arch:AVX2)
+	else()
+		target_compile_options(CMP_Core_AVX PRIVATE -march=haswell)
+	endif()
+
+	set_target_properties(CMP_Core_AVX PROPERTIES 
+		FOLDER ${PROJECT_FOLDER_SDK_LIBS}
+		RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+		ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+	)
+
+	# AVX-512
+	add_library(CMP_Core_AVX512 OBJECT)
+	target_sources(
+		CMP_Core_AVX512 
+		PRIVATE 
+		${COMPRESSONATOR_ROOT_PATH}/cmp_core/source/core_simd_avx512.cpp
+	)
+	target_include_directories(
+		CMP_Core_AVX512 
+		PRIVATE 
+		${COMPRESSONATOR_ROOT_PATH}/cmp_core/source 
+		${COMPRESSONATOR_ROOT_PATH}/cmp_core/shaders
+	)
+
+	if (WIN32)
+		target_compile_options(CMP_Core_AVX512 PRIVATE /arch:AVX-512)
+	else()
+		target_compile_options(CMP_Core_AVX512 PRIVATE -march=knl)
+	endif()
+
+	set_target_properties(CMP_Core_AVX512 PROPERTIES 
+		FOLDER ${PROJECT_FOLDER_SDK_LIBS}
+		RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+		ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+	)
+
+	# Link SIMD libraries to CMP_Core
+	target_link_libraries(CMP_Core PRIVATE CMP_Core_SSE CMP_Core_AVX CMP_Core_AVX512)
 endif()
-
-set_target_properties(CMP_Core_SSE PROPERTIES 
-    FOLDER ${PROJECT_FOLDER_SDK_LIBS}
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-)
-
-# AVX
-add_library(CMP_Core_AVX OBJECT)
-target_sources(
-    CMP_Core_AVX 
-    PRIVATE 
-    ${COMPRESSONATOR_ROOT_PATH}/cmp_core/source/core_simd_avx.cpp
-)
-target_include_directories(
-    CMP_Core_AVX 
-    PRIVATE 
-    ${COMPRESSONATOR_ROOT_PATH}/cmp_core/source 
-    ${COMPRESSONATOR_ROOT_PATH}/cmp_core/shaders
-)
-
-if (WIN32)
-    target_compile_options(CMP_Core_AVX PRIVATE /arch:AVX2)
-else()
-    target_compile_options(CMP_Core_AVX PRIVATE -march=haswell)
-endif()
-
-set_target_properties(CMP_Core_AVX PROPERTIES 
-    FOLDER ${PROJECT_FOLDER_SDK_LIBS}
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-)
-
-# AVX-512
-add_library(CMP_Core_AVX512 OBJECT)
-target_sources(
-    CMP_Core_AVX512 
-    PRIVATE 
-    ${COMPRESSONATOR_ROOT_PATH}/cmp_core/source/core_simd_avx512.cpp
-)
-target_include_directories(
-    CMP_Core_AVX512 
-    PRIVATE 
-    ${COMPRESSONATOR_ROOT_PATH}/cmp_core/source 
-    ${COMPRESSONATOR_ROOT_PATH}/cmp_core/shaders
-)
-
-if (WIN32)
-    target_compile_options(CMP_Core_AVX512 PRIVATE /arch:AVX-512)
-else()
-    target_compile_options(CMP_Core_AVX512 PRIVATE -march=knl)
-endif()
-
-set_target_properties(CMP_Core_AVX512 PROPERTIES 
-    FOLDER ${PROJECT_FOLDER_SDK_LIBS}
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-)
-
-# Link SIMD libraries to CMP_Core
-target_link_libraries(CMP_Core PRIVATE CMP_Core_SSE CMP_Core_AVX CMP_Core_AVX512)

--- a/cmp_compressonatorlib/compressonator.cpp
+++ b/cmp_compressonatorlib/compressonator.cpp
@@ -465,6 +465,12 @@ CMP_ERROR CMP_API CMP_ConvertTexture(CMP_Texture*               pSourceTexture,
         }
         RESTORE_FP_EXCEPTIONS;
 
+        SAFE_DELETE(pCodecIn);
+        SAFE_DELETE(pCodecOut);
+        SAFE_DELETE(pSrcBuffer);
+        SAFE_DELETE(pTempBuffer);
+        SAFE_DELETE(pDestBuffer);
+
         return GetError(err2);
     }
 }

--- a/cmp_core/CMakeLists.txt
+++ b/cmp_core/CMakeLists.txt
@@ -66,42 +66,46 @@ set_target_properties(CMP_Core PROPERTIES FOLDER ${PROJECT_FOLDER_SDK_LIBS})
 
 # Core SIMD options
 
-# SSE
-add_library(CMP_Core_SSE STATIC)
-target_sources(CMP_Core_SSE PRIVATE source/core_simd_sse.cpp)
-target_include_directories(CMP_Core_SSE PRIVATE source shaders)
+# Metallicafan212: Actually check for support before linking it
+# 				   This fixes ARM builds
+if(AMD_COMPRESSONATOR_AMD64 OR AMD_COMPRESSONATOR_X86)
+	# SSE
+	add_library(CMP_Core_SSE STATIC)
+	target_sources(CMP_Core_SSE PRIVATE source/core_simd_sse.cpp)
+	target_include_directories(CMP_Core_SSE PRIVATE source shaders)
 
-if (UNIX)
-    target_compile_options(CMP_Core_SSE PRIVATE -march=nehalem)
+	if (UNIX)
+		target_compile_options(CMP_Core_SSE PRIVATE -march=nehalem)
+	endif()
+
+	set_target_properties(CMP_Core_SSE PROPERTIES FOLDER ${PROJECT_FOLDER_SDK_LIBS})
+
+	# AVX
+	add_library(CMP_Core_AVX STATIC)
+	target_sources(CMP_Core_AVX PRIVATE source/core_simd_avx.cpp)
+	target_include_directories(CMP_Core_AVX PRIVATE source shaders)
+
+	if (WIN32)
+		target_compile_options(CMP_Core_AVX PRIVATE /arch:AVX2)
+	else()
+		target_compile_options(CMP_Core_AVX PRIVATE -march=haswell)
+	endif()
+
+	set_target_properties(CMP_Core_AVX PROPERTIES FOLDER ${PROJECT_FOLDER_SDK_LIBS})
+
+	# AVX-512
+	add_library(CMP_Core_AVX512 STATIC)
+	target_sources(CMP_Core_AVX512 PRIVATE source/core_simd_avx512.cpp)
+	target_include_directories(CMP_Core_AVX512 PRIVATE source shaders)
+
+	if (WIN32)
+		target_compile_options(CMP_Core_AVX512 PRIVATE /arch:AVX-512)
+	else()
+		target_compile_options(CMP_Core_AVX512 PRIVATE -march=knl)
+	endif()
+
+	set_target_properties(CMP_Core_AVX512 PROPERTIES FOLDER ${PROJECT_FOLDER_SDK_LIBS})
+
+	# Link SIMD libraries to CMP_Core
+	target_link_libraries(CMP_Core PRIVATE CMP_Core_SSE CMP_Core_AVX CMP_Core_AVX512)
 endif()
-
-set_target_properties(CMP_Core_SSE PROPERTIES FOLDER ${PROJECT_FOLDER_SDK_LIBS})
-
-# AVX
-add_library(CMP_Core_AVX STATIC)
-target_sources(CMP_Core_AVX PRIVATE source/core_simd_avx.cpp)
-target_include_directories(CMP_Core_AVX PRIVATE source shaders)
-
-if (WIN32)
-    target_compile_options(CMP_Core_AVX PRIVATE /arch:AVX2)
-else()
-    target_compile_options(CMP_Core_AVX PRIVATE -march=haswell)
-endif()
-
-set_target_properties(CMP_Core_AVX PROPERTIES FOLDER ${PROJECT_FOLDER_SDK_LIBS})
-
-# AVX-512
-add_library(CMP_Core_AVX512 STATIC)
-target_sources(CMP_Core_AVX512 PRIVATE source/core_simd_avx512.cpp)
-target_include_directories(CMP_Core_AVX512 PRIVATE source shaders)
-
-if (WIN32)
-    target_compile_options(CMP_Core_AVX512 PRIVATE /arch:AVX-512)
-else()
-    target_compile_options(CMP_Core_AVX512 PRIVATE -march=knl)
-endif()
-
-set_target_properties(CMP_Core_AVX512 PROPERTIES FOLDER ${PROJECT_FOLDER_SDK_LIBS})
-
-# Link SIMD libraries to CMP_Core
-target_link_libraries(CMP_Core PRIVATE CMP_Core_SSE CMP_Core_AVX CMP_Core_AVX512)

--- a/cmp_core/shaders/bc1_cmp.h
+++ b/cmp_core/shaders/bc1_cmp.h
@@ -96,13 +96,13 @@ CMP_STATIC CGU_FLOAT (*cpu_bc1ComputeBestEndpoints)(CGU_FLOAT*, CGU_FLOAT*, CGU_
 // NOTE: The requested extension will only be enabled if it is supported by the current CPU.
 CMP_STATIC bool bc1ToggleSIMD(CGU_INT newExtension)
 {
+    CPUExtensions extensions = GetCPUExtensions();
+    
 	// Metallicafan212:	Don't evaluate on non-X86 platforms
 #if AMD_COMPRESSONATOR_AMD64 || AMD_COMPRESSONATOR_X86
     CGU_BOOL useAVX512 = true;
     CGU_BOOL useAVX2   = true;
     CGU_BOOL useSSE42  = true;
-
-    CPUExtensions extensions = GetCPUExtensions();
 
     if (newExtension < EXTENSION_COUNT)  // user requested a specific instruction set extension
     {
@@ -128,7 +128,10 @@ CMP_STATIC bool bc1ToggleSIMD(CGU_INT newExtension)
         cpu_bc1ComputeBestEndpoints = _cpu_bc1ComputeBestEndpoints;
     }
 #else 
-	cpu_bc1ComputeBestEndpoints = _cpu_bc1ComputeBestEndpoints;
+    CGU_BOOL useAVX512 = false;
+    CGU_BOOL useAVX2   = false;
+    CGU_BOOL useSSE42  = false;
+    cpu_bc1ComputeBestEndpoints = _cpu_bc1ComputeBestEndpoints;
 #endif
 
     g_bc1FunctionPointersSet = true;

--- a/cmp_core/shaders/bc1_cmp.h
+++ b/cmp_core/shaders/bc1_cmp.h
@@ -96,6 +96,8 @@ CMP_STATIC CGU_FLOAT (*cpu_bc1ComputeBestEndpoints)(CGU_FLOAT*, CGU_FLOAT*, CGU_
 // NOTE: The requested extension will only be enabled if it is supported by the current CPU.
 CMP_STATIC bool bc1ToggleSIMD(CGU_INT newExtension)
 {
+	// Metallicafan212:	Don't evaluate on non-X86 platforms
+#if AMD_COMPRESSONATOR_AMD64 || AMD_COMPRESSONATOR_X86
     CGU_BOOL useAVX512 = true;
     CGU_BOOL useAVX2   = true;
     CGU_BOOL useSSE42  = true;
@@ -125,6 +127,9 @@ CMP_STATIC bool bc1ToggleSIMD(CGU_INT newExtension)
     {
         cpu_bc1ComputeBestEndpoints = _cpu_bc1ComputeBestEndpoints;
     }
+#else 
+	cpu_bc1ComputeBestEndpoints = _cpu_bc1ComputeBestEndpoints;
+#endif
 
     g_bc1FunctionPointersSet = true;
 

--- a/cmp_core/source/cmp_math_vec4.h
+++ b/cmp_core/source/cmp_math_vec4.h
@@ -656,7 +656,7 @@ public:
     union
     {
         __m128 vec128;  // float Vector 128 bits in total (16 Bytes) = array of 4 floats
-#ifndef _WIN32
+#if !defined(_WIN32) || defined(__clang_version__)
         float f32[4];
 #endif
     };
@@ -694,7 +694,7 @@ public:
     };
 
     // indexing
-#ifndef _WIN32
+#if !defined(_WIN32) || defined(__clang_version__)
     inline const float& operator[](int i) const
     {
         return f32[i];


### PR DESCRIPTION
This pull request fixes an issue I noticed when converting one compressed texture format to another. After the conversion was done, my CPU would still be running at 100% with the Compressonator threads eating all my CPU time.

Specifically: the block that deals with compressed -> compressed only frees the buffers/codecs/threads when there's an error, but did not if the conversion was successful. 