### PR TITLE
fix(CMP_ConvertTexture): Correct error code from CMP_ConvertTexture

### DIFF
--- a/cmp_compressonatorlib/compressonator.cpp
+++ b/cmp_compressonatorlib/compressonator.cpp
@@ -308,7 +308,7 @@ CMP_ERROR CMP_API CMP_ConvertTexture(CMP_Texture*               pSourceTexture,
     CodecType destType = GetCodecType(pDestTexture->format);
     assert(destType != CT_Unknown);
     if (destType == CT_Unknown)
-        return CMP_ERR_UNSUPPORTED_SOURCE_FORMAT;
+        return CMP_ERR_UNSUPPORTED_DEST_FORMAT;
 
     // Figure out the type of processing we are doing
 


### PR DESCRIPTION
CMP_ERR_UNSUPPORTED_SOURCE_FORMAT  was returned when the Destination Format had an unsupported codec. This should be DEST_FORMAT